### PR TITLE
Add extension testing framework

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -73,10 +73,14 @@
   "dependencies": {
     "@hediet/node-reload": "^0.7.3",
     "@hediet/std": "^0.6.0",
+    "@types/mocha": "^8.2.0",
     "bufferutil": "^4.0.1",
     "dayjs": "^1.9.4",
+    "glob": "^7.1.6",
     "mobx": "^6.0.1",
-    "utf-8-validate": "^5.0.2"
+    "mocha": "^8.2.1",
+    "utf-8-validate": "^5.0.2",
+    "vscode-test": "^1.4.1"
   },
   "devDependencies": {
     "@types/copy-webpack-plugin": "^5.0.0",

--- a/extension/src/test/runTest.ts
+++ b/extension/src/test/runTest.ts
@@ -1,0 +1,23 @@
+import * as path from 'path'
+
+import { runTests } from 'vscode-test'
+
+async function main() {
+  try {
+    // The folder containing the Extension Manifest package.json
+    // Passed to `--extensionDevelopmentPath`
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../')
+
+    // The path to test runner
+    // Passed to --extensionTestsPath
+    const extensionTestsPath = path.resolve(__dirname, './suite/index')
+
+    // Download VS Code, unzip it and run the integration test
+    await runTests({ extensionDevelopmentPath, extensionTestsPath })
+  } catch (err) {
+    console.error('Failed to run tests')
+    process.exit(1)
+  }
+}
+
+main()

--- a/extension/src/test/suite/extension.test.ts
+++ b/extension/src/test/suite/extension.test.ts
@@ -1,0 +1,15 @@
+import * as assert from 'assert'
+
+// You can import and use all API from the 'vscode' module
+// as well as import your extension to test it
+import * as vscode from 'vscode'
+// import * as myExtension from '../../extension';
+
+suite('Extension Test Suite', () => {
+  vscode.window.showInformationMessage('Start all tests.')
+
+  test('Sample test', () => {
+    assert.equal(-1, [1, 2, 3].indexOf(5))
+    assert.equal(-1, [1, 2, 3].indexOf(0))
+  })
+})

--- a/extension/src/test/suite/index.ts
+++ b/extension/src/test/suite/index.ts
@@ -1,0 +1,40 @@
+/* eslint consistent-return: off */
+/* eslint no-shadow: off */
+import * as path from 'path'
+import * as Mocha from 'mocha'
+import * as glob from 'glob'
+
+export function run(): Promise<void> {
+  // Create the mocha test
+  const mocha = new Mocha({
+    ui: 'tdd',
+    color: true
+  })
+
+  const testsRoot = path.resolve(__dirname, '..')
+
+  return new Promise((c, e) => {
+    glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
+      if (err) {
+        return e(err)
+      }
+
+      // Add files to the test suite
+      files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)))
+
+      try {
+        // Run the mocha test
+        mocha.run(failures => {
+          if (failures > 0) {
+            e(new Error(`${failures} tests failed.`))
+          } else {
+            c()
+          }
+        })
+      } catch (e) {
+        console.error(e)
+        e(e)
+      }
+    })
+  })
+}


### PR DESCRIPTION
- Adds packages: 'vscode-test', 'mocha', '@types/mocha', 'glob'
- Includes commented usage and examples
- Uses arrangement that is best documented for needs like our own
- Foundation for issue #24 Start adding tests
