### PR TITLE
Remove unnecessary path from cli commands

### DIFF
--- a/extension/src/IntegratedTerminal.test.ts
+++ b/extension/src/IntegratedTerminal.test.ts
@@ -1,9 +1,7 @@
 import { IntegratedTerminal, runExperiment } from './IntegratedTerminal'
-import * as DvcPath from './DvcPath'
 
 describe('runExperiment', () => {
   it('should run the correct command in the IntegratedTerminal', async () => {
-    const pathSpy = jest.spyOn(DvcPath, 'getDvcPath').mockReturnValueOnce('dvc')
     const terminalSpy = jest
       .spyOn(IntegratedTerminal, 'run')
       .mockResolvedValueOnce(undefined)
@@ -12,6 +10,5 @@ describe('runExperiment', () => {
     expect(undef).toBeUndefined()
 
     expect(terminalSpy).toBeCalledWith('dvc exp run')
-    expect(pathSpy).toBeCalledTimes(1)
   })
 })

--- a/extension/src/dvcCommands.ts
+++ b/extension/src/dvcCommands.ts
@@ -1,8 +1,5 @@
-import { getDvcPath } from './DvcPath'
-
 const getCliCommand = (command: string): string => {
-  const dvcPath = getDvcPath()
-  return `${dvcPath} ${command}`
+  return `dvc ${command}`
 }
 
 const RUN_EXPERIMENT = 'exp run'


### PR DESCRIPTION
This PR removes the dvc path variable from cli commands that will be passed to the terminal.

This code is not required as the dvc binary will either be available globally or the integrated terminal will source the required virtual environment for us.