### PR TITLE
Show webview before running experiments

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -115,6 +115,7 @@ export class Extension {
   }
 
   private refreshExperimentsWebview = async () => {
+    await this.config.ready
     const experiments = await getExperiments({
       pythonBinPath: this.config.pythonBinPath,
       cliPath: this.config.dvcPath,


### PR DESCRIPTION
When you select "run experiment" it locks the repository before showing the experiments webview (which means you get stuck on a loading screen for the entirety of the experiment run).

This change loads the webview before starting the run.

Also added an onCompleted listener to update the table once the run is finished.