### PR TITLE
Notify experiments clients once initial data load is complete

### DIFF
--- a/extension/src/experiments/repository.ts
+++ b/extension/src/experiments/repository.ts
@@ -84,6 +84,7 @@ export class ExperimentsRepository {
         )
       )
       this.deferred.resolve()
+      this.notifyChanged()
     })
   }
 


### PR DESCRIPTION
Fixes #743 

This one is easier to explain using videos. 

If we get into the view panel before the data loads then this happens (as described in #743):

https://user-images.githubusercontent.com/37993418/130890602-6560872d-d0de-4db1-a5ea-c2f5be7d7ff7.mov

If the user waits for all of the data to be loaded then we get the expected behaviour:

https://user-images.githubusercontent.com/37993418/130890695-0cb03f5b-e3b6-42e0-b9af-a8507696cec9.mov

The fix is to notify all clients once the data has been loaded, we then don't get stuck in the empty state (**this is a demo for the fix**):

https://user-images.githubusercontent.com/37993418/130890729-b33085cb-a5d0-4357-84c2-740ad8334d9d.mov
