### PR TITLE
Remove `resetAllMocks` from `index.test.ts` to fix manual mocks

### DIFF
--- a/extension/src/__mocks__/vscode.ts
+++ b/extension/src/__mocks__/vscode.ts
@@ -15,6 +15,6 @@ export const workspace = {
   ]
 }
 export const Uri = {
-  file: URI.file,
+  file: jest.fn(URI.file),
   joinPath: jest.fn(Utils.joinPath)
 }

--- a/extension/src/cli/index.test.ts
+++ b/extension/src/cli/index.test.ts
@@ -10,10 +10,6 @@ jest.mock('vscode')
 
 const mockedExecPromise = mocked(execPromise)
 
-beforeEach(() => {
-  jest.resetAllMocks()
-})
-
 describe('add', () => {
   it('should call execPromise with the correct parameters', async () => {
     const fsPath = __filename


### PR DESCRIPTION
This is mostly just here to prove that `resetAllMocks` is breaking manually mocked `jest.fn`s, I'm not sure about the proper way to reset mocks with this information.