### PR TITLE
Remove unnecessary (leftover) timeouts from tests

### DIFF
--- a/extension/src/test/suite/cli/runner.test.ts
+++ b/extension/src/test/suite/cli/runner.test.ts
@@ -33,7 +33,7 @@ suite('CLI Runner Test Suite', () => {
       await cliRunner.run(cwd, '1000')
 
       expect(windowErrorMessageSpy).to.be.calledOnce
-    }).timeout(6000)
+    })
 
     it('should be able to stop a started command', async () => {
       const cliRunner = disposable.track(new CliRunner({} as Config, 'sleep'))
@@ -126,7 +126,7 @@ suite('CLI Runner Test Suite', () => {
       await started
       expect((await eventStream).includes(text)).to.be.true
       return completed
-    }).timeout(12000)
+    })
 
     it('should send an error event if the command fails with an exit code and stderr', async () => {
       const mockSendTelemetryEvent = stub(Telemetry, 'sendErrorTelemetryEvent')
@@ -158,6 +158,6 @@ suite('CLI Runner Test Suite', () => {
       expect(error.message).to.have.length.greaterThan(0)
       expect(command).to.equal('sleep 1 && then die')
       expect(exitCode).to.be.greaterThan(0)
-    }).timeout(4000)
+    })
   })
 })

--- a/extension/src/test/suite/vscode/pseudoTerminal.test.ts
+++ b/extension/src/test/suite/vscode/pseudoTerminal.test.ts
@@ -58,7 +58,7 @@ suite('Pseudo Terminal Test Suite', () => {
       pseudoTerminal.dispose()
 
       return closeTerminalEvent()
-    }).timeout(12000)
+    })
 
     it('should be able to handle multiple output events', async () => {
       const disposable = Disposable.fn()
@@ -108,6 +108,6 @@ suite('Pseudo Terminal Test Suite', () => {
       pseudoTerminal.dispose()
 
       return closeTerminalEvent()
-    }).timeout(12000)
+    })
   })
 })


### PR DESCRIPTION
Noticed when I was making the update for #804.

I think these are leftover from when we were previously using explicit `delay`s. No longer required.

Removed timeouts from 

```
  CLI Runner Test Suite
    CliRunner

      ✔ should only be able to run a single command at a time (249ms)

      ✔ should be able to stop a started command (512ms)

      ✔ should send an error event if the command fails with an exit code and stderr (585ms)

...

  Pseudo Terminal Test Suite
    PseudoTerminal

      ✔ should be able to open a terminal (70ms)

      ✔ should be able to handle multiple output events (406ms)

```

2000ms should be more than enough time for each of these tests.