### PR TITLE
Preformatted error messages

### DIFF
--- a/extension/src/Experiments/commands/quickPick.test.ts
+++ b/extension/src/Experiments/commands/quickPick.test.ts
@@ -137,15 +137,19 @@ describe('garbageCollectExperiments', () => {
     mockedExecuteProcess.mockRejectedValueOnce(mockedError)
 
     await garbageCollectExperiments(exampleExecutionOptions)
-    expect(mockedShowErrorMessage).toBeCalledWith(stderr)
+    expect(mockedShowErrorMessage).toBeCalledWith(
+      'Failed to garbage collect experiments'
+    )
   })
 
-  it('reports the message from a non-shell Exception', async () => {
+  it('Shows an error on a non-shell Exception', async () => {
     const exampleMessage = 'example Error message that will be shown'
     mockedShowQuickPick.mockResolvedValueOnce([])
     mockedExecuteProcess.mockRejectedValueOnce(new Error(exampleMessage))
     await garbageCollectExperiments(exampleExecutionOptions)
-    expect(mockedShowErrorMessage).toBeCalledWith(exampleMessage)
+    expect(mockedShowErrorMessage).toBeCalledWith(
+      'Failed to garbage collect experiments'
+    )
   })
 
   it('executes the proper default command given no selections', async () => {
@@ -191,11 +195,15 @@ describe('applyExperiment', () => {
     })
   })
 
-  it('throws from a non-shell Exception', async () => {
+  it('catches a non-shell Exception', async () => {
     mockedShowQuickPick.mockResolvedValueOnce([])
     mockedExecuteProcess.mockRejectedValueOnce(new Error())
-    await expect(applyExperiment(exampleExecutionOptions)).rejects.toThrow()
-    expect(mockedShowErrorMessage).not.toBeCalled()
+    await expect(applyExperiment(exampleExecutionOptions)).resolves.toBe(
+      undefined
+    )
+    expect(mockedShowErrorMessage).toBeCalledWith(
+      'Error running command "dvc exp list --names-only"!'
+    )
   })
 
   it('displays an error message when there are no experiments to select', async () => {
@@ -204,7 +212,7 @@ describe('applyExperiment', () => {
     await applyExperiment(exampleExecutionOptions)
     expect(mockedShowQuickPick).not.toBeCalled()
     expect(mockedShowErrorMessage).toBeCalledWith(
-      'There are no experiments to select!'
+      'There are no experiments to select'
     )
   })
 
@@ -224,7 +232,7 @@ describe('removeExperiment', () => {
     await removeExperiment(exampleExecutionOptions)
 
     expect(mockedShowInformationMessage).toBeCalledWith(
-      'Experiment exp-2021 has been removed!'
+      'Experiment exp-2021 has been removed'
     )
     expect(mockedExecuteProcess).toBeCalledWith({
       executable: 'dvc',

--- a/extension/src/Experiments/commands/report.test.ts
+++ b/extension/src/Experiments/commands/report.test.ts
@@ -38,11 +38,13 @@ describe('queueExperiment', () => {
     expect(mockedShowInformationMessage).toBeCalledWith(stdout)
   })
 
-  it('displays an error message with the contents of stderr when the command fails', async () => {
+  it('displays an error message when the command fails', async () => {
     const stderr = 'Example stderr that will be resolved literally'
     const mockedError = { stderr }
     mockedExecuteProcess.mockRejectedValueOnce(mockedError)
     await queueExperiment(exampleExecutionOptions)
-    expect(mockedShowErrorMessage).toBeCalledWith(stderr)
+    expect(mockedShowErrorMessage).toBeCalledWith(
+      'Failed to queue an experiment'
+    )
   })
 })

--- a/extension/src/Experiments/commands/report.ts
+++ b/extension/src/Experiments/commands/report.ts
@@ -1,7 +1,7 @@
 import { window } from 'vscode'
 import { experimentRunQueue } from '../../cli/executor'
 import { ExecutionOptions } from '../../cli/execution'
-import { reportErrorMessage } from '../../vscode/reporting'
+import { showCliProcessError } from '../../vscode/reporting'
 
 export const queueExperiment = async (
   options: ExecutionOptions
@@ -9,6 +9,6 @@ export const queueExperiment = async (
   try {
     window.showInformationMessage(await experimentRunQueue(options))
   } catch (e) {
-    reportErrorMessage(e)
+    showCliProcessError(e, 'Failed to queue an experiment')
   }
 }

--- a/extension/src/vscode/reporting.ts
+++ b/extension/src/vscode/reporting.ts
@@ -27,5 +27,12 @@ export class CliProcessError extends Error {
   }
 }
 
-export const reportErrorMessage = (error: MaybeConsoleError) =>
-  window.showErrorMessage(error.stderr || error.message)
+const inferErrorMessage = (error: CliProcessError | Error): string =>
+  error instanceof CliProcessError
+    ? `Error running command "dvc ${error.args.join(' ')}"!`
+    : error.message
+
+export const showCliProcessError = (
+  error: MaybeConsoleError,
+  message: string = inferErrorMessage(error)
+) => window.showErrorMessage(message)


### PR DESCRIPTION
Builds off #469 by adding a handler function to use in `catch` that displays error info with `showErrorMessage`, taking the error itself and and optional message that is otherwise populated with the Error's `stderr`, or otherwise `message`.

This is more the result of an attempt to figure out how to integrate error handling into each command, and it seems the best way is to use `try/catch` in the logic of each command because every command is going to have at least slightly different data shapes and requirements for handling.

I've only focused on the experiments commands for now, but if we adopt this we would want to use this pattern on other commands as well.