### PR TITLE
Fix assignment of command name (missing percentage sign)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -215,7 +215,7 @@
         "icon": "$(close-all)"
       },
       {
-        "title": "%command.views.experimentsSortByTree.removeAllSorts",
+        "title": "%command.views.experimentsSortByTree.removeAllSorts%",
         "command": "dvc.views.experimentsSortByTree.removeAllSorts",
         "category": "DVC",
         "icon": "$(close-all)"


### PR DESCRIPTION
Fixes this:

![image](https://user-images.githubusercontent.com/37993418/131431825-9c148e57-bf48-4ca8-baf9-b2c9fa60317c.png)

I checked for other instances of the issue but could not find any