### PR TITLE
Add shared data class (plots and experiments)

### DIFF
--- a/extension/src/data/index.ts
+++ b/extension/src/data/index.ts
@@ -1,0 +1,145 @@
+import { join, resolve } from 'path'
+import { EventEmitter, Event } from 'vscode'
+import { Disposable } from '@hediet/std/disposable'
+import { Deferred } from '@hediet/std/synchronization'
+import {
+  createFileSystemWatcher,
+  createNecessaryFileSystemWatcher
+} from '../fileSystem/watcher'
+import { getGitRepositoryRoot } from '../git'
+import { ProcessManager } from '../processManager'
+import { AvailableCommands, InternalCommands } from '../commands/internal'
+import { ExperimentsRepoJSONOutput } from '../cli/reader'
+import { sameContents, uniqueValues } from '../util/array'
+import { collectFiles } from '../experiments/paramsAndMetrics/collect'
+
+const DOT_GIT = '.git'
+const GIT_REFS = join(DOT_GIT, 'refs')
+export const EXPERIMENTS_GIT_REFS = join(GIT_REFS, 'exps')
+
+export class Data {
+  public readonly dispose = Disposable.fn()
+  public readonly onDidChangeExperimentsData: Event<ExperimentsRepoJSONOutput>
+
+  private readonly dvcRoot: string
+  private files: string[] = []
+
+  private readonly deferred = new Deferred()
+  private readonly initialized = this.deferred.promise
+
+  private readonly processManager: ProcessManager
+  private readonly internalCommands: InternalCommands
+
+  private readonly experimentsDataChanged: EventEmitter<ExperimentsRepoJSONOutput> =
+    this.dispose.track(new EventEmitter())
+
+  private readonly paramsAndMetricsFilesChanged = new EventEmitter<void>()
+  private readonly onDidChangeParamsAndMetricsFiles: Event<void> =
+    this.paramsAndMetricsFilesChanged.event
+
+  private watcher?: Disposable
+
+  constructor(dvcRoot: string, internalCommands: InternalCommands) {
+    this.dvcRoot = dvcRoot
+    this.processManager = new ProcessManager({
+      name: 'update',
+      process: () => this.updateData()
+    })
+
+    this.internalCommands = internalCommands
+    this.onDidChangeExperimentsData = this.experimentsDataChanged.event
+
+    this.initialize()
+    this.watchExpGitRefs()
+  }
+
+  public isReady() {
+    return this.initialized
+  }
+
+  public update() {
+    return this.processManager.run('update')
+  }
+
+  private initialize() {
+    const waitForInitialData = this.dispose.track(
+      this.onDidChangeExperimentsData(() => {
+        this.watcher = this.watchParamsAndMetricsFiles()
+
+        this.dispose.track(
+          this.onDidChangeParamsAndMetricsFiles(() => {
+            const watcher = this.watchParamsAndMetricsFiles()
+            this.dispose.untrack(this.watcher)
+            this.watcher?.dispose()
+            this.watcher = watcher
+          })
+        )
+        this.dispose.untrack(waitForInitialData)
+        waitForInitialData.dispose()
+        this.deferred.resolve()
+      })
+    )
+    this.update()
+  }
+
+  private async watchExpGitRefs(): Promise<void> {
+    const gitRoot = await getGitRepositoryRoot(this.dvcRoot)
+    const dotGitGlob = resolve(gitRoot, DOT_GIT, '**')
+    this.dispose.track(
+      createNecessaryFileSystemWatcher(dotGitGlob, (path: string) => {
+        if (
+          path.includes('HEAD') ||
+          path.includes(EXPERIMENTS_GIT_REFS) ||
+          path.includes(join(GIT_REFS, 'heads'))
+        ) {
+          return this.update()
+        }
+      })
+    )
+  }
+
+  private async updateData(): Promise<void> {
+    const data =
+      await this.internalCommands.executeCommand<ExperimentsRepoJSONOutput>(
+        AvailableCommands.EXPERIMENT_SHOW,
+        this.dvcRoot
+      )
+
+    this.transformAndSetFiles(data)
+
+    return this.notifyChanged(data)
+  }
+
+  private transformAndSetFiles(data: ExperimentsRepoJSONOutput) {
+    const files = collectFiles(data)
+
+    if (sameContents(this.files, files)) {
+      return
+    }
+
+    this.files = files
+    this.paramsAndMetricsFilesChanged.fire()
+  }
+
+  private notifyChanged(data: ExperimentsRepoJSONOutput) {
+    this.experimentsDataChanged.fire(data)
+  }
+
+  private watchParamsAndMetricsFiles() {
+    return this.dispose.track(
+      createFileSystemWatcher(
+        join(
+          this.dvcRoot,
+          '**',
+          `{${uniqueValues([
+            'dvc.lock',
+            'dvc.yaml',
+            'params.yaml',
+            ...this.files
+          ]).join(',')}}`
+        ),
+        () => this.update()
+      )
+    )
+  }
+}

