### PR TITLE
Add extension load analytics event

### DIFF
--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -5,12 +5,18 @@ export const EXTENSION_ID = 'iterative.dvc'
 
 export const EventName = Object.assign(
   {
-    EXTENSION_LOAD: 'EXTENSION.LOAD'
+    EXTENSION_LOAD: 'extension.load'
   } as const,
   RegisteredCommands
 )
 
 export interface IEventNamePropertyMapping {
+  [EventName.EXTENSION_LOAD]: {
+    cliAccessible: boolean
+    workspaceFolderCount: number
+    dvcRootCount: number
+  }
+
   [EventName.EXPERIMENT_APPLY]: undefined
   [EventName.EXPERIMENT_BRANCH]: undefined
   [EventName.EXPERIMENT_FILTER_ADD]: undefined
@@ -28,7 +34,6 @@ export interface IEventNamePropertyMapping {
   [EventName.EXPERIMENT_SORT_REMOVE]: undefined
   [EventName.EXPERIMENT_SORTS_REMOVE]: undefined
   [EventName.EXPERIMENT_SORTS_REMOVE_ALL]: undefined
-  [EventName.EXTENSION_LOAD]: { workspaceFolderCount: number }
   [EventName.QUEUE_EXPERIMENT]: undefined
   [EventName.STOP_EXPERIMENT]: { stopped: boolean; wasRunning: boolean }
 

--- a/extension/src/vscode/workspaceFolders.ts
+++ b/extension/src/vscode/workspaceFolders.ts
@@ -1,6 +1,9 @@
 import { workspace } from 'vscode'
 import { definedAndNonEmpty } from '../util/array'
 
+export const getWorkspaceFolderCount = () =>
+  (workspace.workspaceFolders || []).length
+
 export const getWorkspaceFolders = (): string[] =>
   (workspace.workspaceFolders || []).map(
     workspaceFolder => workspaceFolder.uri.fsPath


### PR DESCRIPTION
This PR adds an analytics event for when the extension has completed loading.

The event contains the following custom properties:
```
        {
          cliAccessible: boolean, // where or the not the config lets the user access the cli through the extension 
          dvcRootCount: number, // dvc projects in the workspace
          workspaceFolderCount: number // workspace folders in the workspace
        },
       { duration: number } // ms for the extension to become usable

```

LMK if you'd like to see any updates 👍🏻 .