### PR TITLE
Move all state reponsibility inside of RepositoryState

### DIFF
--- a/extension/src/Repository/index.test.ts
+++ b/extension/src/Repository/index.test.ts
@@ -51,6 +51,7 @@ beforeEach(() => {
 
 describe('Repository', () => {
   const dvcRoot = resolve(__dirname, '..', '..', 'demo')
+  const emptyState = new RepositoryState(dvcRoot).getState()
 
   describe('ready', () => {
     it('should wait for the state to be ready before resolving', async () => {
@@ -116,7 +117,6 @@ describe('Repository', () => {
 
       expect(repository.getState()).toEqual(
         expect.objectContaining({
-          dispose: Disposable.fn(),
           deleted: emptySet,
           notInCache: emptySet,
           new: emptySet,
@@ -175,7 +175,7 @@ describe('Repository', () => {
         { path: model }
       ] as ListOutput[])
 
-      expect(repository.getState()).toEqual(new RepositoryState(dvcRoot))
+      expect(repository.getState()).toEqual(emptyState)
 
       await repository.resetState()
 
@@ -204,9 +204,7 @@ describe('Repository', () => {
       )
 
       expect(repository.getState()).toEqual({
-        dvcRoot,
         deleted,
-        dispose: Disposable.fn(),
         modified: emptySet,
         new: emptySet,
         notInCache: emptySet,
@@ -273,7 +271,7 @@ describe('Repository', () => {
       ])
       mockedGetAllUntracked.mockResolvedValueOnce(untracked)
 
-      expect(repository.getState()).toEqual(new RepositoryState(dvcRoot))
+      expect(repository.getState()).toEqual(emptyState)
 
       await repository.resetState()
 
@@ -305,8 +303,6 @@ describe('Repository', () => {
 
       expect(repository.getState()).toEqual({
         deleted,
-        dispose: Disposable.fn(),
-        dvcRoot,
         modified,
         new: new Set(),
         notInCache,

--- a/extension/src/Repository/index.ts
+++ b/extension/src/Repository/index.ts
@@ -38,11 +38,11 @@ export class RepositoryState
 
   private dvcRoot: string
 
-  public tracked: Set<string> = new Set()
   public deleted: Set<string> = new Set()
   public modified: Set<string> = new Set()
   public new: Set<string> = new Set()
   public notInCache: Set<string> = new Set()
+  public tracked: Set<string> = new Set()
   public untracked: Set<string> = new Set()
 
   private filterRootDir(dirs: string[] = []) {
@@ -121,6 +121,17 @@ export class RepositoryState
     this.untracked = untracked
   }
 
+  public getState() {
+    return {
+      deleted: this.deleted,
+      modified: this.modified,
+      new: this.new,
+      notInCache: this.notInCache,
+      tracked: this.tracked,
+      untracked: this.untracked
+    }
+  }
+
   constructor(dvcRoot: string) {
     this.dvcRoot = dvcRoot
   }
@@ -137,11 +148,7 @@ export class Repository {
   }
 
   public getState() {
-    return this.state
-  }
-
-  public getTracked() {
-    return this.state.tracked
+    return this.state.getState()
   }
 
   @observable
@@ -181,15 +188,15 @@ export class Repository {
     const slowerTrackedUpdated = this.updateTracked()
 
     await statusesUpdated
-    this.sourceControlManagement.setState(this.state)
+    this.sourceControlManagement.setState(this.state.getState())
 
     await slowerTrackedUpdated
-    this.decorationProvider?.setState(this.state)
+    this.decorationProvider?.setState(this.state.getState())
   }
 
   private setState() {
-    this.sourceControlManagement.setState(this.state)
-    this.decorationProvider?.setState(this.state)
+    this.sourceControlManagement.setState(this.state.getState())
+    this.decorationProvider?.setState(this.state.getState())
   }
 
   public async updateState() {


### PR DESCRIPTION
# 1/5 `master` <- this <- #464 <- #465 <- #466 <- #467

The purpose of this chain is to update the logic used by the Repository class to derive each tracked paths status. I will detail the change in logic on #466.

Short description of each PR is shown below:

This - PR moves more responsibility to the `RepositoryState` class. 
#464 - Moves the class into it's own file.
#465 - Updates the available statuses: new is renamed to added and renamed & stageModified are added.
#466 - Uses `diff` to drive the majority of statuses.
#467 - refactors the internals of `RepositoryState`.