### PR TITLE
Add sorts to storybook test data

### DIFF
--- a/webview/src/stories/Experiments.stories.tsx
+++ b/webview/src/stories/Experiments.stories.tsx
@@ -21,7 +21,14 @@ export default {
     }
   },
   args: {
-    tableData: { columns: complexColumnData, rows: complexRowData, sorts: [] },
+    tableData: {
+      columns: complexColumnData,
+      rows: complexRowData,
+      sorts: [
+        { descending: true, path: 'params:params.yaml:epochs' },
+        { descending: false, path: 'params:params.yaml:log_file' }
+      ]
+    },
     vsCodeApi: dummyVsCodeApi
   },
   component: Experiments,


### PR DESCRIPTION
Storybook now looks like this:

<img width="1680" alt="Screen Shot 2021-09-21 at 12 36 36 pm" src="https://user-images.githubusercontent.com/37993418/134103303-0fd9b7f2-07f2-43e9-b981-e11bf75dbf9c.png">

[Q] Are we ok with having the sort indicator underneath the placeholder entry for asc sorted columns (I think studio uses an arrow)? Something to consider, 👍🏻 .
