### PR TITLE
Increase timeout of runner stop test (for Mac)

### DIFF
--- a/extension/src/test/suite/cli/runner.test.ts
+++ b/extension/src/test/suite/cli/runner.test.ts
@@ -68,7 +68,7 @@ suite('CLI Runner Test Suite', () => {
         'dvc.runner.running',
         false
       )
-    })
+    }).timeout(6000)
 
     it('should be able to execute a command and provide the correct events in the correct order', async () => {
       const text = ':weeeee:'


### PR DESCRIPTION
Saw this failure [here](https://github.com/iterative/vscode-dvc/runs/3568909575?check_suite_focus=true), also haven't seen this locally. By increasing the timeout to 6s the process should be sent `SIGKILL` and be finished off before the test fails.