### PR TITLE
Rename WebviewManager

### DIFF
--- a/extension/src/WebviewSerializer.ts
+++ b/extension/src/WebviewSerializer.ts
@@ -1,7 +1,7 @@
 import { window, WebviewPanel } from 'vscode'
 import { Disposable } from '@hediet/std/disposable'
-import { ExperimentsWebview } from '../Experiments/Webview'
-import { Config } from '../Config'
+import { ExperimentsWebview } from './Experiments/Webview'
+import { Config } from './Config'
 
 export class WebviewSerializer {
   public readonly dispose = Disposable.fn()

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -15,7 +15,7 @@ import {
   getReloadCount
 } from '@hediet/node-reload'
 import { Config } from './Config'
-import { WebviewSerializer } from './Webviews'
+import { WebviewSerializer } from './WebviewSerializer'
 import { Experiments } from './Experiments'
 import { Command, ExperimentFlag, ExperimentSubCommands } from './cli/args'
 import { registerExperimentCommands } from './Experiments/register'
@@ -50,7 +50,7 @@ export class Extension {
 
   private readonly resourceLocator: ResourceLocator
   private readonly config: Config
-  private readonly webviews: WebviewSerializer
+  private readonly webviewSerializer: WebviewSerializer
   private dvcRoots: string[] = []
   private decorationProviders: Record<string, DecorationProvider> = {}
   private dvcRepositories: Record<string, Repository> = {}
@@ -305,8 +305,8 @@ export class Extension {
       this.config.onDidChangeExecutionDetails(() => this.initializeOrNotify())
     )
 
-    this.webviews = new WebviewSerializer(this.config)
-    this.dispose.track(this.webviews)
+    this.webviewSerializer = new WebviewSerializer(this.config)
+    this.dispose.track(this.webviewSerializer)
 
     registerExperimentCommands(this.config, this.dispose)
 


### PR DESCRIPTION
This PR renames the old `WebviewManager` to move closely reflect it's (now) single responsibility.