### PR TITLE
Add new resources into ResourceLocator

### DIFF
--- a/extension/src/resourceLocator.test.ts
+++ b/extension/src/resourceLocator.test.ts
@@ -16,4 +16,33 @@ describe('ResourceLocator', () => {
       light
     })
   })
+
+  it('should be able to find any experiments resource', () => {
+    const mockPath = Uri.file('some/path')
+    const resourceLocator = new ResourceLocator(mockPath)
+
+    const redCircleFilled = Uri.file(
+      'some/path/resources/experiments/circle-filled-#f14c4c.svg'
+    )
+
+    expect(
+      resourceLocator.getExperimentsResource('circle-filled', '#f14c4c')
+    ).toEqual(redCircleFilled)
+
+    const blueSpinner = Uri.file(
+      'some/path/resources/experiments/loading-spin-#3794ff.svg'
+    )
+
+    expect(
+      resourceLocator.getExperimentsResource('loading-spin', '#3794ff')
+    ).toEqual(blueSpinner)
+
+    const yellowDot = Uri.file(
+      'some/path/resources/experiments/debug-stackframe-dot-#cca700.svg'
+    )
+
+    expect(
+      resourceLocator.getExperimentsResource('debug-stackframe-dot', '#cca700')
+    ).toEqual(yellowDot)
+  })
 })

--- a/extension/src/resourceLocator.ts
+++ b/extension/src/resourceLocator.ts
@@ -28,6 +28,18 @@ export class ResourceLocator {
     )
   }
 
+  public getExperimentsResource(
+    name: 'circle-filled' | 'debug-stackframe-dot' | 'loading-spin',
+    color: string
+  ): Uri {
+    return Uri.joinPath(
+      this.extensionUri,
+      'resources',
+      'experiments',
+      `${name}-${color}.svg`
+    )
+  }
+
   private getResourceLocations(...path: string[]): { dark: Uri; light: Uri } {
     return {
       dark: this.getResourceLocation('dark', ...path),


### PR DESCRIPTION
# 2/5 `master` <- #1039 <- this <- #1041 <- #1042 <- #1043

Relates to #712

This PR adds the ability to locate the newly created SVGs into our `ResourceLocator`.