### PR TITLE
Move pull and push target commands

### DIFF
--- a/extension/src/fileSystem/tree.ts
+++ b/extension/src/fileSystem/tree.ts
@@ -14,12 +14,7 @@ import { fireWatcher } from './watcher'
 import { deleteTarget, moveTargets } from './workspace'
 import { definedAndNonEmpty } from '../util/array'
 import { ListOutput } from '../cli/reader'
-import { tryThenMaybeForce } from '../cli/actions'
-import {
-  CommandId,
-  AvailableCommands,
-  InternalCommands
-} from '../commands/internal'
+import { AvailableCommands, InternalCommands } from '../commands/internal'
 import { getFirstWorkspaceFolder } from '../vscode/workspaceFolders'
 import { RegisteredCliCommands, RegisteredCommands } from '../commands/external'
 import { sendViewOpenedTelemetryEvent } from '../telemetry'
@@ -296,28 +291,6 @@ export class TrackedExplorerTree implements TreeDataProvider<PathItem> {
           relDestination
         )
       }
-    )
-
-    this.internalCommands.registerExternalCliCommand<Resource>(
-      RegisteredCliCommands.PULL_TARGET,
-      resource => this.tryThenMaybeForce(AvailableCommands.PULL, resource)
-    )
-
-    this.internalCommands.registerExternalCliCommand<Resource>(
-      RegisteredCliCommands.PUSH_TARGET,
-      resource => this.tryThenMaybeForce(AvailableCommands.PUSH, resource)
-    )
-  }
-
-  private tryThenMaybeForce(
-    commandId: CommandId,
-    { dvcRoot, resourceUri }: Resource
-  ) {
-    return tryThenMaybeForce(
-      this.internalCommands,
-      commandId,
-      dvcRoot,
-      relative(dvcRoot, resourceUri.path)
     )
   }
 }

--- a/extension/src/repository/commands/register.ts
+++ b/extension/src/repository/commands/register.ts
@@ -31,6 +31,16 @@ const registerResourceCommands = (internalCommands: InternalCommands): void => {
     RegisteredCliCommands.COMMIT_TARGET,
     getResourceCommand(internalCommands, AvailableCommands.COMMIT)
   )
+
+  internalCommands.registerExternalCliCommand<Resource>(
+    RegisteredCliCommands.PULL_TARGET,
+    getResourceCommand(internalCommands, AvailableCommands.PULL)
+  )
+
+  internalCommands.registerExternalCliCommand<Resource>(
+    RegisteredCliCommands.PUSH_TARGET,
+    getResourceCommand(internalCommands, AvailableCommands.PUSH)
+  )
 }
 
 const registerResourceGroupCommands = (


### PR DESCRIPTION
# 3/4 `master` <- #969 <- #971 <- this <- #973

Addresses the second point in #962 by making it possible to call `pull` & `push` from both the `TrackedExplorerTree` and `SourceControlManagement` views.