### PR TITLE
Only send selected experiments data to plots webview

### DIFF
--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -79,7 +79,14 @@ export class ExperimentsModel {
 
     return {
       colors,
-      plots: this.livePlots
+      plots: this.livePlots.map(plot => {
+        const { title, values } = plot
+
+        return {
+          title,
+          values: values.filter(value => this.status[value.group])
+        }
+      })
     }
   }
 


### PR DESCRIPTION
# 2/3 `master` <- #1044 <- this <- #1046

Relates to #712

This is important because it enables the Y-axis in each plot to auto-adjust to the new max/min values in the data.

### Demo

https://user-images.githubusercontent.com/37993418/141895011-88153f28-7cc1-43b6-a8e9-2969bbfff2aa.mov

**Note**: I cannot explain why that experiment started with that loss.