### PR TITLE
Import path functions instead of full object

### DIFF
--- a/extension/src/DvcReader.test.ts
+++ b/extension/src/DvcReader.test.ts
@@ -1,4 +1,4 @@
-import path from 'path'
+import { resolve, join } from 'path'
 import { mocked } from 'ts-jest/utils'
 
 import { inferDefaultOptions, getExperiments } from './DvcReader'
@@ -13,11 +13,11 @@ jest.mock('./util')
 const mockedFs = mocked(fs)
 const mockedExecPromise = mocked(execPromise)
 
-const extensionDirectory = path.resolve(__dirname, '..')
+const extensionDirectory = resolve(__dirname, '..')
 
 const testReaderOptions = {
   bin: 'dvc',
-  cwd: path.resolve()
+  cwd: resolve()
 }
 
 beforeEach(() => {
@@ -28,7 +28,7 @@ test('Inferring default options on a directory with accessible .env', async () =
   mockedFs.accessSync.mockReturnValue()
 
   expect(await inferDefaultOptions(extensionDirectory)).toEqual({
-    bin: path.join(extensionDirectory, '.env', 'bin', 'dvc'),
+    bin: join(extensionDirectory, '.env', 'bin', 'dvc'),
     cwd: extensionDirectory
   })
 })

--- a/extension/src/DvcReader.ts
+++ b/extension/src/DvcReader.ts
@@ -1,5 +1,5 @@
 import { accessSync } from 'fs'
-import * as path from 'path'
+import { resolve } from 'path'
 import { execPromise } from './util'
 
 export interface ReaderOptions {
@@ -37,7 +37,7 @@ export interface ExperimentsRepoJSONOutput
 export const inferDefaultOptions: (
   cwd: string
 ) => Promise<ReaderOptions> = async cwd => {
-  const envDvcPath = path.resolve(cwd, '.env', 'bin', 'dvc')
+  const envDvcPath = resolve(cwd, '.env', 'bin', 'dvc')
   let bin
   try {
     accessSync(envDvcPath)

--- a/extension/src/__mocks__/vscode.ts
+++ b/extension/src/__mocks__/vscode.ts
@@ -1,4 +1,4 @@
-import path from 'path'
+import { join } from 'path'
 
 export const Extension = jest.fn()
 export const extensions = jest.fn()
@@ -8,7 +8,7 @@ export const workspace = {
   workspaceFolders: [
     {
       uri: {
-        fsPath: path.join(__dirname, '..', '..')
+        fsPath: join(__dirname, '..', '..')
       }
     }
   ]

--- a/extension/src/test/suite/index.ts
+++ b/extension/src/test/suite/index.ts
@@ -1,6 +1,6 @@
 /* eslint consistent-return: off */
 /* eslint no-shadow: off */
-import path from 'path'
+import { resolve } from 'path'
 import Mocha from 'mocha'
 import glob from 'glob'
 
@@ -11,7 +11,7 @@ export function run(): Promise<void> {
     color: true
   })
 
-  const testsRoot = path.resolve(__dirname, '..')
+  const testsRoot = resolve(__dirname, '..')
 
   return new Promise((c, e) => {
     glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
@@ -20,7 +20,7 @@ export function run(): Promise<void> {
       }
 
       // Add files to the test suite
-      files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)))
+      files.forEach(f => mocha.addFile(resolve(testsRoot, f)))
 
       try {
         // Run the mocha test

--- a/extension/src/util.test.ts
+++ b/extension/src/util.test.ts
@@ -1,6 +1,6 @@
 import { delay } from './util'
 
-test('Delay', async () => {
+test('delay', async () => {
   let changedAfterDelay = false
   const delayThenChangePromise = delay(50).then(() => {
     changedAfterDelay = true

--- a/extension/webpack.config.ts
+++ b/extension/webpack.config.ts
@@ -1,13 +1,13 @@
 import * as webpack from 'webpack'
 import { CleanWebpackPlugin } from 'clean-webpack-plugin'
 import { readFileSync } from 'fs'
-import path = require('path')
+import { join, resolve } from 'path'
 import CopyPlugin = require('copy-webpack-plugin')
 
-const r = (file: string) => path.resolve(__dirname, file)
+const r = (file: string) => resolve(__dirname, file)
 
 function includeDependency(location: string) {
-  const content = readFileSync(path.join(location, 'package.json'), {
+  const content = readFileSync(join(location, 'package.json'), {
     encoding: 'utf8'
   })
   const pkgName = JSON.parse(content).name

--- a/webview/webpack.config.ts
+++ b/webview/webpack.config.ts
@@ -1,10 +1,10 @@
 import * as webpack from 'webpack'
 import { CleanWebpackPlugin } from 'clean-webpack-plugin'
-import path = require('path')
+import { resolve } from 'path'
 import HtmlWebpackPlugin = require('html-webpack-plugin')
 import ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
 
-const r = (file: string) => path.resolve(__dirname, file)
+const r = (file: string) => resolve(__dirname, file)
 
 module.exports = {
   entry: [r('src/index.tsx')],


### PR DESCRIPTION
This PR fixes up all of the imports of path (see https://github.com/iterative/vscode-dvc/pull/121#discussion_r584393283)