### PR TITLE
Increase timeout of every test that shows a webview

### DIFF
--- a/extension/src/test/suite/cli/runner.test.ts
+++ b/extension/src/test/suite/cli/runner.test.ts
@@ -31,7 +31,7 @@ suite('CLI Runner Test Suite', () => {
       await cliRunner.run(cwd, '1000')
 
       expect(windowErrorMessageSpy).to.be.calledOnce
-    }).timeout(5000)
+    }).timeout(8000)
 
     it('should be able to stop a started command', async () => {
       const cliRunner = disposable.track(new CliRunner({} as Config, 'sleep'))
@@ -66,7 +66,7 @@ suite('CLI Runner Test Suite', () => {
         'dvc.runner.running',
         false
       )
-    }).timeout(6000)
+    }).timeout(8000)
 
     it('should be able to execute a command and provide the correct events in the correct order', async () => {
       const text = ':weeeee:'

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -113,7 +113,7 @@ suite('Experiments Test Suite', () => {
 
       expect(webview.isActive()).to.be.true
       expect(webview.isVisible()).to.be.true
-    }).timeout(6000)
+    }).timeout(8000)
 
     it('should only be able to open a single experiments webview', async () => {
       const { experiments } = buildExperiments(disposable)
@@ -140,7 +140,7 @@ suite('Experiments Test Suite', () => {
       expect(webview === sameWebview).to.be.true
 
       expect(windowSpy).not.to.have.been.called
-    }).timeout(5000)
+    }).timeout(8000)
 
     it('should handle column reordering messages from the webview', async () => {
       const { experiments } = buildExperiments(disposable, expShowFixture)
@@ -190,7 +190,7 @@ suite('Experiments Test Suite', () => {
       await columnOrderSet
 
       expect(mockSetColumnReordered).to.be.calledWith(columnOrder)
-    })
+    }).timeout(8000)
 
     it('should be able to sort', async () => {
       const config = disposable.track(new Config())
@@ -335,7 +335,7 @@ suite('Experiments Test Suite', () => {
         ],
         sorts: [{ descending: false, path: sortPath }]
       })
-    }).timeout(5000)
+    }).timeout(8000)
   })
 
   describe('persisted state', () => {

--- a/extension/src/test/suite/experiments/model/filterBy/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/filterBy/tree.test.ts
@@ -134,7 +134,7 @@ suite('Experiments Filter By Tree Test Suite', () => {
       }
 
       expect(messageSpy).to.be.calledWith(expectedTableData)
-    }).timeout(6000)
+    }).timeout(8000)
 
     it('should be able to remove all filters with dvc.views.experimentsFilterByTree.removeAllFilters', async () => {
       const mockShowQuickPick = stub(window, 'showQuickPick')

--- a/extension/src/test/suite/experiments/model/sortBy/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/sortBy/tree.test.ts
@@ -247,7 +247,7 @@ suite('Experiments Sort By Tree Test Suite', () => {
         dvcDemoPath
       )
       expect(getParamsArray(), 'final sort clear').to.deep.equal([1, 3, 2, 4])
-    }).timeout(5000)
+    }).timeout(8000)
 
     it('should handle the user exiting from the choose repository quick pick', async () => {
       const mockShowQuickPick = stub(window, 'showQuickPick')
@@ -278,6 +278,6 @@ suite('Experiments Sort By Tree Test Suite', () => {
         getRepositorySpy,
         'should not call get repository in removeSorts without a root'
       ).not.to.be.called
-    })
+    }).timeout(8000)
   })
 })

--- a/extension/src/test/suite/experiments/model/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/tree.test.ts
@@ -110,7 +110,7 @@ suite('Experiments Tree Test Suite', () => {
         setSelectionModeSpy,
         'selecting any experiment disables auto apply filters to experiments selection'
       ).to.be.calledOnceWith(false)
-    }).timeout(6000)
+    }).timeout(8000)
 
     it('should be able to select / de-select experiments using dvc.views.experimentsTree.selectExperiments', async () => {
       const { plots, messageSpy } = await buildPlots(disposable)
@@ -174,7 +174,7 @@ suite('Experiments Tree Test Suite', () => {
         setSelectionModeSpy,
         'auto apply filters to experiment selection is disabled'
       ).to.be.calledOnceWith(false)
-    }).timeout(6000)
+    }).timeout(8000)
 
     it('should be able to apply filters using dvc.views.experimentsTree.autoApplyFilters', async () => {
       const { plots, messageSpy } = await buildPlots(disposable)
@@ -217,7 +217,7 @@ suite('Experiments Tree Test Suite', () => {
         'auto apply filters to experiment selection is enabled'
       ).to.be.calledOnceWith(true)
       messageSpy.resetHistory()
-    })
+    }).timeout(8000)
 
     it('should automatically apply filters to experiments selection if dvc.experiments.filter.selected has been set via dvc.views.experimentsTree.autoApplyFilters', async () => {
       const mockShowQuickPick = stub(window, 'showQuickPick')
@@ -287,6 +287,6 @@ suite('Experiments Tree Test Suite', () => {
         messageSpy,
         'the old filters are still applied to the message'
       ).to.be.calledWith(expectedMessage)
-    })
+    }).timeout(8000)
   })
 })

--- a/extension/src/test/suite/experiments/workspace.test.ts
+++ b/extension/src/test/suite/experiments/workspace.test.ts
@@ -63,7 +63,7 @@ suite('Workspace Experiments Test Suite', () => {
 
       expect(focusedExperiments).to.equal(experiments)
       expect(mockQuickPickOne).to.be.calledOnce
-    }).timeout(5000)
+    }).timeout(8000)
 
     it('should not prompt to pick a project if there is only one project', async () => {
       const mockQuickPickOne = stub(QuickPick, 'quickPickOne').resolves(
@@ -77,7 +77,7 @@ suite('Workspace Experiments Test Suite', () => {
 
       expect(mockQuickPickOne).to.not.be.called
     })
-  })
+  }).timeout(8000)
 
   describe('dvc.queueExperiment', () => {
     it('should be able to queue an experiment', async () => {

--- a/extension/src/test/suite/fileSystem/tree.test.ts
+++ b/extension/src/test/suite/fileSystem/tree.test.ts
@@ -199,7 +199,7 @@ suite('Tracked Explorer Tree Test Suite', () => {
       await activeEditorChanged
 
       expect(getActiveTextEditorFilename()).to.equal(fileToOpen)
-    }).timeout(5000)
+    }).timeout(8000)
 
     it('should be able to open a file to the side', async () => {
       const fileToOpen = join(dvcDemoPath, 'logs.json')

--- a/extension/src/test/suite/plots/index.test.ts
+++ b/extension/src/test/suite/plots/index.test.ts
@@ -40,6 +40,6 @@ suite('Plots Test Suite', () => {
 
       expect(webview.isActive()).to.be.true
       expect(webview.isVisible()).to.be.true
-    }).timeout(6000)
+    }).timeout(8000)
   })
 })

--- a/extension/src/test/suite/repository/index.test.ts
+++ b/extension/src/test/suite/repository/index.test.ts
@@ -131,6 +131,6 @@ suite('Repository Test Suite', () => {
       expect(mockList).to.be.calledOnce
       expect(mockDiff).to.be.calledTwice
       expect(mockStatus).to.be.calledTwice
-    }).timeout(5000)
+    }).timeout(8000)
   })
 })


### PR DESCRIPTION
Relates to #964

1. Increases the non-standard timeout to 8000. 
2. Adds a non-standards timeout to all tests that show a webview.