### PR TITLE
Switch ExperimentsTree to string | ExperimentItem tree type

### DIFF
--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -107,8 +107,8 @@ export class Experiments {
     return this.getRepository(dvcRoot).getExperiments()
   }
 
-  public getCheckpoints(dvcRoot: string, experimentName: string) {
-    return this.getRepository(dvcRoot).getCheckpoints(experimentName)
+  public getCheckpoints(dvcRoot: string, experimentId: string) {
+    return this.getRepository(dvcRoot).getCheckpoints(experimentId)
   }
 
   public getCwdThenRun = async (commandId: CommandId) => {

--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -61,14 +61,8 @@ export class ExperimentsModel {
     }))
   }
 
-  public getCheckpoints(name: string): Experiment[] | undefined {
-    const id = this.getExperiments().find(
-      experiment => experiment.displayName === name
-    )?.id
-    if (!id) {
-      return
-    }
-    return this.checkpointsByTip.get(id)
+  public getCheckpoints(experimentId: string): Experiment[] | undefined {
+    return this.checkpointsByTip.get(experimentId)
   }
 
   public getRowData() {

--- a/extension/src/experiments/model/tree.test.ts
+++ b/extension/src/experiments/model/tree.test.ts
@@ -85,9 +85,19 @@ describe('ExperimentsTree', () => {
       })
 
       const experiments = [
-        { displayName: '90aea7f', hasChildren: true },
-        { displayName: 'f0778b3', hasChildren: false, running: true },
-        { displayName: 'f81f1b5', hasChildren: false, queued: true }
+        { displayName: '90aea7f', hasChildren: true, id: '90aea7f' },
+        {
+          displayName: 'f0778b3',
+          hasChildren: false,
+          id: 'f0778b3',
+          running: true
+        },
+        {
+          displayName: 'f81f1b5',
+          hasChildren: false,
+          id: 'f81f1b5',
+          queued: true
+        }
       ]
       const experimentsTree = new ExperimentsTree(mockedExperiments)
       mockedGetExperiments.mockReturnValueOnce(experiments)
@@ -102,18 +112,21 @@ describe('ExperimentsTree', () => {
           collapsibleState: 1,
           dvcRoot: 'repo',
           iconPath: new ThemeIcon('primitive-dot'),
+          id: '90aea7f',
           label: '90aea7f'
         },
         {
           collapsibleState: 0,
           dvcRoot: 'repo',
           iconPath: new ThemeIcon('loading~spin'),
+          id: 'f0778b3',
           label: 'f0778b3'
         },
         {
           collapsibleState: 0,
           dvcRoot: 'repo',
           iconPath: new ThemeIcon('watch'),
+          id: 'f81f1b5',
           label: 'f81f1b5'
         }
       ])
@@ -127,8 +140,8 @@ describe('ExperimentsTree', () => {
       const experimentsTree = new ExperimentsTree(mockedExperiments)
 
       const checkpoints = [
-        { displayName: 'aaaaaaa' },
-        { displayName: 'bbbbbbb' }
+        { displayName: 'aaaaaaa', id: 'aaaaaaaaaaaaaaaaa' },
+        { displayName: 'bbbbbbb', id: 'bbbbbbbbbbbbbbbbb' }
       ]
       mockedGetCheckpoints.mockReturnValueOnce(checkpoints)
 
@@ -136,6 +149,7 @@ describe('ExperimentsTree', () => {
         collapsibleState: 1,
         dvcRoot: 'repo',
         iconPath: new ThemeIcon('loading~spin'),
+        id: 'ebbd66f',
         label: 'ebbd66f'
       })
 
@@ -144,12 +158,14 @@ describe('ExperimentsTree', () => {
           collapsibleState: 0,
           dvcRoot: 'repo',
           iconPath: new ThemeIcon('debug-stackframe-dot'),
+          id: 'aaaaaaaaaaaaaaaaa',
           label: 'aaaaaaa'
         },
         {
           collapsibleState: 0,
           dvcRoot: 'repo',
           iconPath: new ThemeIcon('debug-stackframe-dot'),
+          id: 'bbbbbbbbbbbbbbbbb',
           label: 'bbbbbbb'
         }
       ])
@@ -193,6 +209,7 @@ describe('ExperimentsTree', () => {
         collapsibleState: 0,
         dvcRoot: 'demo',
         iconPath: new ThemeIcon('watch'),
+        id: 'f0778b3',
         label: 'f0778b3'
       })
       expect(treeItem).toEqual({ ...mockedItem, iconPath: { id: 'watch' } })
@@ -216,6 +233,7 @@ describe('ExperimentsTree', () => {
         collapsibleState: 0,
         dvcRoot: 'demo',
         iconPath: new ThemeIcon('loading~spin'),
+        id: 'workspace',
         label: 'workspace'
       })
 
@@ -242,6 +260,7 @@ describe('ExperimentsTree', () => {
         collapsibleState: 1,
         dvcRoot: 'demo',
         iconPath: new ThemeIcon('loading~spin'),
+        id: 'f0778b3',
         label: 'f0778b3'
       })
 
@@ -268,6 +287,7 @@ describe('ExperimentsTree', () => {
         collapsibleState: 0,
         dvcRoot: 'demo',
         iconPath: new ThemeIcon('debug-stackframe-dot'),
+        id: 'f0778b3',
         label: 'f0778b3'
       })
       expect(treeItem).toEqual({
@@ -293,6 +313,7 @@ describe('ExperimentsTree', () => {
         collapsibleState: 1,
         dvcRoot: 'demo',
         iconPath: new ThemeIcon('primitive-dot'),
+        id: 'f0998a3',
         label: 'f0998a3'
       })
 

--- a/extension/src/experiments/model/tree.ts
+++ b/extension/src/experiments/model/tree.ts
@@ -19,6 +19,7 @@ enum Status {
 
 type ExperimentItem = {
   dvcRoot: string
+  id: string
   label: string
   collapsibleState: TreeItemCollapsibleState
   iconPath: ThemeIcon
@@ -69,8 +70,8 @@ export class ExperimentsTree
       return Promise.resolve(this.getExperiments(element))
     }
 
-    const { dvcRoot, label } = element
-    return Promise.resolve(this.getCheckpoints(dvcRoot, label) || [])
+    const { dvcRoot, id } = element
+    return Promise.resolve(this.getCheckpoints(dvcRoot, id) || [])
   }
 
   private async getRootElements() {
@@ -97,6 +98,7 @@ export class ExperimentsTree
         : TreeItemCollapsibleState.None,
       dvcRoot,
       iconPath: this.getExperimentThemeIcon(experiment),
+      id: experiment.id,
       label: experiment.displayName
     }))
   }
@@ -121,12 +123,13 @@ export class ExperimentsTree
     return new ThemeIcon('primitive-dot')
   }
 
