### PR TITLE
Re-add .vscode-test to coverage exclusion list

### DIFF
--- a/extension/src/test/suite/index.ts
+++ b/extension/src/test/suite/index.ts
@@ -14,7 +14,7 @@ function setupNyc() {
     cache: true,
     cacheDir: join(cwd, '.cache', 'nyc'),
     cwd,
-    exclude: [...defaultExclude],
+    exclude: [...defaultExclude, '**/.vscode-test/**'],
     hookRequire: true,
     hookRunInContext: true,
     hookRunInThisContext: true,


### PR DESCRIPTION
This somehow got lost in the mayhem of #428.