### PR TITLE
Show error message if pickDvcRoot is invoked with no roots to pick

### DIFF
--- a/extension/src/Experiments/index.ts
+++ b/extension/src/Experiments/index.ts
@@ -1,4 +1,4 @@
-import { Event, EventEmitter } from 'vscode'
+import { Event, EventEmitter, window } from 'vscode'
 import { Disposable } from '@hediet/std/disposable'
 import { Deferred } from '@hediet/std/synchronization'
 import { makeObservable, observable } from 'mobx'
@@ -197,12 +197,17 @@ export class Experiments {
   }
 
   private pickDvcRoot() {
-    const experiments = Object.keys(this.experiments)
-    if (experiments.length === 1) {
-      return experiments[0]
+    const tableKeys = Object.keys(this.experiments)
+    if (tableKeys.length === 0) {
+      return window.showErrorMessage(
+        'There are no DVC projects in the current workspace'
+      )
+    }
+    if (tableKeys.length === 1) {
+      return tableKeys[0]
     }
     return quickPickOne(
-      experiments,
+      tableKeys,
       'Select which project to run command against'
     )
   }

--- a/extension/src/test/suite/Experiments/index.test.ts
+++ b/extension/src/test/suite/Experiments/index.test.ts
@@ -152,6 +152,27 @@ suite('Experiments Test Suite', () => {
 
       expect(mockQuickPickOne).to.not.be.called
     })
+
+    it('should show an error message if there are no projects', async () => {
+      const mockQuickPickOne = stub(QuickPick, 'quickPickOne').resolves(
+        dvcDemoPath
+      )
+
+      const mockShowErrorMessage = stub(window, 'showErrorMessage')
+
+      stub(CliReader, 'experimentShow').resolves(complexExperimentsOutput)
+
+      const config = disposable.track(new Config())
+
+      const experiments = new Experiments(config)
+
+      await experiments.showExperimentsTable()
+
+      expect(mockQuickPickOne).to.not.be.called
+      expect(mockShowErrorMessage).to.be.calledWith(
+        'There are no DVC projects in the current workspace'
+      )
+    })
   })
 
   describe('getExperimentsTableForCommand', () => {


### PR DESCRIPTION
Follows from #476, separated in case we decide we want that and not this.