### PR TITLE
remove extra pip upgrade

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,8 +57,6 @@ jobs:
 
       - run: yarn install
 
-      - run: python3 -m pip install --upgrade pip
-
       - run: yarn run-p "ci:setup:*"
 
       - run: xvfb-run -a yarn run-p "ci:run:*"


### PR DESCRIPTION
This is also called in `virtualenv-install.sh` so it can be removed.