### PR TITLE
Remove unused test helper

### DIFF
--- a/extension/src/util/testHelpers.ts
+++ b/extension/src/util/testHelpers.ts
@@ -1,5 +1,0 @@
-import { Uri } from 'vscode'
-
-export function mapPaths(uris?: Uri[]): string[] | undefined {
-  return uris?.map(uri => uri.fsPath)
-}


### PR DESCRIPTION
We don't need this helper as we chose to handle URI differently within our unit tests.