### PR TITLE
Use experiment id to assign a color (not display name)

### DIFF
--- a/extension/src/experiments/model/colors/collect.test.ts
+++ b/extension/src/experiments/model/colors/collect.test.ts
@@ -7,19 +7,23 @@ const generateExperimentNameList = (n: number): string[] =>
 describe('collectColors', () => {
   it('should assign the correct colors to the correct experiments', () => {
     const { assigned } = collectColors(
-      ['exp-e7a67', 'test-branch', 'exp-83425'],
+      [
+        '4fb124aebddb2adf1545030907687fa9a4c80e70',
+        '42b8736b08170529903cd203a1f40382a4b4a8cd',
+        '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d'
+      ],
       new Map()
     )
     expect(assigned).toEqual(
       new Map([
-        ['exp-83425', '#cca700'],
-        ['exp-e7a67', '#f14c4c'],
-        ['test-branch', '#3794ff']
+        ['1ba7bcd6ce6154e72e18b155475663ecbbd1f49d', '#cca700'],
+        ['4fb124aebddb2adf1545030907687fa9a4c80e70', '#f14c4c'],
+        ['42b8736b08170529903cd203a1f40382a4b4a8cd', '#3794ff']
       ])
     )
   })
 
-  it('should return the original list of colors if no experiment names are provided', () => {
+  it('should return the original list of colors if no experiment ids are provided', () => {
     const { available } = collectColors([], new Map())
     expect(available).toEqual(copyOriginalColors())
   })
@@ -28,9 +32,9 @@ describe('collectColors', () => {
     const { assigned, available } = collectColors(
       [],
       new Map([
-        ['exp-e7a67', '#f14c4c'],
-        ['test-branch', '#3794ff'],
-        ['exp-83425', '#cca700']
+        ['4fb124aebddb2adf1545030907687fa9a4c80e70', '#f14c4c'],
+        ['42b8736b08170529903cd203a1f40382a4b4a8cd', '#3794ff'],
+        ['1ba7bcd6ce6154e72e18b155475663ecbbd1f49d', '#cca700']
       ]),
       []
     )
@@ -44,9 +48,9 @@ describe('collectColors', () => {
     const { assigned, available } = collectColors(
       [],
       new Map([
-        ['exp-e7a67', '#f14c4c'],
-        ['test-branch', '#3794ff'],
-        ['exp-83425', '#cca700']
+        ['4fb124aebddb2adf1545030907687fa9a4c80e70', '#f14c4c'],
+        ['42b8736b08170529903cd203a1f40382a4b4a8cd', '#3794ff'],
+        ['1ba7bcd6ce6154e72e18b155475663ecbbd1f49d', '#cca700']
       ]),
       originalColorsList.slice(3)
     )
@@ -57,15 +61,19 @@ describe('collectColors', () => {
   it('should return the original assigned and available colors given the same info', () => {
     const originalColorsList = copyOriginalColors()
     const originalAssigned = new Map([
-      ['exp-83425', '#cca700'],
-      ['exp-e7a67', '#f14c4c'],
-      ['test-branch', '#3794ff']
+      ['1ba7bcd6ce6154e72e18b155475663ecbbd1f49d', '#cca700'],
+      ['4fb124aebddb2adf1545030907687fa9a4c80e70', '#f14c4c'],
+      ['42b8736b08170529903cd203a1f40382a4b4a8cd', '#3794ff']
     ])
 
     const originalAvailable = originalColorsList.slice(2)
 
     const { assigned, available } = collectColors(
-      ['exp-83425', 'exp-e7a67', 'test-branch'],
+      [
+        '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d',
+        '4fb124aebddb2adf1545030907687fa9a4c80e70',
+        '42b8736b08170529903cd203a1f40382a4b4a8cd'
+      ],
       originalAssigned,
       originalAvailable
     )

--- a/extension/src/experiments/model/colors/collect.ts
+++ b/extension/src/experiments/model/colors/collect.ts
@@ -7,12 +7,12 @@ export type Colors = {
 }
 
 const getOrderedColorsToUnassign = (
-  experimentNames: string[],
+  experimentIds: string[],
   currentColors: Map<string, string>
 ): string[] => {
   const colorsToUnassign: string[] = []
-  currentColors.forEach((color: string, name: string) => {
-    if (!experimentNames.includes(name)) {
+  currentColors.forEach((color: string, id: string) => {
+    if (!experimentIds.includes(id)) {
       colorsToUnassign.unshift(color)
     }
   })
@@ -20,15 +20,15 @@ const getOrderedColorsToUnassign = (
 }
 
 const unassignColors = (
-  experimentNames: string[],
+  experimentIds: string[],
   current: Map<string, string>,
   unassigned: string[]
 ): string[] => {
-  if (!definedAndNonEmpty(experimentNames)) {
+  if (!definedAndNonEmpty(experimentIds)) {
     return copyOriginalColors()
   }
 
-  const colorsToUnassign = getOrderedColorsToUnassign(experimentNames, current)
+  const colorsToUnassign = getOrderedColorsToUnassign(experimentIds, current)
   colorsToUnassign.forEach(color => {
     if (!unassigned.includes(color)) {
       unassigned.unshift(color)
@@ -38,35 +38,35 @@ const unassignColors = (
 }
 
 const assignColors = (
-  experimentNames: string[],
+  experimentIds: string[],
   current: Map<string, string>,
   available: string[]
 ): Colors => {
   const assigned = new Map()
 
-  experimentNames.forEach(name => {
+  experimentIds.forEach(id => {
     if (available.length === 0) {
       available = copyOriginalColors()
     }
-    const existingColor = current.get(name)
+    const existingColor = current.get(id)
 
     if (existingColor) {
-      assigned.set(name, existingColor)
+      assigned.set(id, existingColor)
       return
     }
 
     const nextColor = available.shift() as string
-    assigned.set(name, nextColor)
+    assigned.set(id, nextColor)
   })
   return { assigned, available }
 }
 
 export const collectColors = (
-  experimentNames: string[],
+  experimentIds: string[],
   current: Map<string, string>,
   unassigned = copyOriginalColors()
 ): Colors => {
-  const available = unassignColors(experimentNames, current, unassigned)
+  const available = unassignColors(experimentIds, current, unassigned)
 
-  return assignColors(experimentNames, current, available)
+  return assignColors(experimentIds, current, available)
 }

--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -90,7 +90,7 @@ export class ExperimentsModel {
     this.livePlots = livePlots
 
     this.colors = collectColors(
-      this.getCurrentExperimentNames(),
+      this.getCurrentExperimentIds(),
       this.getAssignedColors(),
       this.colors.available
     )
@@ -181,7 +181,7 @@ export class ExperimentsModel {
         return {
           ...this.addDisplayColor(experiment),
           subRows: checkpoints.map(checkpoint =>
-            this.addDisplayColor(checkpoint, experiment.displayName)
+            this.addDisplayColor(checkpoint, experiment.id)
           )
         }
       })
@@ -279,18 +279,16 @@ export class ExperimentsModel {
     return { colors, currentSorts, filters }
   }
 
-  private getCurrentExperimentNames() {
+  private getCurrentExperimentIds() {
     return this.flattenExperiments()
       .filter(exp => !exp.queued)
-      .map(exp => exp.displayName)
+      .map(exp => exp.id)
       .filter(Boolean) as string[]
   }
 
-  private addDisplayColor(experiment: Experiment, displayName?: string) {
+  private addDisplayColor(experiment: Experiment, id?: string) {
     const assignedColors = this.getAssignedColors()
-    const displayColor = assignedColors.get(
-      displayName || experiment.displayName
-    )
+    const displayColor = assignedColors.get(id || experiment.id)
 
     return displayColor
       ? {

--- a/extension/src/experiments/model/livePlots/collect.ts
+++ b/extension/src/experiments/model/livePlots/collect.ts
@@ -105,12 +105,12 @@ const collectFromExperimentsObject = (
     const { checkpoint_tip, metrics } = data
     const iteration = addToMapCount(checkpoint_tip, checkpointCount)
 
-    const experimentName = experimentsObject[checkpoint_tip].data?.name
-    if (!experimentName) {
+    const experiment = experimentsObject[checkpoint_tip]
+    if (!experiment) {
       continue
     }
 
-    collectFromMetrics(acc, experimentName, iteration, metrics)
+    collectFromMetrics(acc, checkpoint_tip, iteration, metrics)
   }
 }
 

--- a/extension/src/test/fixtures/expShow/livePlots.ts
+++ b/extension/src/test/fixtures/expShow/livePlots.ts
@@ -2,64 +2,212 @@ import { LivePlotsData } from '../../../plots/webview/contract'
 
 const data: LivePlotsData = {
   colors: {
-    domain: ['exp-e7a67', 'test-branch', 'exp-83425'],
+    domain: [
+      '4fb124aebddb2adf1545030907687fa9a4c80e70',
+      '42b8736b08170529903cd203a1f40382a4b4a8cd',
+      '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d'
+    ],
     range: ['#f14c4c', '#3794ff', '#cca700']
   },
   plots: [
     {
       title: 'metrics:summary.json:loss',
       values: [
-        { group: 'exp-83425', x: 1, y: 1.9896177053451538 },
-        { group: 'exp-83425', x: 2, y: 1.9329891204833984 },
-        { group: 'exp-83425', x: 3, y: 1.8798457384109497 },
-        { group: 'exp-83425', x: 4, y: 1.8261293172836304 },
-        { group: 'exp-83425', x: 5, y: 1.775016188621521 },
-        { group: 'test-branch', x: 1, y: 1.9882521629333496 },
-        { group: 'test-branch', x: 2, y: 1.9293040037155151 },
-        { group: 'exp-e7a67', x: 1, y: 2.020392894744873 },
-        { group: 'exp-e7a67', x: 2, y: 2.0205044746398926 }
+        {
+          group: '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d',
+          x: 1,
+          y: 1.9896177053451538
+        },
+        {
+          group: '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d',
+          x: 2,
+          y: 1.9329891204833984
+        },
+        {
+          group: '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d',
+          x: 3,
+          y: 1.8798457384109497
+        },
+        {
+          group: '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d',
+          x: 4,
+          y: 1.8261293172836304
+        },
+        {
+          group: '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d',
+          x: 5,
+          y: 1.775016188621521
+        },
+        {
+          group: '42b8736b08170529903cd203a1f40382a4b4a8cd',
+          x: 1,
+          y: 1.9882521629333496
+        },
+        {
+          group: '42b8736b08170529903cd203a1f40382a4b4a8cd',
+          x: 2,
+          y: 1.9293040037155151
+        },
+        {
+          group: '4fb124aebddb2adf1545030907687fa9a4c80e70',
+          x: 1,
+          y: 2.020392894744873
+        },
+        {
+          group: '4fb124aebddb2adf1545030907687fa9a4c80e70',
+          x: 2,
+          y: 2.0205044746398926
+        }
       ]
     },
     {
       title: 'metrics:summary.json:accuracy',
       values: [
-        { group: 'exp-83425', x: 1, y: 0.40904998779296875 },
-        { group: 'exp-83425', x: 2, y: 0.46094998717308044 },
-        { group: 'exp-83425', x: 3, y: 0.5113166570663452 },
-        { group: 'exp-83425', x: 4, y: 0.557449996471405 },
-        { group: 'exp-83425', x: 5, y: 0.5926499962806702 },
-        { group: 'test-branch', x: 1, y: 0.4083833396434784 },
-        { group: 'test-branch', x: 2, y: 0.4668000042438507 },
-        { group: 'exp-e7a67', x: 1, y: 0.3723166584968567 },
-        { group: 'exp-e7a67', x: 2, y: 0.3724166750907898 }
+        {
+          group: '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d',
+          x: 1,
+          y: 0.40904998779296875
+        },
+        {
+          group: '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d',
+          x: 2,
+          y: 0.46094998717308044
+        },
+        {
+          group: '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d',
+          x: 3,
+          y: 0.5113166570663452
+        },
+        {
+          group: '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d',
+          x: 4,
+          y: 0.557449996471405
+        },
+        {
+          group: '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d',
+          x: 5,
+          y: 0.5926499962806702
+        },
+        {
+          group: '42b8736b08170529903cd203a1f40382a4b4a8cd',
+          x: 1,
+          y: 0.4083833396434784
+        },
+        {
+          group: '42b8736b08170529903cd203a1f40382a4b4a8cd',
+          x: 2,
+          y: 0.4668000042438507
+        },
+        {
+          group: '4fb124aebddb2adf1545030907687fa9a4c80e70',
+          x: 1,
+          y: 0.3723166584968567
+        },
+        {
+          group: '4fb124aebddb2adf1545030907687fa9a4c80e70',
+          x: 2,
+          y: 0.3724166750907898
+        }
       ]
     },
     {
       title: 'metrics:summary.json:val_loss',
       values: [
-        { group: 'exp-83425', x: 1, y: 1.9391471147537231 },
-        { group: 'exp-83425', x: 2, y: 1.8825950622558594 },
-        { group: 'exp-83425', x: 3, y: 1.827923059463501 },
-        { group: 'exp-83425', x: 4, y: 1.7749212980270386 },
-        { group: 'exp-83425', x: 5, y: 1.7233840227127075 },
-        { group: 'test-branch', x: 1, y: 1.9363881349563599 },
-        { group: 'test-branch', x: 2, y: 1.8770883083343506 },
-        { group: 'exp-e7a67', x: 1, y: 1.9979370832443237 },
-        { group: 'exp-e7a67', x: 2, y: 1.9979370832443237 }
+        {
+          group: '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d',
+          x: 1,
+          y: 1.9391471147537231
+        },
+        {
+          group: '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d',
+          x: 2,
+          y: 1.8825950622558594
+        },
+        {
+          group: '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d',
+          x: 3,
+          y: 1.827923059463501
+        },
+        {
+          group: '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d',
+          x: 4,
+          y: 1.7749212980270386
+        },
+        {
+          group: '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d',
+          x: 5,
+          y: 1.7233840227127075
+        },
+        {
+          group: '42b8736b08170529903cd203a1f40382a4b4a8cd',
+          x: 1,
+          y: 1.9363881349563599
+        },
+        {
+          group: '42b8736b08170529903cd203a1f40382a4b4a8cd',
+          x: 2,
+          y: 1.8770883083343506
+        },
+        {
+          group: '4fb124aebddb2adf1545030907687fa9a4c80e70',
+          x: 1,
+          y: 1.9979370832443237
+        },
+        {
+          group: '4fb124aebddb2adf1545030907687fa9a4c80e70',
+          x: 2,
+          y: 1.9979370832443237
+        }
       ]
     },
     {
       title: 'metrics:summary.json:val_accuracy',
       values: [
-        { group: 'exp-83425', x: 1, y: 0.49399998784065247 },
-        { group: 'exp-83425', x: 2, y: 0.5550000071525574 },
-        { group: 'exp-83425', x: 3, y: 0.6035000085830688 },
-        { group: 'exp-83425', x: 4, y: 0.6414999961853027 },
-        { group: 'exp-83425', x: 5, y: 0.6704000234603882 },
-        { group: 'test-branch', x: 1, y: 0.4970000088214874 },
-        { group: 'test-branch', x: 2, y: 0.5608000159263611 },
-        { group: 'exp-e7a67', x: 1, y: 0.4277999997138977 },
-        { group: 'exp-e7a67', x: 2, y: 0.4277999997138977 }
+        {
+          group: '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d',
+          x: 1,
+          y: 0.49399998784065247
+        },
+        {
+          group: '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d',
+          x: 2,
+          y: 0.5550000071525574
+        },
+        {
+          group: '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d',
+          x: 3,
+          y: 0.6035000085830688
+        },
+        {
+          group: '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d',
+          x: 4,
+          y: 0.6414999961853027
+        },
+        {
+          group: '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d',
+          x: 5,
+          y: 0.6704000234603882
+        },
+        {
+          group: '42b8736b08170529903cd203a1f40382a4b4a8cd',
+          x: 1,
+          y: 0.4970000088214874
+        },
+        {
+          group: '42b8736b08170529903cd203a1f40382a4b4a8cd',
+          x: 2,
+          y: 0.5608000159263611
+        },
+        {
+          group: '4fb124aebddb2adf1545030907687fa9a4c80e70',
+          x: 1,
+          y: 0.4277999997138977
+        },
+        {
+          group: '4fb124aebddb2adf1545030907687fa9a4c80e70',
+          x: 2,
+          y: 0.4277999997138977
+        }
       ]
     }
   ]

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -417,9 +417,9 @@ suite('Experiments Test Suite', () => {
         'The correct colors are persisted'
       ).to.deep.equal({
         assigned: [
-          ['exp-e7a67', '#f14c4c'],
-          ['test-branch', '#3794ff'],
-          ['exp-83425', '#cca700']
+          ['4fb124aebddb2adf1545030907687fa9a4c80e70', '#f14c4c'],
+          ['42b8736b08170529903cd203a1f40382a4b4a8cd', '#3794ff'],
+          ['1ba7bcd6ce6154e72e18b155475663ecbbd1f49d', '#cca700']
         ],
         available: copyOriginalColors().slice(3)
       })
@@ -500,9 +500,9 @@ suite('Experiments Test Suite', () => {
 
     it('should initialize with state reflected from the given Memento', async () => {
       const assigned: [string, string][] = [
-        ['exp-e7a67', '#1e5a52'],
-        ['test-branch', '#96958f'],
-        ['exp-83425', '#5f5856']
+        ['4fb124aebddb2adf1545030907687fa9a4c80e70', '#1e5a52'],
+        ['42b8736b08170529903cd203a1f40382a4b4a8cd', '#96958f'],
+        ['1ba7bcd6ce6154e72e18b155475663ecbbd1f49d', '#5f5856']
       ]
       const available = ['#000000', '#FFFFFF', '#ABCDEF']
 
@@ -536,7 +536,11 @@ suite('Experiments Test Suite', () => {
       ])
       const livePlots = testRepository.getLivePlots()
       expect(livePlots?.colors).to.deep.equal({
-        domain: ['exp-e7a67', 'test-branch', 'exp-83425'],
+        domain: [
+          '4fb124aebddb2adf1545030907687fa9a4c80e70',
+          '42b8736b08170529903cd203a1f40382a4b4a8cd',
+          '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d'
+        ],
         range: ['#1e5a52', '#96958f', '#5f5856']
       })
     })

--- a/extension/src/test/suite/experiments/util.ts
+++ b/extension/src/test/suite/experiments/util.ts
@@ -59,9 +59,9 @@ export const buildExperiments = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   stub(ExperimentsModel.prototype as any, 'getAssignedColors').returns(
     new Map([
-      ['exp-e7a67', '#f14c4c'],
-      ['test-branch', '#3794ff'],
-      ['exp-83425', '#cca700']
+      ['4fb124aebddb2adf1545030907687fa9a4c80e70', '#f14c4c'],
+      ['42b8736b08170529903cd203a1f40382a4b4a8cd', '#3794ff'],
+      ['1ba7bcd6ce6154e72e18b155475663ecbbd1f49d', '#cca700']
     ])
   )
 


### PR DESCRIPTION
# 3/5 `master` <- #1039 <- #1040 <- this <- #1042 <- #1043

Relates to #712.

This PR switches the color collection from depending on experiment display names to experiment Ids (commit sha). The original decision to depend on a non-id field was a poor one. This change makes subsequently adding colors into the `ExperimentsTree` a lot easier.