### PR TITLE
Follow up on Config status bar items

### DIFF
--- a/extension/src/Config.ts
+++ b/extension/src/Config.ts
@@ -63,10 +63,6 @@ export class Config {
   @observable
   private dvcPathStatusBarItem: StatusBarItem
 
-  private updateDvcPathStatusBarItem = (path = this.getCliPath()): void => {
-    this.dvcPathStatusBarItem.text = this.getRelativePathText(path)
-  }
-
   private getWorkspaceRoot = (): string => {
     const { workspaceFolders } = workspace
     if (!workspaceFolders || workspaceFolders.length === 0) {
@@ -199,12 +195,6 @@ export class Config {
     return workspace.getConfiguration().update(this.defaultProjectOption, path)
   }
 
-  private updateDefaultProjectStatusBarItem = (): void => {
-    this.defaultProjectStatusBarItem.text = this.getRelativePathText(
-      this.getDefaultProject()
-    )
-  }
-
   private createStatusBarItem = (
     command: string,
     tooltip: string,
@@ -218,6 +208,13 @@ export class Config {
     dvcPathStatusBarItem.show()
 
     return dvcPathStatusBarItem
+  }
+
+  private setStatusBarItemText(
+    statusBarItem: StatusBarItem,
+    path: string
+  ): void {
+    statusBarItem.text = this.getRelativePathText(path)
   }
 
   private getRelativePathText(path?: string): string {
@@ -279,10 +276,16 @@ export class Config {
     this.dispose.track(
       workspace.onDidChangeConfiguration(e => {
         if (e.affectsConfiguration(this.dvcPathOption)) {
-          this.updateDvcPathStatusBarItem()
+          this.setStatusBarItemText(
+            this.dvcPathStatusBarItem,
+            this.getCliPath()
+          )
         }
         if (e.affectsConfiguration(this.defaultProjectOption)) {
-          this.updateDefaultProjectStatusBarItem()
+          this.setStatusBarItemText(
+            this.defaultProjectStatusBarItem,
+            this.getDefaultProject()
+          )
         }
       })
     )


### PR DESCRIPTION
# 1/2 master <- this <- #431

Follows up from [this](https://github.com/iterative/vscode-dvc/pull/418#discussion_r632679067).

This PR changes our status bar items to use a path relative to the workspace root and adds an option to unset the default project from the select default project quick pick.

Demo: 

https://user-images.githubusercontent.com/37993418/118417837-483cfb00-b6f9-11eb-9fd1-30bae9e28578.mov

