### PR TITLE
Improve Jest mocking of vscode: Option C - provide default implementation for all Uri mocks

### DIFF
--- a/extension/src/ResourceLocator.test.ts
+++ b/extension/src/ResourceLocator.test.ts
@@ -1,4 +1,3 @@
-import { mocked } from 'ts-jest/utils'
 import { Uri } from 'vscode'
 import { ResourceLocator } from './ResourceLocator'
 
@@ -12,12 +11,9 @@ describe('ResourceLocator', () => {
     const dark = Uri.file('some/path/media/dvc-color.svg')
     const light = Uri.file('some/path/media/dvc-color.svg')
 
-    const mockedUriClass = mocked(Uri)
-
     expect(resourceLocator.dvcIconPath).toEqual({
       dark,
       light
     })
-    expect(mockedUriClass.joinPath).toBeCalledTimes(2)
   })
 })

--- a/extension/src/__mocks__/vscode.ts
+++ b/extension/src/__mocks__/vscode.ts
@@ -16,5 +16,5 @@ export const workspace = {
 }
 export const Uri = {
   file: URI.file,
-  joinPath: jest.fn(Utils.joinPath)
+  joinPath: Utils.joinPath
 }


### PR DESCRIPTION
Option C of 3. See #253 for detailed explanation of the options.