### PR TITLE
delete duplicate file

### DIFF
--- a/extension/src/util.ts
+++ b/extension/src/util.ts
@@ -1,4 +1,0 @@
-import { promisify } from 'util'
-import { exec } from 'child_process'
-
-export const execPromise = promisify(exec)


### PR DESCRIPTION
Discovered while working on connection our extension to the integrated terminal:

There were two copies of the `util.ts` file in the extension folder. One under `src` and another under `src/util/index.ts`. This PR removes the former.