### PR TITLE
Update CLI unavailable message and add Don't Show Again option

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -251,6 +251,12 @@
           "type": "string",
           "default": null
         },
+        "dvc.noCLIUnavailableInfo": {
+          "title": "%config.noCLIUnavailableInfo.title%",
+          "description": "%config.noCLIUnavailableInfo.description%",
+          "type": "boolean",
+          "default": false
+        },
         "dvc.views.trackedExplorerTree.noOpenUnsupported": {
           "title": "%config.noOpenUnsupported.title%",
           "description": "%config.noOpenUnsupported.description%",

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -39,6 +39,8 @@
   "config.dvcPath.title": "DVC CLI Path",
   "config.defaultProject.description": "When enabled all generic commands will be run against this project.",
   "config.defaultProject.title": "DVC Default Project",
+  "config.noCLIUnavailableInfo.title": "DVC - No CLI Unavailable Information",
+  "config.noCLIUnavailableInfo.description": "Do not show an information prompt when the CLI is unavailable to the extension.",
   "config.noOpenUnsupported.description": "Do not attempt to open dvc tracked files that are not supported by the text editor.",
   "config.noOpenUnsupported.title": "DVC Tracked - No Open Unsupported Files",
   "config.noPromptPullMissing.description": "Do not prompt to pull dvc tracked files that do not exist.",

--- a/extension/src/config.ts
+++ b/extension/src/config.ts
@@ -36,6 +36,7 @@ export class Config {
   private readonly initialized = this.deferred.promise
 
   private dvcPathOption = 'dvc.dvcPath'
+  private dvcPath = getConfigValue(this.dvcPathOption)
   private defaultProjectOption = 'dvc.defaultProject'
 
   private dvcPathQuickPickItems = [
@@ -91,6 +92,16 @@ export class Config {
     this.dispose.track(
       window.onDidChangeActiveColorTheme(() => {
         this.vsCodeTheme = window.activeColorTheme
+      })
+    )
+
+    this.dispose.track(
+      workspace.onDidChangeConfiguration(e => {
+        if (e.affectsConfiguration(this.dvcPathOption)) {
+          const oldPath = this.dvcPath
+          this.dvcPath = this.getCliPath()
+          this.notifyIfChanged(oldPath, this.dvcPath)
+        }
       })
     )
   }

--- a/extension/src/setup.ts
+++ b/extension/src/setup.ts
@@ -1,5 +1,6 @@
 import { window } from 'vscode'
 import { IExtension } from './interfaces'
+import { getConfigValue, setConfigValue } from './vscode/config'
 
 export const setup = async (extension: IExtension) => {
   const hasWorkspaceFolder = extension.hasWorkspaceFolder()
@@ -15,8 +16,17 @@ export const setup = async (extension: IExtension) => {
 
   extension.reset()
 
-  window.showInformationMessage(
-    'DVC extension is unable to initialize as the cli is not available.\n' +
-      'Update your config options to try again.'
+  if (getConfigValue('dvc.noCLIUnavailableInfo')) {
+    return
+  }
+
+  const response = await window.showInformationMessage(
+    'The DVC extension cannot currently access the CLI.\n' +
+      'Update your config to try again.',
+    "Don't Show Again"
   )
+
+  if (response) {
+    return setConfigValue('dvc.noCLIUnavailableInfo', true)
+  }
 }


### PR DESCRIPTION
This PR updates the text displayed when the CLI cannot be accessed by the extension either on load of the workspace or when the execution details change in the config. It also adds an option to never show the information message again (in that workspace).

This is an initial step in improving initial setup of a workspace. From here I want to add a setup workspace button that takes the user through a quick pick based setup wizard to get their execution details right. They should only ever have to do it once and it'll mean we can drop a lot complexity out of the docs. 

Demo:

https://user-images.githubusercontent.com/37993418/128849729-fc85336f-6795-4c0c-b0a7-1b09d98b55e7.mov

