### PR TITLE
Exclude tsx tests for Code Climate

### DIFF
--- a/.codeclimate.json
+++ b/.codeclimate.json
@@ -1,7 +1,7 @@
 {
   "version": "2",
   "exclude_patterns": [
-    "**/*.test.ts",
+    "**/*.test.*",
     "extension/src/test/fixtures",
     "extension/src/test/suite",
     "extension/src/test/util",


### PR DESCRIPTION
Small change to exclude `tsx` test files from Code Climate scrutiny.