### PR TITLE
Increase default timeout of webview @testing-library/react tests

### DIFF
--- a/webview/jest.config.js
+++ b/webview/jest.config.js
@@ -8,5 +8,6 @@ module.exports = {
     '\\.(scss|css|less)$': 'identity-obj-proxy'
   },
   preset: 'ts-jest',
-  testEnvironment: 'node'
+  testEnvironment: 'node',
+  testTimeout: 10000
 }


### PR DESCRIPTION
Saw the same issue with [windows again this morning](https://github.com/iterative/vscode-dvc/runs/3876629194?check_suite_focus=true) (#895). 

I went back to SO and read further. The new theory is that the test is being torn down whilst it is in the middle of assertions. I can now also recreate the behaviour locally by setting the timeout to 100ms. This probably only shows up on windows because the performance of those machines is horrible.

From SO: "The test was then failing on timeout, tearing down the DOM, but then giving this error instead of the timeout error in my test"

### Demo

https://user-images.githubusercontent.com/37993418/137070121-69f179c6-0395-430b-acd0-736c9454d10f.mov
