### PR TITLE
Remove debug-stackframe-dot svgs and code

### DIFF
--- a/extension/resources/experiments/debug-stackframe-dot-#0b2c0e.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#0b2c0e.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#0b2c0e"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#143446.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#143446.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#143446"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#1a1c19.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#1a1c19.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#1a1c19"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#1a204b.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#1a204b.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#1a204b"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#1a408c.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#1a408c.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#1a408c"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#1e5a52.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#1e5a52.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#1e5a52"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#1f5010.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#1f5010.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#1f5010"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#261e8d.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#261e8d.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#261e8d"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#268721.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#268721.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#268721"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#296a91.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#296a91.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#296a91"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#2cb2ee.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#2cb2ee.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#2cb2ee"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#369c9d.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#369c9d.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#369c9d"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#379063.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#379063.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#379063"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#3794ff.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#3794ff.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#3794ff"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#390e16.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#390e16.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#390e16"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#3a8ce6.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#3a8ce6.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#3a8ce6"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#4063e2.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#4063e2.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#4063e2"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#41d8f5.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#41d8f5.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#41d8f5"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#41e39d.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#41e39d.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#41e39d"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#453110.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#453110.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#453110"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#50f0ea.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#50f0ea.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#50f0ea"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#5b0d09.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#5b0d09.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#5b0d09"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#5f5856.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#5f5856.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#5f5856"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#67175f.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#67175f.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#67175f"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#7ddc4f.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#7ddc4f.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#7ddc4f"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#825b20.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#825b20.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#825b20"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#828b24.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#828b24.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#828b24"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#89d185.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#89d185.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#89d185"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#8a2244.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#8a2244.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#8a2244"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#911f10.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#911f10.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#911f10"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#936b8f.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#936b8f.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#936b8f"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#96958f.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#96958f.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#96958f"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#a4bce3.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#a4bce3.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#a4bce3"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#b180d7.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#b180d7.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#b180d7"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#bbdda2.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#bbdda2.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#bbdda2"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#c753d7.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#c753d7.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#c753d7"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#cca700.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#cca700.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#cca700"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#d18616.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#d18616.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#d18616"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#d6e5e7.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#d6e5e7.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#d6e5e7"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#e08d2b.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#e08d2b.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#e08d2b"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#e1459f.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#e1459f.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#e1459f"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#e2492d.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#e2492d.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#e2492d"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#e53765.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#e53765.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#e53765"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#e5d63f.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#e5d63f.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#e5d63f"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#e98d8d.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#e98d8d.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#e98d8d"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#ea9ded.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#ea9ded.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#ea9ded"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#ebccbe.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#ebccbe.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#ebccbe"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#eec181.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#eec181.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#eec181"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#f14c4c.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#f14c4c.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#f14c4c"/></svg>

--- a/extension/resources/experiments/debug-stackframe-dot-#f3c8ed.svg
+++ b/extension/resources/experiments/debug-stackframe-dot-#f3c8ed.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M10 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0z" fill="#f3c8ed"/></svg>

--- a/extension/src/experiments/model/tree.test.ts
+++ b/extension/src/experiments/model/tree.test.ts
@@ -374,13 +374,13 @@ describe('ExperimentsTree', () => {
       const treeItem = experimentsTree.getTreeItem({
         collapsibleState: 0,
         dvcRoot: 'demo',
-        iconPath: new ThemeIcon('debug-stackframe-dot'),
+        iconPath: new ThemeIcon('circle-filled'),
         id: 'f0778b3',
         label: 'f0778b3'
       })
       expect(treeItem).toEqual({
         ...mockedItem,
-        iconPath: { id: 'debug-stackframe-dot' }
+        iconPath: { id: 'circle-filled' }
       })
     })
 

--- a/extension/src/resourceLocator.test.ts
+++ b/extension/src/resourceLocator.test.ts
@@ -44,16 +44,5 @@ describe('ResourceLocator', () => {
     expect(
       resourceLocator.getExperimentsResource(IconName.LOADING_SPIN, '#3794ff')
     ).toEqual(blueSpinner)
-
-    const yellowDot = Uri.file(
-      'some/path/resources/experiments/debug-stackframe-dot-#cca700.svg'
-    )
-
-    expect(
-      resourceLocator.getExperimentsResource(
-        IconName.DEBUG_STACKFRAME_DOT,
-        '#cca700'
-      )
-    ).toEqual(yellowDot)
   })
 })

--- a/extension/src/resourceLocator.ts
+++ b/extension/src/resourceLocator.ts
@@ -6,7 +6,6 @@ export type Resource = { dark: Uri; light: Uri }
 export enum IconName {
   CIRCLE_FILLED = 'circle-filled',
   CIRCLE_OUTLINE = 'circle-outline',
-  DEBUG_STACKFRAME_DOT = 'debug-stackframe-dot',
   LOADING_SPIN = 'loading-spin'
 }
 

--- a/scripts/create-svgs.ts
+++ b/scripts/create-svgs.ts
@@ -20,25 +20,21 @@ const writeSpinner = (loadingIcon: string, color: string) => {
   )
 }
 
-;['loading', 'circle-filled', 'circle-outline', 'debug-stackframe-dot'].map(
-  iconName => {
-    const icon = readFileSync(
-      `./node_modules/@vscode/codicons/src/icons/${iconName}.svg`
+;['loading', 'circle-filled', 'circle-outline'].map(iconName => {
+  const icon = readFileSync(
+    `./node_modules/@vscode/codicons/src/icons/${iconName}.svg`
+  )
+
+  colors.map(color => {
+    const newIcon = icon.toString().replace(/(?<=d=".*?")/, ` fill="${color}"`)
+
+    if (iconName === 'loading') {
+      return writeSpinner(newIcon, color)
+    }
+
+    writeFileSync(
+      `./extension/resources/experiments/${iconName}-${color}.svg`,
+      newIcon
     )
-
-    colors.map(color => {
-      const newIcon = icon
-        .toString()
-        .replace(/(?<=d=".*?")/, ` fill="${color}"`)
-
-      if (iconName === 'loading') {
-        return writeSpinner(newIcon, color)
-      }
-
-      writeFileSync(
-        `./extension/resources/experiments/${iconName}-${color}.svg`,
-        newIcon
-      )
-    })
-  }
-)
+  })
+})


### PR DESCRIPTION
This PR cleans up the code and svgs required for `debug-stackframe-dot` icons in the experiments sidebar tree. They are no longer needed because we replaced them in #1057.

Relates to #712 