### PR TITLE
Only initialize extension once in flaky test

### DIFF
--- a/extension/src/test/suite/extension.test.ts
+++ b/extension/src/test/suite/extension.test.ts
@@ -296,7 +296,7 @@ suite('Extension Test Suite', () => {
         mockDisposer,
         'should dispose of the current repositories and experiments if the cli can no longer be found'
       ).to.have.been.called
-    }).timeout(10000)
+    }).timeout(12000)
 
     it('should send an error telemetry event when setupWorkspace fails', async () => {
       const clock = useFakeTimers()


### PR DESCRIPTION
# 5/4 `master` <- #933 <- #934 <- #935 <- #936 <- this

This PR condenses two of the existing `dvc.setupWorkspace` into a single test. The remaining test is even simpler and should hopefully be more reliable.

The reason that I have put it at the end of the chain is because I have changed the `initialize` / `reset` behaviour of the extension and I want to verify that the test still passes when using the new behaviour.