### PR TITLE
Set epochs in demo project to 2

### DIFF
--- a/demo/train.py
+++ b/demo/train.py
@@ -8,7 +8,7 @@ import torchvision
 import dvclive
 
 
-EPOCHS = 10
+EPOCHS = 2
 
 
 class ConvNet(torch.nn.Module):


### PR DESCRIPTION
This makes experiment runs a _lot_ faster to do in the demo, while still showing off checkpoints.

We can also change this in the runner script and queue runs to show off that queued runs take a snapshot of the whole repo as opposed to just params.