--- a/extension/src/data/workspace.ts
+++ b/extension/src/data/workspace.ts
@@ -1,0 +1,24 @@
+import { Data } from '.'
+import { WorkspaceExperiments } from '../experiments/workspace'
+import { BaseWorkspace } from '../workspace'
+
+export class WorkspaceData extends BaseWorkspace<Data> {
+  public create(
+    dvcRoots: string[],
+    workspaceExperiments: WorkspaceExperiments
+  ) {
+    dvcRoots.forEach(dvcRoot => {
+      const data = this.dispose.track(new Data(dvcRoot, this.internalCommands))
+      this.dispose.track(
+        data.onDidChangeExperimentsData(data =>
+          workspaceExperiments.update(dvcRoot, data)
+        )
+      )
+      this.setRepository(dvcRoot, data)
+    })
+  }
+
+  public update(dvcRoot: string) {
+    this.getRepository(dvcRoot).update()
+  }
+}

--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -14,6 +14,7 @@ import {
   InternalCommands
 } from '../commands/internal'
 import { BaseWorkspace, IWorkspace } from '../workspace'
+import { ExperimentsRepoJSONOutput } from '../cli/reader'
 
 export class WorkspaceExperiments
   extends BaseWorkspace<Experiments>
@@ -40,6 +41,11 @@ export class WorkspaceExperiments
     if (experiments) {
       this.repositories = experiments
     }
