### PR TITLE
Last attempt at fixing flaky test

### DIFF
--- a/extension/src/test/suite/IntegratedTerminal.test.ts
+++ b/extension/src/test/suite/IntegratedTerminal.test.ts
@@ -49,7 +49,7 @@ suite('Integrated Terminal Test Suite', () => {
       await waitForAndDispose(disposable)
 
       expect(eventCount).to.equal(1)
-    }).timeout(12000)
+    }).timeout(20000)
 
     it('should be able to run a command', async () => {
       const disposable = Disposable.fn()


### PR DESCRIPTION
Had to increase the timeout on the first test (gave it ~20% extra time) and also gave an extra 500 ms for the python environment to take effect before trying to run that test.
I have run the pipeline ~5 times with the new changes. 
If there are any more failures I will remove the test.