### PR TITLE
Reorder new quick pick description and label

### DIFF
--- a/extension/src/experiments/model/sortBy/quickPick.ts
+++ b/extension/src/experiments/model/sortBy/quickPick.ts
@@ -38,8 +38,8 @@ export const pickSortsToRemove = (
 
   return quickPickManyValues<SortDefinition>(
     sorts.map(sort => ({
-      description: sort.path,
-      label: sort.descending ? 'descending' : 'ascending',
+      description: sort.descending ? 'descending' : 'ascending',
+      label: sort.path,
       value: sort
     })),
     {


### PR DESCRIPTION
Rewatched the video from #746 and realised that I messed this up. This is what the quick pick looks like now:

<img width="1679" alt="Screen Shot 2021-08-27 at 8 09 35 am" src="https://user-images.githubusercontent.com/37993418/131042764-82ad873a-1278-4fad-ba29-5a53af0d7924.png">