+  }
+
+  public update(dvcRoot: string, data: ExperimentsRepoJSONOutput) {
+    // stubby mcstub face
+    return [dvcRoot, data]
   }
 
   public getFocusedTable(): Experiments | undefined {

--- a/extension/src/test/suite/data/index.test.ts
+++ b/extension/src/test/suite/data/index.test.ts
@@ -1,0 +1,175 @@
+import { join, sep } from 'path'
+import { afterEach, beforeEach, describe, it, suite } from 'mocha'
+import { FileSystemWatcher } from 'vscode'
+import { expect } from 'chai'
+import { stub, restore, spy, useFakeTimers } from 'sinon'
+import { Disposable } from '../../../extension'
+import { CliReader } from '../../../cli/reader'
+import complexExperimentsOutput from '../../fixtures/complex-output-example'
+import { Config } from '../../../config'
+import { dvcDemoPath, getFirstArgOfCall } from '../util'
+import { OutputChannel } from '../../../vscode/outputChannel'
+import { Data } from '../../../data'
+import { InternalCommands } from '../../../commands/internal'
+import * as Watcher from '../../../fileSystem/watcher'
+
+suite('Data Test Suite', () => {
+  const disposable = Disposable.fn()
+
+  beforeEach(() => {
+    restore()
+  })
+
+  afterEach(() => {
+    disposable.dispose()
+  })
+
+  describe('Data', () => {
+    it('should debounce all calls to update that are made within 200ms', async () => {
+      const config = disposable.track(new Config())
+      const cliReader = disposable.track(new CliReader(config))
+      const mockExperimentShow = stub(cliReader, 'experimentShow').resolves(
+        complexExperimentsOutput
+      )
+
+      const outputChannel = disposable.track(
+        new OutputChannel([cliReader], '-1', 'data test suite')
+      )
+
+      const internalCommands = disposable.track(
+        new InternalCommands(config, outputChannel, cliReader)
+      )
+
+      const data = disposable.track(new Data(dvcDemoPath, internalCommands))
+
+      await Promise.all([
+        data.update(),
+        data.update(),
+        data.update(),
+        data.update(),
+        data.update(),
+        data.update()
+      ])
+
+      expect(mockExperimentShow).to.be.calledOnce
+    })
+
+    it('should call the updater function on setup', async () => {
+      const config = disposable.track(new Config())
+      const cliReader = disposable.track(new CliReader(config))
+      const mockExperimentShow = stub(cliReader, 'experimentShow').resolves(
+        complexExperimentsOutput
+      )
+
+      const createFileSystemWatcherSpy = spy(Watcher, 'createFileSystemWatcher')
+
+      const outputChannel = disposable.track(
+        new OutputChannel([cliReader], '-2', 'WWWEEEEEEEE')
+      )
+
+      const internalCommands = disposable.track(
+        new InternalCommands(config, outputChannel, cliReader)
+      )
+      const data = new Data(dvcDemoPath, internalCommands)
+
+      await data.isReady()
+
+      expect(mockExperimentShow).to.be.calledOnce
+      expect(createFileSystemWatcherSpy).to.be.calledOnce
+
+      expect(getFirstArgOfCall(createFileSystemWatcherSpy, 0)).to.equal(
+        join(
+          dvcDemoPath,
+          '**',
+          `{dvc.lock,dvc.yaml,params.yaml,nested${sep}params.yaml,summary.json}`
+        )
+      )
+    })
+
+    it('should dispose of the current watcher and instantiate a new one if the params files change', async () => {
+      const clock = useFakeTimers()
+      const config = disposable.track(new Config())
+      const cliReader = disposable.track(new CliReader(config))
+      const mockExperimentShow = stub(cliReader, 'experimentShow').resolves(
+        complexExperimentsOutput
+      )
+
+      const mockDispose = stub()
+
+      const mockCreateFileSystemWatcher = stub(
+        Watcher,
+        'createFileSystemWatcher'
+      )
+      mockCreateFileSystemWatcher.callsFake(() => {
+        return { dispose: mockDispose } as unknown as FileSystemWatcher
+      })
+
+      const outputChannel = disposable.track(
+        new OutputChannel([cliReader], '200', 'chunnel')
+      )
+
+      const internalCommands = disposable.track(
+        new InternalCommands(config, outputChannel, cliReader)
+      )
+      const data = new Data(dvcDemoPath, internalCommands)
+
+      await data.isReady()
+      clock.tick(200000000)
+
+      mockExperimentShow.resolves(
+        Object.assign(
+          { ...complexExperimentsOutput },
+          {
+            workspace: {
+              baseline: {
+                data: {
+                  metrics: {
+                    ...(complexExperimentsOutput.workspace.baseline.data
+                      ?.metrics || {}),
+                    'new_summary.json': {
+                      data: { auc: 0, loss: 1 }
+                    }
+                  },
+                  params: {
+                    ...(complexExperimentsOutput.workspace.baseline.data
+                      ?.params || {}),
+                    'new_params.yml': {
+                      data: { new_seed: 10000, new_weight_decay: 0 }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        )
+      )
+
+      const dataUpdatedEvent = new Promise(resolve =>
+        data.onDidChangeExperimentsData(data => resolve(data))
+      )
+
+      data.update()
+
+      await dataUpdatedEvent
+
+      expect(mockCreateFileSystemWatcher).to.be.calledTwice
+      expect(mockDispose).to.be.calledOnce
+      expect(getFirstArgOfCall(mockCreateFileSystemWatcher, 0)).to.equal(
+        join(
+          dvcDemoPath,
+          `**`,
+          `{dvc.lock,dvc.yaml,params.yaml,nested${sep}params.yaml,summary.json}`
+        )
+      )
+      expect(getFirstArgOfCall(mockCreateFileSystemWatcher, 1)).to.equal(
+        join(
+          dvcDemoPath,
+          '**',
+          `{dvc.lock,dvc.yaml,params.yaml,nested${sep}params.yaml,new_params.yml,new_summary.json,summary.json}`
+        )
+      )
+
+      clock.restore()
+    })
+  })
+})


### PR DESCRIPTION
# 1/4 `master` <- this <- #934 <- #935 <- #936 

Split from https://github.com/iterative/vscode-dvc/pull/931. The overall purpose of this chain is to make `exp show` data available to both the `Experiments` and (upcoming) `Plots` classes / webview in a slightly more elegant way.

This PR introduces a new `Data` class which will be used to share data between the `Experiments` and `Plots` classes.

Initially I am duplicating responsibilities between this class and things that are scattered throughout the experiments folder. In subsequent PRs I remove this duplicate responsibilities.