-  private getCheckpoints(dvcRoot: string, name: string) {
-    return (this.experiments.getCheckpoints(dvcRoot, name) || []).map(
+  private getCheckpoints(dvcRoot: string, experimentId: string) {
+    return (this.experiments.getCheckpoints(dvcRoot, experimentId) || []).map(
       checkpoint => ({
         collapsibleState: TreeItemCollapsibleState.None,
         dvcRoot,
         iconPath: new ThemeIcon('debug-stackframe-dot'),
+        id: checkpoint.id,
         label: checkpoint.displayName
       })
     )

--- a/extension/src/experiments/repository.ts
+++ b/extension/src/experiments/repository.ts
@@ -180,8 +180,8 @@ export class ExperimentsRepository {
     return this.experiments.getExperiments()
   }
 
-  public getCheckpoints(name: string) {
-    return this.experiments.getCheckpoints(name)
+  public getCheckpoints(experimentId: string) {
+    return this.experiments.getCheckpoints(experimentId)
   }
 
   private async updateData(): Promise<boolean | undefined> {

--- a/extension/src/test/suite/experiments/repository.test.ts
+++ b/extension/src/test/suite/experiments/repository.test.ts
@@ -103,7 +103,7 @@ suite('Experiments Repository Test Suite', () => {
   })
 
   describe('getCheckpoints', () => {
-    it('should return the correct checkpoints for the given experiment name', async () => {
+    it("should return the correct checkpoints for an experiment's id", async () => {
       const config = disposable.track(new Config())
       const cliReader = disposable.track(new CliReader(config))
       stub(cliReader, 'experimentShow').resolves(complexExperimentsOutput)
@@ -121,12 +121,14 @@ suite('Experiments Repository Test Suite', () => {
       )
       await experimentsRepository.isReady()
 
-      const notAnExperimentName = ':cartwheel:'
+      const notAnExperimentId = ':cartwheel:'
       const notCheckpoints =
-        experimentsRepository.getCheckpoints(notAnExperimentName)
+        experimentsRepository.getCheckpoints(notAnExperimentId)
       expect(notCheckpoints).to.be.undefined
 
-      const checkpoints = experimentsRepository.getCheckpoints('exp-05694')
+      const checkpoints = experimentsRepository.getCheckpoints(
+        'd3f4a0d3661c5977540d2205d819470cf0d2145a'
+      )
 
       expect(
         checkpoints?.map(checkpoint => checkpoint.displayName)


### PR DESCRIPTION
This one is close to a rewrite but should be fairly easy to follow. I removed as many passthrough methods as possible.

The bulk of the additional code is in the tests so overall we should have a reduction in complexity of the tree and surrounding code.