### PR TITLE
Remove fat arrow functions from CliRunner

### DIFF
--- a/extension/src/cli/runner.ts
+++ b/extension/src/cli/runner.ts
@@ -124,12 +124,10 @@ export class CliRunner implements ICli {
   }
 
   private createProcess({ cwd, args }: { cwd: string; args: Args }): Process {
-    const env = getEnv(this.config.pythonBinPath)
-
     const process = createProcess({
       args,
       cwd,
-      env,
+      env: getEnv(this.config.pythonBinPath),
       executable: this.getOverrideOrCliPath()
     })
 


### PR DESCRIPTION
Thought I would move a single class off of fat arrow functions. If I do one or two every day then I should be done within a week... 🔋 