### PR TITLE
Use static package filename in Build GH Action.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,9 @@ jobs:
               with:
                   node-version: 10.x
             - run: yarn install
-            - run: yarn build
+            - run: yarn build -o ./vscode-dvc.vsix
             - name: Upload
               uses: actions/upload-artifact@v2
               with:
                   name: Built package
-                  path: ./extension/dvc-integration-0.1.0.vsix
+                  path: ./extension/vscode-dvc.vsix


### PR DESCRIPTION
This way, we won't have to worry about versioned package names breaking the script or mandating an update.

Only applies to the GHA via the workflow, so local build behavior is unchanged.