### PR TITLE
Remove explicit delay from integration tests

### DIFF
--- a/extension/src/test/suite/extension.test.ts
+++ b/extension/src/test/suite/extension.test.ts
@@ -294,12 +294,20 @@ suite('Extension Test Suite', () => {
         'GONE AGAIN'
       )
 
-      const mockDisposer = spy(Disposer, 'reset')
+      const mockDisposer = stub(Disposer, 'reset')
+
+      const disposalEvent = new Promise(resolve => {
+        mockDisposer.callsFake((...args) => {
+          mockDisposer.wrappedMethod(...args)
+          resolve(undefined)
+        })
+      })
 
       await selectDvcPathFromFilePicker()
 
-      expect(mockShowOpenDialog).to.be.calledOnce
+      await disposalEvent
 
+      expect(mockShowOpenDialog).to.be.calledOnce
       expect(mockShowOpenDialog).to.have.been.called
       expect(mockCanRunCli).to.have.been.called
       expect(mockDisposer).to.have.been.called


### PR DESCRIPTION
# 2/3 <- `master` <- #713  <- this <- #715

This PR removes the explicit delay from the configuration change event and replaces it with a stub event that we can wait for.