### PR TITLE
Make Imports of `index` Files Consistent

### DIFF
--- a/extension/src/cli/index.test.ts
+++ b/extension/src/cli/index.test.ts
@@ -2,12 +2,12 @@ import { Config } from '../Config'
 import {
   GcQuickPickItem,
   experimentGcCommand,
-  queueExperimentCommand
-} from './index'
+  queueExperimentCommand,
+  addTarget
+} from '.'
 import { mocked } from 'ts-jest/utils'
 import { execPromise } from '../util'
 import { basename, resolve } from 'path'
-import { addTarget } from '.'
 import { QuickPickOptions, window } from 'vscode'
 import { GcPreserveFlag } from './commands'
 

--- a/webview/src/components/Experiments/index.tsx
+++ b/webview/src/components/Experiments/index.tsx
@@ -15,7 +15,7 @@ import {
   SortByFn
 } from 'react-table'
 import dayjs from '../../dayjs'
-import { Table } from '../Table/index'
+import { Table } from '../Table'
 import parseExperiments, { Experiment } from '../../util/parse-experiments'
 
 import styles from '../Table/styles.module.scss'
@@ -23,8 +23,8 @@ import styles from '../Table/styles.module.scss'
 import buildDynamicColumns from '../../util/build-dynamic-columns'
 
 import { VsCodeApi } from '../../model/Model'
-import SortIndicator from '../SortIndicator/index'
-import ManageColumns from '../ManageColumns/index'
+import SortIndicator from '../SortIndicator'
+import ManageColumns from '../ManageColumns'
 
 const countRowsAndAddIndexes: (
   rows: Row<Experiment>[],

--- a/webview/src/components/GUI.tsx
+++ b/webview/src/components/GUI.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { observer } from 'mobx-react'
 import { hotComponent } from '../hotComponent'
 
-import ExperimentsGUI from './Experiments/index'
+import ExperimentsGUI from './Experiments'
 import { Model } from '../model/Model'
 
 export const GUI: React.FC<{ model: Model }> = hotComponent(module)(

--- a/webview/src/components/SortIndicator/index.tsx
+++ b/webview/src/components/SortIndicator/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { InstanceProp } from '../Table/index'
+import { InstanceProp } from '../Table'
 import styles from './styles.module.scss'
 
 const SortIndicator: React.FC<InstanceProp> = ({ instance }) => {

--- a/webview/src/components/Table/index.tsx
+++ b/webview/src/components/Table/index.tsx
@@ -3,7 +3,7 @@ import { Cell, HeaderGroup, TableInstance, Row } from 'react-table'
 import cx from 'classnames'
 import { Experiment } from '../../util/parse-experiments'
 import styles from './styles.module.scss'
-import { Menu, MenuToggle, MenuItemGroup, MenuItem } from '../Menu/index'
+import { Menu, MenuToggle, MenuItemGroup, MenuItem } from '../Menu'
 import SortIconToggle from '../SortIconToggle'
 
 export interface InstanceProp {

--- a/webview/src/stories/Experiments.stories.tsx
+++ b/webview/src/stories/Experiments.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Story, Meta } from '@storybook/react/types-6-0'
 import { action } from '@storybook/addon-actions'
 
-import Experiments from '../components/Experiments/index'
+import Experiments from '../components/Experiments'
 
 import complexExperimentsData from 'dvc/src/webviews/experiments/complex-output-example.json'
 


### PR DESCRIPTION
I noticed I missed the import issue in [this comment on #269](https://github.com/iterative/vscode-dvc/pull/269#discussion_r612826422), and decided to run a ripgrep for `import.*index` across the repo to see if we do it elsewhere- there were a few in the Webview.

This changes all imports with `index` to use the other form without an explicit `index`, making this consistent across our repo.