### PR TITLE
Fix CI

### DIFF
--- a/extension/src/test/suite/experiments/data/index.test.ts
+++ b/extension/src/test/suite/experiments/data/index.test.ts
@@ -2,12 +2,16 @@ import { join, sep } from 'path'
 import { afterEach, beforeEach, describe, it, suite } from 'mocha'
 import { FileSystemWatcher } from 'vscode'
 import { expect } from 'chai'
-import { stub, restore, useFakeTimers } from 'sinon'
+import { stub, restore } from 'sinon'
 import { Disposable } from '../../../../extension'
 import { CliReader } from '../../../../cli/reader'
 import expShowFixture from '../../../fixtures/expShow/output'
 import { Config } from '../../../../config'
-import { dvcDemoPath, getFirstArgOfCall } from '../../util'
+import {
+  dvcDemoPath,
+  FakeTimersDisposable,
+  getFirstArgOfCall
+} from '../../util'
 import { OutputChannel } from '../../../../vscode/outputChannel'
 import { ExperimentsData } from '../../../../experiments/data'
 import { InternalCommands } from '../../../../commands/internal'
@@ -104,7 +108,7 @@ suite('Experiments Data Test Suite', () => {
     it('should dispose of the current watcher and instantiate a new one if the params files change', async () => {
       stub(Watcher, 'createNecessaryFileSystemWatcher').returns(mockWatcher)
 
-      const clock = useFakeTimers()
+      const fakeTimers = disposable.track(new FakeTimersDisposable())
       const config = disposable.track(new Config())
       const cliReader = disposable.track(new CliReader(config))
       const mockExperimentShow = stub(cliReader, 'experimentShow').resolves(
@@ -133,7 +137,7 @@ suite('Experiments Data Test Suite', () => {
       )
 
       await data.isReady()
-      clock.tick(200000000)
+      fakeTimers.advance(200000000)
 
       mockExperimentShow.resolves(
         Object.assign(
@@ -185,8 +189,6 @@ suite('Experiments Data Test Suite', () => {
           `{dvc.lock,dvc.yaml,params.yaml,nested${sep}params.yaml,new_params.yml,new_summary.json,summary.json}`
         )
       )
-
-      clock.restore()
     })
   })
 })

--- a/extension/src/test/suite/experiments/workspace.test.ts
+++ b/extension/src/test/suite/experiments/workspace.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, it, suite } from 'mocha'
 import { expect } from 'chai'
-import { stub, restore, useFakeTimers } from 'sinon'
+import { stub, restore } from 'sinon'
 import { window, commands, QuickPickItem } from 'vscode'
 import { buildMultiRepoExperiments, buildSingleRepoExperiments } from './util'
 import { Disposable } from '../../../extension'
@@ -9,7 +9,7 @@ import { WorkspaceExperiments } from '../../../experiments/workspace'
 import { Experiments } from '../../../experiments'
 import * as QuickPick from '../../../vscode/quickPick'
 import { CliExecutor } from '../../../cli/executor'
-import { closeAllEditors, dvcDemoPath } from '../util'
+import { closeAllEditors, dvcDemoPath, FakeTimersDisposable } from '../util'
 import { RegisteredCliCommands } from '../../../commands/external'
 import * as Telemetry from '../../../telemetry'
 import { CliRunner } from '../../../cli/runner'
@@ -99,13 +99,10 @@ suite('Workspace Experiments Test Suite', () => {
     })
 
     it('should send a telemetry event containing a duration when an experiment is queued', async () => {
-      const clock = useFakeTimers()
+      const fakeTimers = disposable.track(new FakeTimersDisposable())
       const duration = 54321
 
-      stub(CliExecutor.prototype, 'experimentRunQueue').callsFake(() => {
-        clock.tick(duration)
-        return Promise.resolve('true')
-      })
+      stub(CliExecutor.prototype, 'experimentRunQueue').resolves('true')
 
       const mockSendTelemetryEvent = stub(Telemetry, 'sendTelemetryEvent')
 
@@ -115,19 +112,22 @@ suite('Workspace Experiments Test Suite', () => {
         'getOnlyOrPickProject'
       ).returns(dvcDemoPath)
 
-      await commands.executeCommand(RegisteredCliCommands.QUEUE_EXPERIMENT)
+      const queueExperiment = commands.executeCommand(
+        RegisteredCliCommands.QUEUE_EXPERIMENT
+      )
+      fakeTimers.advance(duration)
+
+      await queueExperiment
 
       expect(mockSendTelemetryEvent).to.be.calledWith(
         RegisteredCliCommands.QUEUE_EXPERIMENT,
         undefined,
         { duration }
       )
-
-      clock.restore()
     })
 
     it('should send a telemetry event containing an error message when an experiment fails to queue', async () => {
-      const clock = useFakeTimers()
+      const fakeTimers = disposable.track(new FakeTimersDisposable())
       const duration = 77777
       const mockErrorMessage =
         'ERROR: unexpected error - [Errno 2] No such file or directory'
@@ -137,7 +137,7 @@ suite('Workspace Experiments Test Suite', () => {
       )
 
       stub(CliExecutor.prototype, 'experimentRunQueue').callsFake(() => {
-        clock.tick(duration)
+        fakeTimers.advance(duration)
         throw new Error(mockErrorMessage)
       })
 
@@ -158,8 +158,6 @@ suite('Workspace Experiments Test Suite', () => {
       )
       expect(mockGenericError, 'the generic error should be shown').to.be
         .calledOnce
-
-      clock.restore()
     })
   })
 

--- a/extension/src/test/suite/extension.test.ts
+++ b/extension/src/test/suite/extension.test.ts
@@ -1,11 +1,12 @@
 import { join, resolve } from 'path'
 import { afterEach, beforeEach, describe, it, suite } from 'mocha'
 import { expect } from 'chai'
-import { stub, restore, spy, useFakeTimers, match } from 'sinon'
+import { stub, restore, spy, match } from 'sinon'
 import { window, commands, workspace, Uri } from 'vscode'
 import {
   closeAllEditors,
   configurationChangeEvent,
+  FakeTimersDisposable,
   quickPickInitialized,
   selectQuickPickItem
 } from './util'
@@ -301,7 +302,7 @@ suite('Extension Test Suite', () => {
     }).timeout(25000)
 
     it('should send an error telemetry event when setupWorkspace fails', async () => {
-      const clock = useFakeTimers()
+      disposable.track(new FakeTimersDisposable())
       const mockErrorMessage = 'NOPE'
       stub(Setup, 'setupWorkspace').rejects(new Error(mockErrorMessage))
       const mockSendTelemetryEvent = stub(Telemetry, 'sendTelemetryEvent')
@@ -315,19 +316,17 @@ suite('Extension Test Suite', () => {
         { error: mockErrorMessage },
         { duration: 0 }
       )
-
-      clock.restore()
     })
   })
 
   describe('dvc.stopRunningExperiment', () => {
     it('should send a telemetry event containing properties relating to the event', async () => {
-      const clock = useFakeTimers()
+      const fakeTimers = disposable.track(new FakeTimersDisposable())
       const duration = 1234
       const mockSendTelemetryEvent = stub(Telemetry, 'sendTelemetryEvent')
 
       const stop = commands.executeCommand(RegisteredCommands.STOP_EXPERIMENT)
-      clock.tick(duration)
+      fakeTimers.advance(duration)
       await stop
 
       expect(mockSendTelemetryEvent).to.be.calledWith(
@@ -340,8 +339,6 @@ suite('Extension Test Suite', () => {
           duration
         }
       )
-
-      clock.restore()
     })
   })
 

--- a/extension/src/test/suite/repository/index.test.ts
+++ b/extension/src/test/suite/repository/index.test.ts
@@ -1,26 +1,25 @@
 import { afterEach, beforeEach, describe, it, suite } from 'mocha'
 import { expect } from 'chai'
-import { stub, restore, useFakeTimers, SinonFakeTimers } from 'sinon'
+import { stub, restore } from 'sinon'
 import { Disposable } from '../../../extension'
 import { CliReader } from '../../../cli/reader'
 import { Config } from '../../../config'
 import { InternalCommands } from '../../../commands/internal'
 import { Repository } from '../../../repository'
-import { dvcDemoPath } from '../util'
+import { dvcDemoPath, FakeTimersDisposable } from '../util'
 import { OutputChannel } from '../../../vscode/outputChannel'
 
 suite('Repository Test Suite', () => {
   const disposable = Disposable.fn()
-  let clock: SinonFakeTimers
+  let fakeTimers: FakeTimersDisposable
 
   beforeEach(() => {
     restore()
-    clock = useFakeTimers(new Date())
+    fakeTimers = disposable.track(new FakeTimersDisposable())
   })
 
   afterEach(() => {
     disposable.dispose()
-    clock.restore()
   })
 
   const buildRepository = () => {
@@ -47,7 +46,7 @@ suite('Repository Test Suite', () => {
     it('should not queue a reset within 200ms of one starting', async () => {
       const { mockDiff, mockList, mockStatus, repository } = buildRepository()
 
-      clock.tick(50)
+      fakeTimers.advance(50)
 
       await Promise.all([
         repository.isReady(),
@@ -67,13 +66,13 @@ suite('Repository Test Suite', () => {
       const { mockDiff, mockList, mockStatus, repository } = buildRepository()
 
       await repository.isReady()
-      clock.tick(200)
+      fakeTimers.advance(200)
       mockList.resetHistory()
       mockDiff.resetHistory()
       mockStatus.resetHistory()
 
       const firstUpdate = repository.update()
-      clock.tick(50)
+      fakeTimers.advance(50)
 
       await Promise.all([
         firstUpdate,
@@ -90,7 +89,7 @@ suite('Repository Test Suite', () => {
 
     it('should debounce all calls made within 200ms of a reset', async () => {
       const { mockDiff, mockList, mockStatus, repository } = buildRepository()
-      clock.tick(50)
+      fakeTimers.advance(50)
 
       await Promise.all([
         repository.isReady(),
@@ -113,11 +112,11 @@ suite('Repository Test Suite', () => {
 
       await repository.isReady()
       mockReset.restore()
-      clock.tick(200)
+      fakeTimers.advance(200)
 
       const firstUpdate = repository.update()
       const firstReset = repository.reset()
-      clock.tick(50)
+      fakeTimers.advance(50)
 
       await Promise.all([
         firstUpdate,

--- a/extension/src/test/suite/util.ts
+++ b/extension/src/test/suite/util.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'path'
-import { SinonSpy, SinonStub } from 'sinon'
+import { SinonSpy, SinonStub, useFakeTimers } from 'sinon'
 import {
   commands,
   ConfigurationChangeEvent,
@@ -79,5 +79,21 @@ export const getActiveTextEditorFilename = (): string | undefined =>
 export const closeAllEditors = async () => {
   if (definedAndNonEmpty(window.visibleTextEditors)) {
     await commands.executeCommand('workbench.action.closeAllEditors')
+  }
+}
+
+export class FakeTimersDisposable {
+  clock = useFakeTimers({
+    now: new Date(),
+    toFake: ['setTimeout', 'Date']
+  })
+
+  public advance(ms: number) {
+    this.clock.tick(ms)
+  }
+
+  public dispose() {
+    this.clock.runAll()
+    this.clock.restore()
   }
 }


### PR DESCRIPTION
I managed to identify that our use of `useFakeTimers` was causing some tests to hang. The hard part was then working out how to fix them.

I saw this line on a couple of random runs when trying to debug: `FakeTimers: clearTimeout was invoked to clear a native timer instead of one created by this library. To automatically clean-up native timers, use 'shouldClearNativeTimers'.`

I then had to experiment/read the `Sinon` docs to work out what is going on. The short answer is that I am not sure if the breaking change has occurred in the upgrade from `Sinon` 11 to 12 or in the insiders build or a combination of both (or neither) but I have come up with a fix**. 

I have annotated the PR with some of my findings.

LMK if you'd like to see any changes.

**I would expect that the breakage actually came in the insiders build as the CI was running fine on `Sinon` 12 yesterday. 