### PR TITLE
Upgrade vscode dependencies

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -30,7 +30,7 @@
     "theme": "dark"
   },
   "engines": {
-    "vscode": "^1.58.0-insiders",
+    "vscode": "^1.58.1-insiders",
     "node": ">=10.2.0"
   },
   "activationEvents": [
@@ -617,7 +617,7 @@
     "@types/mocha": "^8.2.0",
     "@types/node": "^14.14.22",
     "@types/sinon-chai": "^3.2.5",
-    "@types/vscode": "^1.58.0",
+    "@types/vscode": "^1.58.1",
     "chai": "^4.2.0",
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^9.0.1",
@@ -629,8 +629,8 @@
     "sinon-chai": "^3.5.0",
     "ts-jest": "^27.0.3",
     "ts-loader": "^9.2.3",
-    "vsce": "^1.95.0",
-    "vscode-test": "^1.5.2",
+    "vsce": "^1.96.1",
+    "vscode-test": "^1.6.1",
     "vscode-uri": "^3.0.2",
     "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2"

--- a/extension/src/vscode.proposed.d.ts
+++ b/extension/src/vscode.proposed.d.ts
@@ -165,6 +165,42 @@ declare module 'vscode' {
     candidatePortSource?: CandidatePortSource
   }
 
+  /**
+   * More options to be used when getting an {@link AuthenticationSession} from an {@link AuthenticationProvider}.
+   */
+  export interface AuthenticationGetSessionOptions {
+    /**
+     * Whether we should attempt to reauthenticate even if there is already a session available.
+     *
+     * If true, a modal dialog will be shown asking the user to sign in again. This is mostly used for scenarios
+     * where the token needs to be re minted because it has lost some authorization.
+     *
+     * Defaults to false.
+     */
+    forceRecreate?: boolean
+  }
+
+  export namespace authentication {
+    /**
+     * Get an authentication session matching the desired scopes. Rejects if a provider with providerId is not
+     * registered, or if the user does not consent to sharing authentication information with
+     * the extension. If there are multiple sessions with the same scopes, the user will be shown a
+     * quickpick to select which account they would like to use.
+     *
+     * Currently, there are only two authentication providers that are contributed from built in extensions
+     * to the editor that implement GitHub and Microsoft authentication: their providerId's are 'github' and 'microsoft'.
+     * @param providerId The id of the provider to use
+     * @param scopes A list of scopes representing the permissions requested. These are dependent on the authentication provider
+     * @param options The {@link AuthenticationGetSessionOptions} to use
+     * @returns A thenable that resolves to an authentication session
+     */
+    export function getSession(
+      providerId: string,
+      scopes: readonly string[],
+      options: AuthenticationGetSessionOptions & { forceRecreate: true }
+    ): Thenable<AuthenticationSession>
+  }
+
   export namespace workspace {
     /**
      * Forwards a port. If the current resolver implements RemoteAuthorityResolver:forwardPort then that will be used to make the tunnel.
@@ -751,18 +787,18 @@ declare module 'vscode' {
   //#endregion
 
   // eslint-disable-next-line vscode-dts-region-comments
-  //#region @weinand: new debug session option 'managedByParent' (see https://github.com/microsoft/vscode/issues/128058)
+  //#region @roblourens: new debug session option for simple UI 'managedByParent' (see https://github.com/microsoft/vscode/issues/128588)
 
   /**
    * Options for {@link debug.startDebugging starting a debug session}.
    */
   export interface DebugSessionOptions {
-    /**
-     * Controls whether lifecycle requests like 'restart' are sent to the newly created session or its parent session.
-     * By default (if the property is false or missing), lifecycle requests are sent to the new session.
-     * This property is ignored if the session has no parent session.
-     */
-    managedByParent?: boolean
+    debugUI?: {
+      /**
+       * When true, the debug toolbar will not be shown for this session, the window statusbar color will not be changed, and the debug viewlet will not be automatically revealed.
+       */
+      simple?: boolean
+    }
   }
 
   //#endregion
@@ -946,6 +982,22 @@ declare module 'vscode' {
 
   //#endregion
 
+  //#region Terminal color support https://github.com/microsoft/vscode/issues/128228
+  export interface TerminalOptions {
+    /**
+     * Supports all ThemeColor keys, terminal.ansi* is recommended for contrast/consistency
+     */
+    color?: ThemeColor
+  }
+  export interface ExtensionTerminalOptions {
+    /**
+     * Supports all ThemeColor keys, terminal.ansi* is recommended for contrast/consistency
+     */
+    color?: ThemeColor
+  }
+
+  //#endregion
+
   // eslint-disable-next-line vscode-dts-region-comments
   //#region @jrieken -> exclusive document filters
 
@@ -984,14 +1036,34 @@ declare module 'vscode' {
     dragAndDropController?: DragAndDropController<T>
   }
 
+  export interface TreeDataTransferItem {
+    asString(): Thenable<string>
+  }
+
+  export interface TreeDataTransfer {
+    /**
+     * A map containing a mapping of the mime type of the corresponding data.
+     * The type for tree elements is text/treeitem.
+     * For example, you can reconstruct the your tree elements:
+     * ```ts
+     * JSON.parse(await (items.get('text/treeitems')!.asString()))
+     * ```
+     */
+    // todo@API no Map
+    // @ts-ignore
+    items: Map<string, TreeDataTransferItem>
+  }
+
   export interface DragAndDropController<T> extends Disposable {
+    readonly supportedTypes: string[]
+
     /**
      * Extensions should fire `TreeDataProvider.onDidChangeTreeData` for any elements that need to be refreshed.
      *
      * @param source
      * @param target
      */
-    onDrop(source: T[], target: T): Thenable<void>
+    onDrop(source: TreeDataTransfer, target: T): Thenable<void>
   }
   //#endregion
 
@@ -1501,36 +1573,6 @@ declare module 'vscode' {
 
   //#region @https://github.com/microsoft/vscode/issues/123601, notebook messaging
 
-  export interface NotebookRendererMessage<T> {
-    /**
-     * Editor that sent the message.
-     */
-    editor: NotebookEditor
-
-    /**
-     * Message sent from the webview.
-     */
-    message: T
-  }
-
-  /**
-   * Renderer messaging is used to communicate with a single renderer. It's
-   * returned from {@link notebooks.createRendererMessaging}.
-   */
-  export interface NotebookRendererMessaging<TSend = any, TReceive = TSend> {
-    /**
-     * Events that fires when a message is received from a renderer.
-     */
-    onDidReceiveMessage: Event<NotebookRendererMessage<TReceive>>
-
-    /**
-     * Sends a message to the renderer.
-     * @param editor Editor to target with the message
-     * @param message Message to send
-     */
-    postMessage(editor: NotebookEditor, message: TSend): void
-  }
-
   /**
    * Represents a script that is loaded into the notebook renderer before rendering output. This allows
    * to provide and share functionality for notebook markup and notebook output renderers.
@@ -1596,20 +1638,6 @@ declare module 'vscode' {
       ) => void | Thenable<void>,
       rendererScripts?: NotebookRendererScript[]
     ): NotebookController
-
-    /**
-     * Creates a new messaging instance used to communicate with a specific
-     * renderer. The renderer only has access to messaging if `requiresMessaging`
-     * is set to `always` or `optional` in its `notebookRenderer ` contribution.
-     *
-     * @see https://github.com/microsoft/vscode/issues/123601
-     * @param rendererId The renderer ID to communicate with
-     */
-    // todo@API can ANY extension talk to renderer or is there a check that the calling extension
-    // declared the renderer in its package.json?
-    export function createRendererMessaging<TSend = any, TReceive = TSend>(
-      rendererId: string
-    ): NotebookRendererMessaging<TSend, TReceive>
   }
 
   //#endregion
@@ -1919,18 +1947,11 @@ declare module 'vscode' {
   }
   //#endregion
 
-  //#region https://github.com/microsoft/vscode/issues/107467
-  export namespace test {
-    /**
-     * Creates a new test controller.
-     *
-     * @param id Identifier for the controller, must be globally unique.
-     */
-    export function createTestController(id: string): TestController
-
+  //#region proposed test APIs https://github.com/microsoft/vscode/issues/107467
+  export namespace tests {
     /**
      * Requests that tests be run by their controller.
-     * @param run Run options to use
+     * @param run Run options to use.
      * @param token Cancellation token for the test run
      */
     export function runTests(
@@ -1940,27 +1961,20 @@ declare module 'vscode' {
 
     /**
      * Returns an observer that watches and can request tests.
-     * @stability experimental
      */
     export function createTestObserver(): TestObserver
-
     /**
      * List of test results stored by the editor, sorted in descending
      * order by their `completedAt` time.
-     * @stability experimental
      */
     export const testResults: ReadonlyArray<TestRunResult>
 
     /**
      * Event that fires when the {@link testResults} array is updated.
-     * @stability experimental
      */
     export const onDidChangeTestResults: Event<void>
   }
 
-  /**
-   * @stability experimental
-   */
   export interface TestObserver {
     /**
      * List of tests returned by test provider for files in the workspace.
@@ -1981,9 +1995,6 @@ declare module 'vscode' {
     dispose(): void
   }
 
-  /**
-   * @stability experimental
-   */
   export interface TestsChangeEvent {
     /**
      * List of all tests that are newly added.
@@ -2002,282 +2013,10 @@ declare module 'vscode' {
   }
 
   /**
-   * Interface to discover and execute tests.
-   */
-  export interface TestController {
-    /**
-     * The ID of the controller, passed in {@link vscode.test.createTestController}
-     */
-    readonly id: string
-
-    /**
-     * Root test item. Tests in the workspace should be added as children of
-     * the root. The extension controls when to add these, although the
-     * editor may request children using the {@link resolveChildrenHandler},
-     * and the extension should add tests for a file when
-     * {@link vscode.workspace.onDidOpenTextDocument} fires in order for
-     * decorations for tests within the file to be visible.
-     *
-     * Tests in this collection should be watched and updated by the extension
-     * as files change. See  {@link resolveChildrenHandler} for details around
-     * for the lifecycle of watches.
-     */
-    // todo@API a little weird? what is its label, id, busy state etc? Can I dispose this?
-    // todo@API allow createTestItem-calls without parent and simply treat them as root (similar to createSourceControlResourceGroup)
-    readonly root: TestItem
-
-    /**
-     * Creates a new managed {@link TestItem} instance as a child of this
-     * one.
-     * @param id Unique identifier for the TestItem.
-     * @param label Human-readable label of the test item.
-     * @param parent Parent of the item. This is required; top-level items
-     * should be created as children of the {@link root}.
-     * @param uri URI this TestItem is associated with. May be a file or directory.
-     * @param data Custom data to be stored in {@link TestItem.data}
-     */
-    createTestItem(
-      id: string,
-      label: string,
-      parent: TestItem,
-      uri?: Uri
-    ): TestItem
-
-    /**
-     * A function provided by the extension that the editor may call to request
-     * children of a test item, if the {@link TestItem.canExpand} is `true`.
-     * When called, the item should discover children and call
-     * {@link TestController.createTestItem} as children are discovered.
-     *
-     * The item in the explorer will automatically be marked as "busy" until
-     * the function returns or the returned thenable resolves.
-     *
-     * The controller may wish to set up listeners or watchers to update the
-     * children as files and documents change.
-     *
-     * @param item An unresolved test item for which
-     * children are being requested
-     */
-    resolveChildrenHandler?: (item: TestItem) => Thenable<void> | void
-
-    /**
-     * Starts a test run. When called, the controller should call
-     * {@link TestController.createTestRun}. All tasks associated with the
-     * run should be created before the function returns or the reutrned
-     * promise is resolved.
-     *
-     * @param request Request information for the test run
-     * @param cancellationToken Token that signals the used asked to abort the
-     * test run. If cancellation is requested on this token, all {@link TestRun}
-     * instances associated with the request will be
-     * automatically cancelled as well.
-     */
-    runHandler?: (
-      request: TestRunRequest,
-      token: CancellationToken
-    ) => Thenable<void> | void
-    /**
-     * Creates a {@link TestRun<T>}. This should be called by the
-     * {@link TestRunner} when a request is made to execute tests, and may also
-     * be called if a test run is detected externally. Once created, tests
-     * that are included in the results will be moved into the
-     * {@link TestResultState.Pending} state.
-     *
-     * @param request Test run request. Only tests inside the `include` may be
-     * modified, and tests in its `exclude` are ignored.
-     * @param name The human-readable name of the run. This can be used to
-     * disambiguate multiple sets of results in a test run. It is useful if
-     * tests are run across multiple platforms, for example.
-     * @param persist Whether the results created by the run should be
-     * persisted in the editor. This may be false if the results are coming from
-     * a file already saved externally, such as a coverage information file.
-     */
-    createTestRun(
-      request: TestRunRequest,
-      name?: string,
-      persist?: boolean
-    ): TestRun
-
-    /**
-     * Unregisters the test controller, disposing of its associated tests
-     * and unpersisted results.
-     */
-    dispose(): void
-  }
-
-  /**
-   * Options given to {@link test.runTests}.
-   */
-  export class TestRunRequest {
-    /**
-     * Array of specific tests to run. The controllers should run all of the
-     * given tests and all children of the given tests, excluding any tests
-     * that appear in {@link TestRunRequest.exclude}.
-     */
-    tests: TestItem[]
-
-    /**
-     * An array of tests the user has marked as excluded in the editor. May be
-     * omitted if no exclusions were requested. Test controllers should not run
-     * excluded tests or any children of excluded tests.
-     */
-    exclude?: TestItem[]
-
-    /**
-     * Whether tests in this run should be debugged.
-     */
-    debug: boolean
-
-    /**
-     * @param tests Array of specific tests to run.
-     * @param exclude Tests to exclude from the run
-     * @param debug Whether tests in this run should be debugged.
-     */
-    constructor(
-      tests: readonly TestItem[],
-      exclude?: readonly TestItem[],
-      debug?: boolean
-    )
-  }
-
-  /**
-   * Options given to {@link TestController.runTests}
-   */
-  export interface TestRun {
-    /**
-     * The human-readable name of the run. This can be used to
-     * disambiguate multiple sets of results in a test run. It is useful if
-     * tests are run across multiple platforms, for example.
-     */
-    readonly name?: string
-
-    /**
-     * A cancellation token which will be triggered when the test run is
-     * canceled from the UI.
-     */
-    readonly token: CancellationToken
-
-    /**
-     * Updates the state of the test in the run. Calling with method with nodes
-     * outside the {@link TestRunRequest.tests} or in the
-     * {@link TestRunRequest.exclude} array will no-op.
-     *
-     * @param test The test to update
-     * @param state The state to assign to the test
-     * @param duration Optionally sets how long the test took to run, in milliseconds
-     */
-    //todo@API is this "update" state or set final state? should this be called setTestResult?
-    setState(test: TestItem, state: TestResultState, duration?: number): void
-
-    /**
-     * Appends a message, such as an assertion error, to the test item.
-     *
-     * Calling with method with nodes outside the {@link TestRunRequest.tests}
-     * or in the {@link TestRunRequest.exclude} array will no-op.
-     *
-     * @param test The test to update
-     * @param message The message to add
-     */
-    appendMessage(test: TestItem, message: TestMessage): void
-
-    /**
-     * Appends raw output from the test runner. On the user's request, the
-     * output will be displayed in a terminal. ANSI escape sequences,
-     * such as colors and text styles, are supported.
-     *
-     * @param output Output text to append
-     * @param associateTo Optionally, associate the given segment of output
-     */
-    appendOutput(output: string): void
-
-    /**
-     * Signals that the end of the test run. Any tests whose states have not
-     * been updated will be moved into the {@link TestResultState.Unset} state.
-     */
-    end(): void
-  }
-
-  /**
    * A test item is an item shown in the "test explorer" view. It encompasses
    * both a suite and a test, since they have almost or identical capabilities.
    */
   export interface TestItem {
-    /**
-     * Unique identifier for the TestItem. This is used to correlate
-     * test results and tests in the document with those in the workspace
-     * (test explorer). This must not change for the lifetime of the TestItem.
-     */
-    readonly id: string
-
-    /**
-     * URI this TestItem is associated with. May be a file or directory.
-     */
-    readonly uri?: Uri
-
-    /**
-     * A mapping of children by ID to the associated TestItem instances.
-     */
-    //todo@API use array over es6-map
-    readonly children: ReadonlyMap<string, TestItem>
-
-    /**
-     * The parent of this item, given in {@link TestController.createTestItem}.
-     * This is undefined only for the {@link TestController.root}.
-     */
-    readonly parent?: TestItem
-
-    /**
-     * Indicates whether this test item may have children discovered by resolving.
-     * If so, it will be shown as expandable in the Test Explorer  view, and
-     * expanding the item will cause {@link TestController.resolveChildrenHandler}
-     * to be invoked with the item.
-     *
-     * Default to false.
-     */
-    canResolveChildren: boolean
-
-    /**
-     * Controls whether the item is shown as "busy" in the Test Explorer view.
-     * This is useful for showing status while discovering children. Defaults
-     * to false.
-     */
-    busy: boolean
-
-    /**
-     * Display name describing the test case.
-     */
-    label: string
-
-    /**
-     * Optional description that appears next to the label.
-     */
-    description?: string
-
-    /**
-     * Location of the test item in its `uri`. This is only meaningful if the
-     * `uri` points to a file.
-     */
-    range?: Range
-
-    /**
-     * May be set to an error associated with loading the test. Note that this
-     * is not a test result and should only be used to represent errors in
-     * discovery, such as syntax errors.
-     */
-    error?: string | MarkdownString
-
-    /**
-     * Whether this test item can be run by providing it in the
-     * {@link TestRunRequest.tests} array. Defaults to `true`.
-     */
-    runnable: boolean
-
-    /**
-     * Whether this test item can be debugged by providing it in the
-     * {@link TestRunRequest.tests} array. Defaults to `false`.
-     */
-    debuggable: boolean
-
     /**
      * Marks the test as outdated. This can happen as a result of file changes,
      * for example. In "auto run" mode, tests that are outdated will be
@@ -2286,103 +2025,18 @@ declare module 'vscode' {
      *
      * Extensions should generally not override this method.
      */
+    // todo@api still unsure about this
     invalidateResults(): void
-
-    /**
-     * Removes the test and its children from the tree.
-     */
-    dispose(): void
   }
 
   /**
-   * Possible states of tests in a test run.
-   */
-  export enum TestResultState {
-    // Initial state
-    Unset = 0,
-    // Test will be run, but is not currently running.
-    Queued = 1,
-    // Test is currently running
-    Running = 2,
-    // Test run has passed
-    Passed = 3,
-    // Test run has failed (on an assertion)
-    Failed = 4,
-    // Test run has been skipped
-    Skipped = 5,
-    // Test run failed for some other reason (compilation error, timeout, etc)
-    Errored = 6
-  }
-
-  /**
-   * Represents the severity of test messages.
-   */
-  export enum TestMessageSeverity {
-    Error = 0,
-    Warning = 1,
-    Information = 2,
-    Hint = 3
-  }
-
-  /**
-   * Message associated with the test state. Can be linked to a specific
-   * source range -- useful for assertion failures, for example.
-   */
-  export class TestMessage {
-    /**
-     * Human-readable message text to display.
-     */
-    message: string | MarkdownString
-
-    /**
-     * Message severity. Defaults to "Error".
-     */
-    severity: TestMessageSeverity
-
-    /**
-     * Expected test output. If given with `actualOutput`, a diff view will be shown.
-     */
-    expectedOutput?: string
-
-    /**
-     * Actual test output. If given with `expectedOutput`, a diff view will be shown.
-     */
-    actualOutput?: string
-
-    /**
-     * Associated file location.
-     */
-    location?: Location
-
-    /**
-     * Creates a new TestMessage that will present as a diff in the editor.
-     * @param message Message to display to the user.
-     * @param expected Expected output.
-     * @param actual Actual output.
-     */
-    static diff(
-      message: string | MarkdownString,
-      expected: string,
-      actual: string
-    ): TestMessage
-
-    /**
-     * Creates a new TestMessage instance.
-     * @param message The message to show to the user.
-     */
-    constructor(message: string | MarkdownString)
-  }
-
-  /**
-   * TestResults can be provided to the editor in {@link test.publishTestResult},
-   * or read from it in {@link test.testResults}.
+   * TestResults can be provided to the editor in {@link tests.publishTestResult},
+   * or read from it in {@link tests.testResults}.
    *
    * The results contain a 'snapshot' of the tests at the point when the test
    * run is complete. Therefore, information such as its {@link Range} may be
    * out of date. If the test still exists in the workspace, consumers can use
    * its `id` to correlate the result instance with the living test.
-   *
-   * @todo coverage and other info may eventually be provided here
    */
   export interface TestRunResult {
     /**
@@ -2397,7 +2051,7 @@ declare module 'vscode' {
 
     /**
      * List of test results. The items in this array are the items that
-     * were passed in the {@link test.runTests} method.
+     * were passed in the {@link tests.runTests} method.
      */
     results: ReadonlyArray<Readonly<TestResultSnapshot>>
   }
@@ -2413,6 +2067,11 @@ declare module 'vscode' {
      * those in the workspace (test explorer).
      */
     readonly id: string
+
+    /**
+     * Parent of this item.
+     */
+    readonly parent?: TestResultSnapshot
 
     /**
      * URI this TestItem is associated with. May be a file or file.
@@ -2439,7 +2098,7 @@ declare module 'vscode' {
      * State of the test in each task. In the common case, a test will only
      * be executed in a single task and the length of this array will be 1.
      */
-    readonly taskStates: ReadonlyArray<TestSnapshoptTaskState>
+    readonly taskStates: ReadonlyArray<TestSnapshotTaskState>
 
     /**
      * Optional list of nested tests for this item.
@@ -2447,7 +2106,7 @@ declare module 'vscode' {
     readonly children: Readonly<TestResultSnapshot>[]
   }
 
-  export interface TestSnapshoptTaskState {
+  export interface TestSnapshotTaskState {
     /**
      * Current result of the test.
      */
@@ -2464,6 +2123,24 @@ declare module 'vscode' {
      * failure information if the test fails.
      */
     readonly messages: ReadonlyArray<TestMessage>
+  }
+
+  /**
+   * Possible states of tests in a test run.
+   */
+  export enum TestResultState {
+    // Test will be run, but is not currently running.
+    Queued = 1,
+    // Test is currently running
+    Running = 2,
+    // Test run has passed
+    Passed = 3,
+    // Test run has failed (on an assertion)
+    Failed = 4,
+    // Test run has been skipped
+    Skipped = 5,
+    // Test run failed for some other reason (compilation error, timeout, etc)
+    Errored = 6
   }
 
   //#endregion
@@ -3132,6 +2809,161 @@ declare module 'vscode' {
   }
 
   export type DetailedCoverage = StatementCoverage | FunctionCoverage
+
+  //#endregion
+
+  //#region https://github.com/microsoft/vscode/issues/15533 --- Type hierarchy --- @eskibear
+
+  /**
+   * Represents an item of a type hierarchy, like a class or an interface.
+   */
+  export class TypeHierarchyItem {
+    /**
+     * The name of this item.
+     */
+    name: string
+
+    /**
+     * The kind of this item.
+     */
+    kind: SymbolKind
+
+    /**
+     * Tags for this item.
+     */
+    tags?: ReadonlyArray<SymbolTag>
+
+    /**
+     * More detail for this item, e.g. the signature of a function.
+     */
+    detail?: string
+
+    /**
+     * The resource identifier of this item.
+     */
+    uri: Uri
+
+    /**
+     * The range enclosing this symbol not including leading/trailing whitespace
+     * but everything else, e.g. comments and code.
+     */
+    range: Range
+
+    /**
+     * The range that should be selected and revealed when this symbol is being
+     * picked, e.g. the name of a class. Must be contained by the {@link TypeHierarchyItem.range range}-property.
+     */
+    selectionRange: Range
+
+    /**
+     * Creates a new type hierarchy item.
+     *
+     * @param kind The kind of the item.
+     * @param name The name of the item.
+     * @param detail The details of the item.
+     * @param uri The Uri of the item.
+     * @param range The whole range of the item.
+     * @param selectionRange The selection range of the item.
+     */
+    constructor(
+      kind: SymbolKind,
+      name: string,
+      detail: string,
+      uri: Uri,
+      range: Range,
+      selectionRange: Range
+    )
+  }
+
+  /**
+   * The type hierarchy provider interface describes the contract between extensions
+   * and the type hierarchy feature.
+   */
+  export interface TypeHierarchyProvider {
+    /**
+     * Bootstraps type hierarchy by returning the item that is denoted by the given document
+     * and position. This item will be used as entry into the type graph. Providers should
+     * return `undefined` or `null` when there is no item at the given location.
+     *
+     * @param document The document in which the command was invoked.
+     * @param position The position at which the command was invoked.
+     * @param token A cancellation token.
+     * @returns A type hierarchy item or a thenable that resolves to such. The lack of a result can be
+     * signaled by returning `undefined` or `null`.
+     */
+    prepareTypeHierarchy(
+      document: TextDocument,
+      position: Position,
+      token: CancellationToken
+    ): ProviderResult<TypeHierarchyItem[]>
+
+    /**
+     * Provide all supertypes for an item, e.g all types from which a type is derived/inherited. In graph terms this describes directed
+     * and annotated edges inside the type graph, e.g the given item is the starting node and the result is the nodes
+     * that can be reached.
+     *
+     * @param item The hierarchy item for which super types should be computed.
+     * @param token A cancellation token.
+     * @returns A set of supertypes or a thenable that resolves to such. The lack of a result can be
+     * signaled by returning `undefined` or `null`.
+     */
+    provideTypeHierarchySupertypes(
+      item: TypeHierarchyItem,
+      token: CancellationToken
+    ): ProviderResult<TypeHierarchyItem[]>
+
+    /**
+     * Provide all subtypes for an item, e.g all types which are derived/inherited from the given item. In
+     * graph terms this describes directed and annotated edges inside the type graph, e.g the given item is the starting
+     * node and the result is the nodes that can be reached.
+     *
+     * @param item The hierarchy item for which subtypes should be computed.
+     * @param token A cancellation token.
+     * @returns A set of subtypes or a thenable that resolves to such. The lack of a result can be
+     * signaled by returning `undefined` or `null`.
+     */
+    provideTypeHierarchySubtypes(
+      item: TypeHierarchyItem,
+      token: CancellationToken
+    ): ProviderResult<TypeHierarchyItem[]>
+  }
+
+  export namespace languages {
+    /**
+     * Register a type hierarchy provider.
+     *
+     * @param selector A selector that defines the documents this provider is applicable to.
+     * @param provider A type hierarchy provider.
+     * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
+     */
+    export function registerTypeHierarchyProvider(
+      selector: DocumentSelector,
+      provider: TypeHierarchyProvider
+    ): Disposable
+  }
+  //#endregion
+
+  //#region https://github.com/microsoft/vscode/issues/129037
+
+  enum LanguageStatusSeverity {
+    Information = 0,
+    Warning = 1,
+    Error = 2
+  }
+
+  interface LanguageStatusItem {
+    selector: DocumentSelector
+    text: string
+    detail: string | MarkdownString
+    severity: LanguageStatusSeverity
+    dispose(): void
+  }
+
+  namespace languages {
+    export function createLanguageStatusItem(
+      selector: DocumentSelector
+    ): LanguageStatusItem
+  }
 
   //#endregion
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3524,10 +3524,10 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
-"@types/vscode@^1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.58.0.tgz#91662aa27197c750df314e0d27de4b23512ebe59"
-  integrity sha512-enznxcBi4uYt20LWal09E0+VKEHZlq9PZawTu/mpWCVCFWWbiyR8HNI1ikBP1Ypqv8b3A/0md3DY1jcx+oQ8kQ==
+"@types/vscode@^1.58.1":
+  version "1.58.1"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.58.1.tgz#7deae08792adc73fa57383244a0c79d3530df4f7"
+  integrity sha512-sa76rDXiSif09he8KoaWWUQxsuBr2+uND0xn1GUbEODkuEjp2p7Rqd3t5qlvklfmAedLFdL7MdnsPa57uzwcOw==
 
 "@types/webpack-env@^1.16.0":
   version "1.16.0"
@@ -4484,10 +4484,10 @@ axobject-query@^2.2.0:
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
   integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
 
-azure-devops-node-api@^10.2.2:
-  version "10.2.2"
-  resolved "https://registry.yarnpkg.com/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz#9f557e622dd07bbaa9bd5e7e84e17c761e2151b2"
-  integrity sha512-4TVv2X7oNStT0vLaEfExmy3J4/CzfuXolEcQl/BRUmvGySqKStTG2O55/hUQ0kM7UJlZBLgniM0SBq4d/WkKow==
+azure-devops-node-api@^11.0.1:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/azure-devops-node-api/-/azure-devops-node-api-11.0.1.tgz#b7ec4783230e1de8fc972b23effe7ed2ebac17ff"
+  integrity sha512-YMdjAw9l5p/6leiyIloxj3k7VIvYThKjvqgiQn88r3nhT93ENwsoDS3A83CyJ4uTWzCZ5f5jCi6c27rTU5Pz+A==
   dependencies:
     tunnel "0.0.6"
     typed-rest-client "^1.8.4"
@@ -15088,12 +15088,12 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
-vsce@^1.95.0:
-  version "1.95.0"
-  resolved "https://registry.yarnpkg.com/vsce/-/vsce-1.95.0.tgz#852a5f9c9c6c03c42e8096ffdb032a07260369ed"
-  integrity sha512-OiSrJRd9NT4t+MBVrTblHqo0pOGaoplHzEzSNOGnIsLxyRIqk4CYmoqUnjOrZf8DEalbALsFVTFbTJLeC1hAKA==
+vsce@^1.96.1:
+  version "1.96.1"
+  resolved "https://registry.yarnpkg.com/vsce/-/vsce-1.96.1.tgz#782eb094001f14ce9abecb5d3a1d8586a14bac4b"
+  integrity sha512-KnEVqjfc1dXrpZsbJ8J7B9VQ7GAAx8o5RqBNk42Srv1KF9+e2/aXchQHe9QZxeUs/FiliHoMGpGvnHTXwKIT2A==
   dependencies:
-    azure-devops-node-api "^10.2.2"
+    azure-devops-node-api "^11.0.1"
     chalk "^2.4.2"
     cheerio "^1.0.0-rc.9"
     commander "^6.1.0"
@@ -15114,10 +15114,10 @@ vsce@^1.95.0:
     yauzl "^2.3.1"
     yazl "^2.2.2"
 
-vscode-test@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/vscode-test/-/vscode-test-1.5.2.tgz#d9ec3cab1815afae1d7d81923e3c685d13d32303"
-  integrity sha512-x9PVfKxF6EInH9iSFGQi0V8H5zIW1fC7RAer6yNQR6sy3WyOwlWkuT3I+wf75xW/cO53hxMi1aj/EvqQfDFOAg==
+vscode-test@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/vscode-test/-/vscode-test-1.6.1.tgz#44254c67036de92b00fdd72f6ace5f1854e1a563"
+  integrity sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==
   dependencies:
     http-proxy-agent "^4.0.1"
     https-proxy-agent "^5.0.0"


### PR DESCRIPTION
Upgrading `@types/vscode` , `vscode-test` & `vsce`. Also updates the proposed API.

The drag and drop functionality in tree views is still moving forwards: https://github.com/microsoft/vscode/issues/32592#issuecomment-879159570