### PR TITLE
Add inline experiment column child selection metadata

### DIFF
--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -63,8 +63,8 @@ export class Experiments {
     return this.getTable(dvcRoot).getChildColumns(path)
   }
 
-  public setIsColumnSelected(dvcRoot: string, path: string) {
-    return this.getTable(dvcRoot).setIsColumnSelected(path)
+  public toggleColumnStatus(dvcRoot: string, path: string) {
+    return this.getTable(dvcRoot).toggleColumnStatus(path)
   }
 
   public getCwdThenRun = async (commandId: CommandId) => {

--- a/extension/src/experiments/table.ts
+++ b/extension/src/experiments/table.ts
@@ -94,7 +94,7 @@ export class ExperimentsTable {
     )
   }
 
-  public setIsColumnSelected(path: string) {
+  public toggleColumnStatus(path: string) {
     const status = this.getNextStatus(path)
     this.columnStatus[path] = status
     this.setAreParentsSelected(path)

--- a/extension/src/experiments/views/columnsTree.test.ts
+++ b/extension/src/experiments/views/columnsTree.test.ts
@@ -204,7 +204,7 @@ describe('ExperimentsColumnsTree', () => {
       collapsibleState: 1,
       command: {
         arguments: [paramsPath],
-        command: 'dvc.views.experimentColumnsTree.toggleSelected',
+        command: 'dvc.views.experimentColumnsTree.toggleStatus',
         title: 'toggle'
       },
       description: '3/4',
@@ -247,7 +247,7 @@ describe('ExperimentsColumnsTree', () => {
       collapsibleState: 0,
       command: {
         arguments: [paramsPath],
-        command: 'dvc.views.experimentColumnsTree.toggleSelected',
+        command: 'dvc.views.experimentColumnsTree.toggleStatus',
         title: 'toggle'
       },
       iconPath: mockedEmptyCheckbox,

--- a/extension/src/experiments/views/columnsTree.ts
+++ b/extension/src/experiments/views/columnsTree.ts
@@ -49,10 +49,10 @@ export class ExperimentsColumnsTree implements TreeDataProvider<string> {
 
     this.dispose.track(
       commands.registerCommand(
-        'dvc.views.experimentColumnsTree.toggleSelected',
+        'dvc.views.experimentColumnsTree.toggleStatus',
         resource => {
           const [dvcRoot, path] = this.getDetails(resource)
-          const status = this.experiments.setIsColumnSelected(dvcRoot, path)
+          const status = this.experiments.toggleColumnStatus(dvcRoot, path)
           this.treeDataChanged.fire()
           return status
         }
@@ -81,7 +81,7 @@ export class ExperimentsColumnsTree implements TreeDataProvider<string> {
 
     treeItem.command = {
       arguments: [element],
-      command: 'dvc.views.experimentColumnsTree.toggleSelected',
+      command: 'dvc.views.experimentColumnsTree.toggleStatus',
       title: 'toggle'
     }
 

--- a/extension/src/test/suite/experiments/views/columnsTree.test.ts
+++ b/extension/src/test/suite/experiments/views/columnsTree.test.ts
@@ -36,7 +36,7 @@ suite('Extension Test Suite', () => {
     '..',
     'resources'
   )
-  const toggleCommand = 'dvc.views.experimentColumnsTree.toggleSelected'
+  const toggleCommand = 'dvc.views.experimentColumnsTree.toggleStatus'
   const paramsFile = 'params.yaml'
   const disposable = Disposable.fn()
 
@@ -49,7 +49,7 @@ suite('Extension Test Suite', () => {
   })
 
   describe('ExperimentColumnsTree', () => {
-    it('should be able to toggle whether an experiments column is selected with dvc.views.experimentColumnsTree.toggleSelected', async () => {
+    it('should be able to toggle whether an experiments column is selected with dvc.views.experimentColumnsTree.toggleStatus', async () => {
       const relPath = join('params', paramsFile, 'learning_rate')
       const absPath = join(dvcDemoPath, relPath)
 
@@ -95,8 +95,8 @@ suite('Extension Test Suite', () => {
       expect(isUnselectedAgain).to.equal(ColumnStatus.unselected)
     })
 
-    it("should be able to toggle a parents and change the selected status of it's children with dvc.views.experimentColumnsTree.toggleSelected", async () => {
-      const toggleCommand = 'dvc.views.experimentColumnsTree.toggleSelected'
+    it("should be able to toggle a parents and change the selected status of it's children with dvc.views.experimentColumnsTree.toggleStatus", async () => {
+      const toggleCommand = 'dvc.views.experimentColumnsTree.toggleStatus'
       const relPath = join('params', paramsFile)
       const absPath = join(dvcDemoPath, relPath)
 
@@ -160,7 +160,7 @@ suite('Extension Test Suite', () => {
     })
   })
 
-  it("should be able to select a child and set all it's ancestors' statuses to indeterminate with dvc.views.experimentColumnsTree.toggleSelected", async () => {
+  it("should be able to select a child and set all it's ancestors' statuses to indeterminate with dvc.views.experimentColumnsTree.toggleStatus", async () => {
     const grandParentPath = join('params', paramsFile)
     const parentPath = join(grandParentPath, 'process')
     const absPath = join(dvcDemoPath, grandParentPath)
@@ -230,7 +230,7 @@ suite('Extension Test Suite', () => {
     expect(grandParentColumn?.descendantMetadata).to.equal('2/8')
   })
 
-  it("should be able to unselect the last remaining selected child and set it's ancestors to unselected with dvc.views.experimentColumnsTree.toggleSelected", async () => {
+  it("should be able to unselect the last remaining selected child and set it's ancestors to unselected with dvc.views.experimentColumnsTree.toggleStatus", async () => {
     const grandParentPath = join('params', paramsFile)
     const parentPath = join(grandParentPath, 'process')
     const absPath = join(dvcDemoPath, grandParentPath)


### PR DESCRIPTION
# 1/2 `master` <- this <- #629 

This PR adds an inline count of the number of selected descendant columns / number of total descendant columns.

This is as close as I could get to the design with what is available within the API.

LMK what you think.

Demo: 

https://user-images.githubusercontent.com/37993418/125016635-fee3a900-e0b4-11eb-8dee-8119972c1bdb.mov

Thanks