### PR TITLE
Chromatic action - Auto accept changes on master

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -68,6 +68,7 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           storybookBuildDir: 'webview/storybook-static'
           exitOnceUploaded: true
+          autoAcceptChanges: 'master'
 
       - name: Upload
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This should mitigate the issue with having to approve changes twice (once in the PR and then once when the change hits `master`).

The theory goes that if the changes has made its way into master that it has already been approved. Therefore we can skip the check on master. Can't test until we get a UI change in master 😢 .

[Usage docs from the action](https://github.com/chromaui/action#usage) - `autoAcceptChanges: 'Automatically accept all changes in chromatic: boolean or branchname'`

**Note** - checked studio after the fact, [they do something similar](https://github.com/iterative/viewer/blob/develop/frontend/scripts/chromatic-ci.sh#L18)