### PR TITLE
Remove `--fix` from `lint:eslint`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "format": "prettier --write '**/*.{js,ts,jsx,tsx,md,json,yml,yaml}'",
     "lint:prettier": "prettier -c '**/*.{md,json}'",
-    "lint:eslint": "eslint --cache --fix '**/*.{js,ts,jsx,tsx}'",
+    "lint:eslint": "eslint --cache '**/*.{js,ts,jsx,tsx}'",
     "lint:tsc": "tsc --noEmit",
     "lint": "run-p 'lint:*'",
     "test-build-extension": "yarn workspace dvc run test-vscode-build",


### PR DESCRIPTION
After making #983, I noticed eslint violations that are fixable by `--fix` aren't picked up in CI. This removes `--fix` from `lint:eslint`, the script called by CI, so that it will actually error out instead of silently fixing them in an environment that isn't committed.

I'd considered re-adding `--fix` as a script called `format:eslint` that's called alongside our current prettier `format`, but I'm not sure if we actually want to call eslint every time we format. We can still call `yarn lint:eslint --fix` if we need to.