### PR TITLE
Remove unused/broken CI caches

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -27,27 +27,6 @@ jobs:
           node-version: '14'
           cache: 'yarn'
 
-      - uses: actions/cache@v2
-        name: Restore NYC cache
-        id: nyc-cache
-        with:
-          path: extension/.cache/nyc
-          key: nyc
-
-      - uses: actions/cache@v2
-        name: Restore ESLint cache
-        id: eslint-cache
-        with:
-          path: .eslintcache
-          key: eslint-cache
-
-      - uses: actions/cache@v2
-        name: Restore .vscode-test cache
-        id: vscode-cache
-        with:
-          path: extension/.vscode-test
-          key: vscode-test
-
       - run: yarn run install-frozen-lockfile
 
       - run: yarn run lint

--- a/.github/workflows/cross-platform-test.yml
+++ b/.github/workflows/cross-platform-test.yml
@@ -23,13 +23,6 @@ jobs:
           node-version: '14'
           cache: yarn
 
-      - uses: actions/cache@v2
-        name: Restore .vscode-test cache
-        id: vscode-cache
-        with:
-          path: extension/.vscode-test
-          key: vscode-test-${{ matrix.os }}
-
       - run: yarn install
 
       - run: yarn run test:jest


### PR DESCRIPTION
Our manual caching of folders does not work as expected. The biggest offender is the `.vscode-test` folder. We are carrying a cache that is months old and we still have to download VS Code each time we run the CI.

From the CI:

```
webpack 5.64.1 compiled with 3 warnings in 57441 ms
$ yarn workspace dvc run test-vscode-run
warning dvc@0.2.0: The engine "vscode" appears to be invalid.
$ node ./dist/test/runTest.js
Remove outdated Insiders at D:\a\vscode-dvc\vscode-dvc\extension\.vscode-test\vscode-win32-archive-insiders and re-downloading.
Old: bb9491d9f2c65510226dcc920a6efbf6501d5943 | 2021-09-07T05:16:05.847Z
New: 1e473b624f088fc05269891170a8ffa1c84a35a6 | 2021-11-25T07:57:34.843Z
Removed D:\a\vscode-dvc\vscode-dvc\extension\.vscode-test\vscode-win32-archive-insiders
Downloading VS Code insiders from https://update.code.visualstudio.com/latest/win32-archive/insiderDownloaded VS Code insiders into D:\a\vscode-dvc\vscode-dvc\extension\.vscode-test\vscode-win32-archive-insiders
```
Then in `Post Restore .vscode-test cache` we have:
`Cache hit occurred on the primary key vscode-test, not saving cache.`

Notice that we have been carrying the same outdated version VS Code in the cache since ~`2021-09-07T05:16:05.847Z`.

We get the same messages for the other `actions/cache@v2` caches that we use. I suspect that they are also out of date. They contain `1393 B` & `207 B` respectively so I don't see the point of carrying them at all.

I have no idea how I have missed this up until now.

I have looked around other extensions and I cannot find a single instance of someone attempting to cache the `.vscode-test` folder. ~If we can work out a way to make it work in the future then we can bring the step back.~ We are always going to have to download the folder once, might as well just download it from source and save ourselves the hassle of trying to work out how to build some kind of custom cache mechanism.