### PR TITLE
Add windows hide option to process exection for windows users

### DIFF
--- a/extension/src/processExecution.ts
+++ b/extension/src/processExecution.ts
@@ -33,7 +33,8 @@ export const createProcess = ({
     all: true,
     cwd,
     env,
-    extendEnv: true
+    extendEnv: true,
+    windowsHide: true
   })
 }
 


### PR DESCRIPTION
I saw this bug this morning when working through onboarding for #496 with @hantatsang, this should fix the windows in Windows issue that we were seeing.