### PR TITLE
Add status for default remote to cli reader

### DIFF
--- a/extension/src/cli/args.ts
+++ b/extension/src/cli/args.ts
@@ -54,6 +54,10 @@ export enum ListFlag {
   DVC_ONLY = '--dvc-only'
 }
 
+export enum StatusFlag {
+  CLOUD = '-c'
+}
+
 type Target = string
 
 type Flags = Flag | ExperimentFlag | ListFlag | GcPreserveFlag

--- a/extension/src/cli/reader.test.ts
+++ b/extension/src/cli/reader.test.ts
@@ -366,5 +366,25 @@ describe('CliReader', () => {
         })
       })
     })
+
+    describe('statusDefaultRemote', () => {
+      it('should call the cli with the correct parameters', async () => {
+        const cliOutput = {}
+        const cwd = __dirname
+        mockedCreateProcess.mockReturnValueOnce(
+          getMockedProcess(JSON.stringify(cliOutput))
+        )
+        const diffOutput = await cliReader.statusDefaultRemote(cwd)
+
+        expect(diffOutput).toEqual(cliOutput)
+
+        expect(mockedCreateProcess).toBeCalledWith({
+          args: ['status', '-c', SHOW_JSON],
+          cwd,
+          env: mockedEnv,
+          executable: 'dvc'
+        })
+      })
+    })
   })
 })

--- a/extension/src/cli/reader.ts
+++ b/extension/src/cli/reader.ts
@@ -5,7 +5,8 @@ import {
   ExperimentFlag,
   ExperimentSubCommand,
   Flag,
-  ListFlag
+  ListFlag,
+  StatusFlag
 } from './args'
 import { retryIfLocked } from './retry'
 import { trimAndSplit } from '../util/stdout'
@@ -102,7 +103,8 @@ export const autoRegisteredCommands = {
   EXPERIMENT_SHOW: 'experimentShow',
   LIST_DVC_ONLY: 'listDvcOnly',
   LIST_DVC_ONLY_RECURSIVE: 'listDvcOnlyRecursive',
-  STATUS: 'status'
+  STATUS: 'status',
+  STATUS_DEFAULT_REMOTE: 'statusDefaultRemote'
 } as const
 
 export class CliReader extends Cli {
@@ -165,6 +167,14 @@ export class CliReader extends Cli {
 
   public status(cwd: string): Promise<StatusOutput> {
     return this.readProcessJson<StatusOutput>(cwd, Command.STATUS)
+  }
+
+  public statusDefaultRemote(cwd: string): Promise<StatusOutput> {
+    return this.readProcessJson<StatusOutput>(
+      cwd,
+      Command.STATUS,
+      StatusFlag.CLOUD
+    )
   }
 
   private async readProcess<T = string>(


### PR DESCRIPTION
# 2/2 `master` <- #914 <- this

This PR adds a new status command to our cli reader. We will be using this to check the remote for any changes. If there are any changes then we will display the action button.

From the `status` docs:

![image](https://user-images.githubusercontent.com/37993418/137650574-7f1504c4-61ff-43e7-96af-6500fa28b0fc.png)
