### PR TITLE
Add reportError wrapper for window.showErrorMessage

### DIFF
--- a/extension/src/cli/runner.ts
+++ b/extension/src/cli/runner.ts
@@ -1,4 +1,4 @@
-import { EventEmitter, Event, window } from 'vscode'
+import { EventEmitter, Event } from 'vscode'
 import { Disposable } from '@hediet/std/disposable'
 import { CliResult, CliStarted, ICli, typeCheckCommands } from '.'
 import { Args, Command, ExperimentFlag, ExperimentSubCommand } from './args'
@@ -10,6 +10,7 @@ import { setContextValue } from '../vscode/context'
 import { StopWatch } from '../util/time'
 import { sendErrorTelemetryEvent, sendTelemetryEvent } from '../telemetry'
 import { EventName } from '../telemetry/constants'
+import { reportError } from '../vscode/reporting'
 
 export const autoRegisteredCommands = {
   EXPERIMENT_RUN: 'runExperiment',
@@ -119,7 +120,7 @@ export class CliRunner implements ICli {
     if (!this.pseudoTerminal.isBlocked()) {
       return this.startProcess(cwd, args)
     }
-    window.showErrorMessage(
+    reportError(
       `Cannot start dvc ${args.join(
         ' '
       )} as the output terminal is already occupied.`

--- a/extension/src/experiments/model/filterBy/quickPick.ts
+++ b/extension/src/experiments/model/filterBy/quickPick.ts
@@ -1,8 +1,8 @@
-import { window } from 'vscode'
 import { FilterDefinition, Operator } from '.'
 import { definedAndNonEmpty } from '../../../util/array'
 import { getInput } from '../../../vscode/inputBox'
 import { quickPickManyValues, quickPickValue } from '../../../vscode/quickPick'
+import { reportError } from '../../../vscode/reporting'
 import { pickFromParamsAndMetrics } from '../../paramsAndMetrics/quickPick'
 import { ParamOrMetric } from '../../webview/contract'
 
@@ -118,8 +118,7 @@ export const pickFiltersToRemove = (
   filters: FilterDefinition[]
 ): Thenable<FilterDefinition[] | undefined> => {
   if (!definedAndNonEmpty(filters)) {
-    window.showErrorMessage('There are no filters to remove.')
-    return Promise.resolve(undefined)
+    return reportError('There are no filters to remove.')
   }
 
   return quickPickManyValues<FilterDefinition>(

--- a/extension/src/experiments/model/sortBy/quickPick.ts
+++ b/extension/src/experiments/model/sortBy/quickPick.ts
@@ -1,7 +1,7 @@
-import { window } from 'vscode'
 import { SortDefinition } from '.'
 import { definedAndNonEmpty } from '../../../util/array'
 import { quickPickManyValues, quickPickValue } from '../../../vscode/quickPick'
+import { reportError } from '../../../vscode/reporting'
 import { pickFromParamsAndMetrics } from '../../paramsAndMetrics/quickPick'
 import { ParamOrMetric } from '../../webview/contract'
 
@@ -32,8 +32,7 @@ export const pickSortsToRemove = (
   sorts: SortDefinition[]
 ): Thenable<SortDefinition[] | undefined> => {
   if (!definedAndNonEmpty(sorts)) {
-    window.showErrorMessage('There are no sorts to remove.')
-    return Promise.resolve(undefined)
+    return reportError('There are no sorts to remove.')
   }
 
   return quickPickManyValues<SortDefinition>(

--- a/extension/src/experiments/paramsAndMetrics/quickPick.test.ts
+++ b/extension/src/experiments/paramsAndMetrics/quickPick.test.ts
@@ -2,10 +2,13 @@ import { mocked } from 'ts-jest/utils'
 import { pickFromParamsAndMetrics } from './quickPick'
 import { joinParamOrMetricPath } from './paths'
 import { quickPickValue } from '../../vscode/quickPick'
+import { reportError } from '../../vscode/reporting'
 
 jest.mock('../../vscode/quickPick')
+jest.mock('../../vscode/reporting')
 
 const mockedQuickPickValue = mocked(quickPickValue)
+const mockedReportError = mocked(reportError)
 
 beforeEach(() => {
   jest.resetAllMocks()
@@ -42,6 +45,7 @@ describe('pickFromParamsAndMetrics', () => {
       title: "can't pick from no params or metrics"
     })
     expect(picked).toBeUndefined()
+    expect(mockedReportError).toBeCalledTimes(1)
     expect(mockedQuickPickValue).not.toBeCalled()
   })
 

--- a/extension/src/experiments/paramsAndMetrics/quickPick.ts
+++ b/extension/src/experiments/paramsAndMetrics/quickPick.ts
@@ -1,14 +1,15 @@
-import { QuickPickOptions, window } from 'vscode'
+import { QuickPickOptions } from 'vscode'
+import { definedAndNonEmpty } from '../../util/array'
 import { quickPickValue } from '../../vscode/quickPick'
+import { reportError } from '../../vscode/reporting'
 import { ParamOrMetric } from '../webview/contract'
 
 export const pickFromParamsAndMetrics = (
   paramsAndMetrics: ParamOrMetric[] | undefined,
   quickPickOptions: QuickPickOptions
 ) => {
-  if (!paramsAndMetrics || paramsAndMetrics.length === 0) {
-    window.showErrorMessage('There are no params or metrics to select from')
-    return
+  if (!definedAndNonEmpty(paramsAndMetrics)) {
+    return reportError('There are no params or metrics to select from')
   }
   return quickPickValue<ParamOrMetric>(
     paramsAndMetrics.map(paramOrMetric => ({

--- a/extension/src/experiments/quickPick.test.ts
+++ b/extension/src/experiments/quickPick.test.ts
@@ -1,12 +1,12 @@
 import { mocked } from 'ts-jest/utils'
-import { window } from 'vscode'
 import { pickGarbageCollectionFlags, pickExperimentName } from './quickPick'
 import { quickPickManyValues, quickPickOne } from '../vscode/quickPick'
+import { reportError } from '../vscode/reporting'
 
-jest.mock('vscode')
 jest.mock('../vscode/quickPick')
+jest.mock('../vscode/reporting')
 
-const mockedShowErrorMessage = mocked(window.showErrorMessage)
+const mockedReportError = mocked(reportError)
 const mockedQuickPickOne = mocked(quickPickOne)
 const mockedQuickPickManyValues = mocked(quickPickManyValues)
 
@@ -45,7 +45,7 @@ describe('pickExperimentName', () => {
 
   it('should call showErrorMessage when no experiment names are provided', async () => {
     await pickExperimentName(Promise.resolve([]))
-    expect(mockedShowErrorMessage).toHaveBeenCalledTimes(1)
+    expect(mockedReportError).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/extension/src/experiments/quickPick.ts
+++ b/extension/src/experiments/quickPick.ts
@@ -1,13 +1,13 @@
-import { window } from 'vscode'
 import { GcPreserveFlag } from '../cli/args'
 import { quickPickManyValues, quickPickOne } from '../vscode/quickPick'
+import { reportError } from '../vscode/reporting'
 
 export const pickExperimentName = async (
   experimentNamesPromise: Promise<string[]>
 ): Promise<string | undefined> => {
   const experimentNames = await experimentNamesPromise
   if (experimentNames.length === 0) {
-    window.showErrorMessage('There are no experiments to select.')
+    reportError('There are no experiments to select.')
   } else {
     return quickPickOne(experimentNames, 'Select an experiment')
   }

--- a/extension/src/vscode/reporting.ts
+++ b/extension/src/vscode/reporting.ts
@@ -1,9 +1,16 @@
 import { window } from 'vscode'
 
-export const reportErrorWithOptions = (message: string, ...items: string[]) =>
-  window.showErrorMessage(message, ...items)
+export const reportErrorWithOptions = (
+  message: string,
+  ...items: string[]
+): Thenable<string | undefined> => window.showErrorMessage(message, ...items)
 
-export const reportOutput = async (stdout: Promise<string>) => {
+export const reportError = (message: string): Promise<undefined> => {
+  window.showErrorMessage(message)
+  return Promise.resolve(undefined)
+}
+
+export const reportOutput = async (stdout: Promise<string>): Promise<void> => {
   const output = (await stdout) || 'Operation successful.'
   window.showInformationMessage(output)
 }


### PR DESCRIPTION
# 3/3 `master` <- #849 <- #850 <- this.

This PR wraps remaining calls to `window.showErrorMessage` and hides the `window` from a few more files. Should mean easier testing going forwards.