### PR TITLE
Use data class in experiments

### DIFF
--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -44,8 +44,8 @@ export class WorkspaceExperiments
   }
 
   public update(dvcRoot: string, data: ExperimentsRepoJSONOutput) {
-    // stubby mcstub face
-    return [dvcRoot, data]
+    const experiments = this.getRepository(dvcRoot)
+    experiments.setState(data)
   }
 
   public getFocusedTable(): Experiments | undefined {
@@ -232,11 +232,6 @@ export class WorkspaceExperiments
     return experiments
   }
 
-  public refreshData(dvcRoot: string) {
-    const experiments = this.getRepository(dvcRoot)
-    experiments?.refresh()
-  }
-
   public setWebview(dvcRoot: string, experimentsWebview: TableWebview) {
     const experiments = this.getRepository(dvcRoot)
     if (!experiments) {
@@ -280,8 +275,6 @@ export class WorkspaceExperiments
     )
 
     this.setRepository(dvcRoot, experiments)
-
-    experiments.onDidChangeData()
 
     experiments.dispose.track(
       experiments.onDidChangeIsWebviewFocused(

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -17,6 +17,7 @@ import { setup, setupWorkspace } from './setup'
 import { Status } from './status'
 import { reRegisterVsCodeCommands } from './vscode/commands'
 import { InternalCommands } from './commands/internal'
+import { WorkspaceData } from './data/workspace'
 import { ExperimentsParamsAndMetricsTree } from './experiments/paramsAndMetrics/tree'
 import { ExperimentsSortByTree } from './experiments/model/sortBy/tree'
 import { ExperimentsTree } from './experiments/model/tree'
@@ -56,6 +57,7 @@ export class Extension implements IExtension {
   private dvcRoots: string[] = []
   private repositories: WorkspaceRepositories
   private readonly experiments: WorkspaceExperiments
+  private readonly data: WorkspaceData
   private readonly trackedExplorerTree: TrackedExplorerTree
   private readonly cliExecutor: CliExecutor
   private readonly cliReader: CliReader
@@ -117,6 +119,14 @@ export class Extension implements IExtension {
       new WorkspaceRepositories(this.internalCommands)
     )
 
+    this.data = this.dispose.track(new WorkspaceData(this.internalCommands))
+
+    this.dispose.track(
+      this.cliRunner.onDidCompleteProcess(({ cwd }) => {
+        this.data.update(cwd)
+      })
+    )
+
     this.dispose.track(
       new ExperimentsParamsAndMetricsTree(
         this.experiments,
@@ -134,12 +144,6 @@ export class Extension implements IExtension {
     )
 
     this.dispose.track(new ExperimentsTree(this.experiments))
-
-    this.dispose.track(
-      this.cliRunner.onDidCompleteProcess(({ cwd }) => {
-        this.experiments.refreshData(cwd)
-      })
-    )
 
     this.trackedExplorerTree = this.dispose.track(
       new TrackedExplorerTree(this.internalCommands, this.workspaceChanged)
@@ -288,11 +292,15 @@ export class Extension implements IExtension {
   }
 
   public async initialize() {
+    this.resetMembers()
+
     await Promise.all([
-      this.initializeRepositories(),
+      this.repositories.create(this.dvcRoots, this.trackedExplorerTree),
       this.trackedExplorerTree.initialize(this.dvcRoots),
-      this.initializeExperiments()
+      this.experiments.create(this.dvcRoots, this.resourceLocator)
     ])
+
+    this.data.create(this.dvcRoots, this.experiments)
 
     return Promise.all([
       this.repositories.isReady(),
@@ -305,10 +313,15 @@ export class Extension implements IExtension {
   }
 
   public reset() {
+    this.resetMembers()
+    return this.setAvailable(false)
+  }
+
+  private resetMembers() {
     this.repositories.reset()
     this.trackedExplorerTree.initialize([])
     this.experiments.reset()
-    return this.setAvailable(false)
+    this.data.reset()
   }
 
   private setAvailable(available: boolean) {
@@ -325,16 +338,6 @@ export class Extension implements IExtension {
   private setProjectAvailability() {
     const available = this.hasRoots()
     setContextValue('dvc.project.available', available)
-  }
-
-  private initializeRepositories = () => {
-    this.repositories.reset()
-    this.repositories.create(this.dvcRoots, this.trackedExplorerTree)
-  }
-
-  private initializeExperiments = () => {
-    this.experiments.reset()
-    this.experiments.create(this.dvcRoots, this.resourceLocator)
   }
 
   private findDvcRoots = async (cwd: string): Promise<string[]> => {

--- a/extension/src/test/suite/experiments/util.ts
+++ b/extension/src/test/suite/experiments/util.ts
@@ -12,6 +12,7 @@ import { OutputChannel } from '../../../vscode/outputChannel'
 import complexExperimentsOutput from '../../fixtures/complex-output-example'
 import { buildMockMemento } from '../../util'
 import { dvcDemoPath, resourcePath } from '../util'
+import { WebviewColorTheme } from '../../../experiments/webview/contract'
 
 const buildDependencies = (
   disposer: Disposer,
@@ -58,6 +59,9 @@ export const buildExperiments = (
       buildMockMemento()
     )
   )
+
+  experiments.setState(experimentShowData)
+
   return {
     config,
     experiments,
@@ -84,6 +88,7 @@ export const buildMultiRepoExperiments = (disposer: Disposer) => {
     [dvcDemoPath],
     resourceLocator
   )
+  experiments.setState(complexExperimentsOutput)
   return { experiments, workspaceExperiments }
 }
 
@@ -94,15 +99,22 @@ export const buildSingleRepoExperiments = (disposer: Disposer) => {
   const workspaceExperiments = disposer.track(
     new WorkspaceExperiments(internalCommands, buildMockMemento())
   )
-  workspaceExperiments.create([dvcDemoPath], resourceLocator)
+  const [experiments] = workspaceExperiments.create(
+    [dvcDemoPath],
+    resourceLocator
+  )
+
+  experiments.setState(complexExperimentsOutput)
 
   return { workspaceExperiments }
 }
 
-export const mockInternalCommands = () => {
-  const mockedInternalCommands = new InternalCommands(
-    {} as unknown as Config,
-    {} as unknown as OutputChannel
+export const getMockInternalCommands = (disposer: Disposer) => {
+  const mockedInternalCommands = disposer.track(
+    new InternalCommands(
+      { getTheme: () => WebviewColorTheme.dark } as unknown as Config,
+      {} as unknown as OutputChannel
+    )
   )
   mockedInternalCommands.registerCommand(
     AvailableCommands.EXPERIMENT_SHOW,

--- a/extension/src/test/suite/experiments/workspace.test.ts
+++ b/extension/src/test/suite/experiments/workspace.test.ts
@@ -127,6 +127,7 @@ suite('Workspace Experiments Test Suite', () => {
         resourceLocator
       )
 
+      experiments.setState(complexExperimentsOutput)
       await workspaceExperiments.isReady()
 
       const focused = onDidChangeIsWebviewFocused(experiments)

--- a/extension/src/workspace/index.ts
+++ b/extension/src/workspace/index.ts
@@ -17,7 +17,6 @@ export class BaseWorkspace<T extends Disposable> {
   public dispose = Disposable.fn()
 
   protected repositories: Disposables<T> = {}
-  protected dvcRoots = []
   protected internalCommands: InternalCommands
 
   protected readonly deferred = new Deferred()


### PR DESCRIPTION
# 3/4 `master` <- #933 <- #934 <- this <- #936

This PR wires up the new class with the existing `Experiments` class. 

I remove the responsibility of updating data from the `Experiments` class and replace it with a `setState` function. That means there are a few tests to update but it does actually make the tests simpler overall.