### PR TITLE
Remove hash caching

### DIFF
--- a/extension/src/experiments/table.ts
+++ b/extension/src/experiments/table.ts
@@ -56,7 +56,7 @@ export class ExperimentsTable {
 
   public refresh = async () => {
     await this.updateData()
-    this.sendData()
+    return this.sendData()
   }
 
   public showWebview = async () => {


### PR DESCRIPTION
This caching mechanism may be causing #436, and beyond that isn't very effective at saving processing power. A mechanism like this could be reintroduced in a different way when we start introducing data parsing (#516/#517 and more planned) but currently it does so little that it makes sense to remove it compared to `master`

`dataDelivered` is only used for this mechanism, and private, so it is also removed.