### PR TITLE
Hide unneeded input box

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -160,6 +160,8 @@ export class Extension {
       c.inputBox.placeholder = "Message (Ctrl+Enter to commit on 'master')"
       // ic.commitTemplate = "templatea";
 
+      c.inputBox.visible = false
+
       c.statusBarCommands = [
         {
           command: 'test',


### PR DESCRIPTION
After working through some basic use cases in #169 I realised that we currently have no need for the SCM input box. This one line change removes it from view.