### PR TITLE
Retry cli reader on any error

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,7 @@
     "isout",
     "MNIST",
     "pseudoterminal",
+    "rwlock",
     "sonarjs",
     "stackframe",
     "subdir",

--- a/extension/src/cli/reader.ts
+++ b/extension/src/cli/reader.ts
@@ -7,7 +7,7 @@ import {
   Flag,
   ListFlag
 } from './args'
-import { retryIfLocked } from './retry'
+import { retry } from './retry'
 import { trimAndSplit } from '../util/stdout'
 
 export type PathOutput = { path: string }
@@ -172,7 +172,7 @@ export class CliReader extends Cli {
     formatter: typeof trimAndSplit | typeof JSON.parse,
     ...args: Args
   ): Promise<T> {
-    const output = await retryIfLocked(
+    const output = await retry(
       () => this.executeProcess(cwd, ...args),
       args.join(' ')
     )

--- a/extension/src/cli/retry.test.ts
+++ b/extension/src/cli/retry.test.ts
@@ -1,5 +1,5 @@
 import { mocked } from 'ts-jest/utils'
-import { retryIfLocked } from './retry'
+import { retry } from './retry'
 import { delay } from '../util/time'
 
 const mockedDelay = mocked(delay)
@@ -11,17 +11,14 @@ beforeEach(() => {
   jest.resetAllMocks()
 })
 
-describe('retryIfLocked', () => {
+describe('retry', () => {
   it('should resolve a single promise and return the output', async () => {
     const returnValue = 'I DID IT! WEEEEE'
     const promise = jest.fn().mockResolvedValueOnce(returnValue)
 
     const promiseRefresher = jest.fn().mockImplementation(() => promise())
 
-    const output = await retryIfLocked<string>(
-      promiseRefresher,
-      'Definitely did not'
-    )
+    const output = await retry<string>(promiseRefresher, 'Definitely did not')
 
     expect(output).toEqual(returnValue)
 
@@ -29,7 +26,7 @@ describe('retryIfLocked', () => {
     expect(mockedDelay).not.toBeCalled()
   })
 
-  it('should retry each time a promise rejects with a lock message', async () => {
+  it('should retry each time a promise rejects', async () => {
     const unreliablePromise = jest
       .fn()
       .mockRejectedValueOnce(new Error('I dead because the repo is locked'))
@@ -49,32 +46,12 @@ describe('retryIfLocked', () => {
       .fn()
       .mockImplementation(() => unreliablePromise())
 
-    await retryIfLocked<string>(promiseRefresher, 'Data update')
+    await retry<string>(promiseRefresher, 'Data update')
 
     expect(promiseRefresher).toBeCalledTimes(4)
     expect(mockedDelay).toBeCalledTimes(3)
     expect(mockedDelay).toBeCalledWith(500)
     expect(mockedDelay).toBeCalledWith(1000)
     expect(mockedDelay).toBeCalledWith(2000)
-  })
-
-  it('should not retry if a promise rejects without a lock message', async () => {
-    const unreliablePromise = jest
-      .fn()
-      .mockRejectedValueOnce(new Error('I dead!'))
-      .mockResolvedValueOnce("he's ok")
-
-    mockedDelay.mockResolvedValue()
-
-    const promiseRefresher = jest
-      .fn()
-      .mockImplementation(() => unreliablePromise())
-
-    await expect(
-      retryIfLocked<string>(promiseRefresher, 'Data update')
-    ).rejects.toThrow()
-
-    expect(promiseRefresher).toBeCalledTimes(1)
-    expect(mockedDelay).toBeCalledTimes(0)
   })
 })

--- a/extension/src/cli/retry.ts
+++ b/extension/src/cli/retry.ts
@@ -1,7 +1,7 @@
 import { delay } from '../util/time'
 import { Logger } from '../common/logger'
 
-export const retryIfLocked = async <T>(
+export const retry = async <T>(
   getNewPromise: () => Promise<T>,
   args: string,
   waitBeforeRetry = 500
@@ -12,11 +12,7 @@ export const retryIfLocked = async <T>(
     const errorMessage = (e as Error).message
     Logger.error(`${args} failed with ${errorMessage} retrying...`)
 
-    if (errorMessage.includes('lock')) {
-      await delay(waitBeforeRetry)
-      return retryIfLocked(getNewPromise, args, waitBeforeRetry * 2)
-    }
-
-    throw e
+    await delay(waitBeforeRetry)
+    return retry(getNewPromise, args, waitBeforeRetry * 2)
   }
 }


### PR DESCRIPTION
When I moved the retry function In #889 I changed the logic to only retry when the error message contained the string `lock`. Looks like this was another example of me trying to be too clever / cute. I have just come across an issue where any error in the `dvc.yaml` bricks the entire SCM view (`dvc status` fails and then does not retry).

This change takes us back to retrying all CLI commands on any error. If we want to pursue retrying on X condition(s) then I think we will need error codes from the CLI or some other mechanism that helps us to bucket the different errors accordingly (and easily). For now I think this is the cleanest thing that we can do. We could end up in the situation where we have infinite retries but the exponential back off should help with that.

## Demo

### Current behaviour in master

https://user-images.githubusercontent.com/37993418/137819236-d704181c-8882-49cf-b47b-f1fcb26ff73c.mov

### After the change

https://user-images.githubusercontent.com/37993418/137819410-5269b4fe-7864-4f47-a4c5-e60870194234.mov


