### PR TITLE
Add eslint-plugin-testing-library

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
   ],
   overrides: [
     {
+      extends: ['plugin:testing-library/react'],
       // Jest tests rely on a lot of undefined globals
       files: ['**/*.test.*'],
       rules: {
@@ -59,10 +60,11 @@ module.exports = {
   plugins: [
     '@typescript-eslint',
     'jest',
-    'react-hooks',
     'jsx-a11y',
+    'react-hooks',
     'sonarjs',
-    'sort-keys-fix'
+    'sort-keys-fix',
+    'testing-library'
   ],
   root: true,
   rules: {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-sonarjs": "^0.10.0",
     "eslint-plugin-sort-keys-fix": "^1.1.1",
+    "eslint-plugin-testing-library": "^5.0.0",
     "husky": "^7.0.4",
     "jest": "^27.3.1",
     "lint-staged": "^12.0.3",

--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -2,13 +2,7 @@
  * @jest-environment jsdom
  */
 import React from 'react'
-import {
-  render,
-  cleanup,
-  waitFor,
-  screen,
-  fireEvent
-} from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import { mocked } from 'ts-jest/utils'
 import rowsFixture from 'dvc/src/test/fixtures/expShow/rows'
@@ -56,9 +50,8 @@ describe('App', () => {
 
       it('Then the empty state should be displayed', async () => {
         render(<App />)
-        const emptyState = await waitFor(() =>
-          screen.getByText('Loading experiments...')
-        )
+        const emptyState = await screen.findByText('Loading experiments...')
+
         expect(emptyState).toBeInTheDocument()
       })
     })
@@ -77,11 +70,11 @@ describe('App', () => {
     })
 
     describe('When we render the App and send the message', () => {
-      it('Then the experiments table should be shown', async () => {
+      it('Then the experiments table should be shown', () => {
         render(<App />)
         fireEvent(customWindow, messageToChangeState)
 
-        await waitFor(() => screen.queryAllByText('Experiment'))
+        screen.queryAllByText('Experiment')
         const emptyState = screen.queryByText('Loading experiments...')
         expect(emptyState).not.toBeInTheDocument()
       })

--- a/webview/src/experiments/components/CopyButton/index.test.tsx
+++ b/webview/src/experiments/components/CopyButton/index.test.tsx
@@ -4,13 +4,12 @@
 /* eslint-disable sonarjs/no-identical-functions */
 import React from 'react'
 import {
-  render,
-  cleanup,
-  getByTitle,
   act,
-  waitFor,
-  findByTitle,
-  fireEvent
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor
 } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import { CopyButton } from '.'
@@ -36,71 +35,67 @@ describe('CopyButton', () => {
 
   it('should call writeText with the value prop and show the success icon for a second when writeText resolves', async () => {
     mockWriteText.mockResolvedValueOnce(undefined)
-    const { container } = render(<CopyButton value={exampleCopyText} />)
-    const copyButtonElement = getByTitle(container, defaultStateTitle)
-    await act(async () => {
-      fireEvent.click(copyButtonElement, {
-        bubbles: true,
-        cancelable: true
-      })
-      await waitFor(() => findByTitle(container, successStateTitle))
+    render(<CopyButton value={exampleCopyText} />)
+    const copyButtonElement = screen.getByTitle(defaultStateTitle)
+
+    fireEvent.click(copyButtonElement, {
+      bubbles: true,
+      cancelable: true
     })
+    await waitFor(() => screen.findByTitle(successStateTitle))
+
     expect(mockWriteText).toBeCalledWith(exampleCopyText)
-    await act(async () => {
+    act(() => {
       jest.advanceTimersByTime(1000)
-      await waitFor(() =>
-        expect(getByTitle(container, defaultStateTitle)).toBeInTheDocument()
-      )
     })
+    expect(await screen.findByTitle(defaultStateTitle)).toBeInTheDocument()
   })
 
   it('should call writeText with the value prop and show the failure icon for a second when writeText rejects', async () => {
     mockWriteText.mockRejectedValueOnce(new Error('Copying is not allowed!'))
-    const { container } = render(<CopyButton value={exampleCopyText} />)
-    const copyButtonElement = getByTitle(container, defaultStateTitle)
-    await act(async () => {
-      fireEvent.click(copyButtonElement, {
-        bubbles: true,
-        cancelable: true
-      })
-      await waitFor(() => findByTitle(container, failureStateTitle))
+    render(<CopyButton value={exampleCopyText} />)
+    const copyButtonElement = screen.getByTitle(defaultStateTitle)
+
+    fireEvent.click(copyButtonElement, {
+      bubbles: true,
+      cancelable: true
     })
+
+    await screen.findByTitle(failureStateTitle)
+
     expect(mockWriteText).toBeCalledWith(exampleCopyText)
-    await act(async () => {
+    act(() => {
       jest.advanceTimersByTime(1000)
-      await waitFor(() =>
-        expect(getByTitle(container, defaultStateTitle)).toBeInTheDocument()
-      )
     })
+
+    expect(await screen.findByTitle(defaultStateTitle)).toBeInTheDocument()
   })
 
   it('should restart the state reset timer if clicked while in the success state', async () => {
     mockWriteText.mockResolvedValueOnce(undefined)
-    const { container } = render(<CopyButton value={exampleCopyText} />)
-    const copyButtonElement = getByTitle(container, defaultStateTitle)
+    render(<CopyButton value={exampleCopyText} />)
+    const copyButtonElement = screen.getByTitle(defaultStateTitle)
 
     // Click once
-    await act(async () => {
-      fireEvent.click(copyButtonElement, {
-        bubbles: true,
-        cancelable: true
-      })
-      await waitFor(() => findByTitle(container, successStateTitle))
+    fireEvent.click(copyButtonElement, {
+      bubbles: true,
+      cancelable: true
     })
+    await screen.findByTitle(successStateTitle)
+
     jest.advanceTimersByTime(500)
 
     // Click again while still in success state
     mockWriteText.mockResolvedValueOnce(undefined)
-    await act(async () => {
-      fireEvent.click(copyButtonElement, {
-        bubbles: true,
-        cancelable: true
-      })
-      await waitFor(() => findByTitle(container, successStateTitle))
+
+    fireEvent.click(copyButtonElement, {
+      bubbles: true,
+      cancelable: true
     })
+    await screen.findByTitle(successStateTitle)
 
     // Ensure state hasn't returned to default after it would have from the first click
     jest.advanceTimersByTime(600)
-    expect(getByTitle(container, successStateTitle)).toBeInTheDocument()
+    expect(screen.getByTitle(successStateTitle)).toBeInTheDocument()
   })
 })

--- a/webview/src/experiments/components/Table/Table.test.tsx
+++ b/webview/src/experiments/components/Table/Table.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import '@testing-library/jest-dom/extend-expect'
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
 import { SortDefinition } from 'dvc/src/experiments/model/sortBy'
 import { Experiment, TableData } from 'dvc/src/experiments/webview/contract'
 import React from 'react'
@@ -26,6 +26,10 @@ import { Model } from '../../model'
 jest.mock('../../../shared/api')
 
 describe('Table', () => {
+  const getParentElement = async (text: string) =>
+    // eslint-disable-next-line testing-library/no-node-access
+    (await screen.findByText(text))?.parentElement
+
   const model = new Model()
   const getProps = (props: React.ReactPropTypes) => ({ ...props })
   const headerGroupBasicProps = {
@@ -149,9 +153,7 @@ describe('Table', () => {
 
     it('should not have any sorting classes if the sorts property is empty', async () => {
       renderTable()
-      const column = await waitFor(
-        () => screen.getByText('Timestamp')?.parentElement
-      )
+      const column = await getParentElement('Timestamp')
 
       expect(column?.className.includes(styles.sortingHeaderCellDesc)).toBe(
         false
@@ -164,9 +166,7 @@ describe('Table', () => {
     it('should apply the sortingHeaderCellAsc on the timestamp column if it is not descending in the sorts property', async () => {
       renderTable([{ descending: false, path: 'timestamp' }])
 
-      const column = await waitFor(
-        () => screen.getByText('Timestamp')?.parentElement
-      )
+      const column = await getParentElement('Timestamp')
 
       expect(column?.className.includes(styles.sortingHeaderCellDesc)).toBe(
         false
@@ -177,9 +177,7 @@ describe('Table', () => {
     it('should apply the sortingHeaderCellDesc on the timestamp column if it is descending in the sorts property', async () => {
       renderTable([{ descending: true, path: 'timestamp' }])
 
-      const column = await waitFor(
-        () => screen.getByText('Timestamp')?.parentElement
-      )
+      const column = await getParentElement('Timestamp')
 
       expect(column?.className.includes(styles.sortingHeaderCellDesc)).toBe(
         true
@@ -192,9 +190,7 @@ describe('Table', () => {
     it('should apply the sorting class if the cell is a placeholder above the column header when the sort is ascending', async () => {
       renderTableWithPlaceholder(false)
 
-      const header = await waitFor(() =>
-        screen.getByTestId(`header-${placeholderId}`)
-      )
+      const header = await screen.findByTestId(`header-${placeholderId}`)
 
       expect(header?.className.includes(styles.sortingHeaderCellAsc)).toBe(true)
     })
@@ -202,9 +198,7 @@ describe('Table', () => {
     it('should not apply the sorting class if there is a placeholder above the column header when the sort is ascending', async () => {
       renderTableWithPlaceholder(false)
 
-      const column = await waitFor(
-        () => screen.getByText('Timestamp')?.parentElement
-      )
+      const column = await getParentElement('Timestamp')
 
       expect(column?.className.includes(styles.sortingHeaderCellAsc)).toBe(
         false
@@ -214,9 +208,7 @@ describe('Table', () => {
     it('should not apply the sorting class if the cell is a placeholder above the column header when the sort is descending', async () => {
       renderTableWithPlaceholder(true)
 
-      const header = await waitFor(() =>
-        screen.getByTestId(`header-${placeholderId}`)
-      )
+      const header = await screen.findByTestId(`header-${placeholderId}`)
 
       expect(header?.className.includes(styles.sortingHeaderCellDesc)).toBe(
         false
@@ -226,9 +218,7 @@ describe('Table', () => {
     it('should apply the sorting class if there is a placeholder above the column header when the sort is descending', async () => {
       renderTableWithPlaceholder(true)
 
-      const column = await waitFor(
-        () => screen.getByText('Timestamp')?.parentElement
-      )
+      const column = await getParentElement('Timestamp')
 
       expect(column?.className.includes(styles.sortingHeaderCellDesc)).toBe(
         true
@@ -240,7 +230,7 @@ describe('Table', () => {
     it('should not have the workspaceWithChanges class on a row if there are no workspace changes', async () => {
       renderTable()
 
-      const row = await waitFor(() => screen.getByTestId('workspace-row'))
+      const row = await screen.findByTestId('workspace-row')
 
       expect(row?.className.includes(styles.workspaceWithChanges)).toBe(false)
     })
@@ -248,7 +238,7 @@ describe('Table', () => {
     it('should have the workspaceWithChanges class on a row if there are workspace changes', async () => {
       renderTable(undefined, undefined, ['something_changed'])
 
-      const row = await waitFor(() => screen.getByTestId('workspace-row'))
+      const row = await screen.findByTestId('workspace-row')
 
       expect(row?.className.includes(styles.workspaceWithChanges)).toBe(true)
     })
@@ -256,9 +246,7 @@ describe('Table', () => {
     it('should not have the workspaceChange class on a cell if there are no changes', async () => {
       renderTable()
 
-      const row = await waitFor(() =>
-        screen.getByTestId('timestamp___workspace')
-      )
+      const row = await screen.findByTestId('timestamp___workspace')
 
       expect(row?.className.includes(styles.workspaceChange)).toBe(false)
     })
@@ -266,9 +254,7 @@ describe('Table', () => {
     it('should not have the workspaceChange class on a cell if there are changes to other columns but not this one', async () => {
       renderTable(undefined, undefined, ['a_change'])
 
-      const row = await waitFor(() =>
-        screen.getByTestId('timestamp___workspace')
-      )
+      const row = await screen.findByTestId('timestamp___workspace')
 
       expect(row?.className.includes(styles.workspaceChange)).toBe(false)
     })
@@ -276,9 +262,7 @@ describe('Table', () => {
     it('should have the workspaceChange class on a cell if there are changes matching the column id', async () => {
       renderTable(undefined, undefined, ['timestamp'])
 
-      const row = await waitFor(() =>
-        screen.getByTestId('timestamp___workspace')
-      )
+      const row = await screen.findByTestId('timestamp___workspace')
 
       expect(row?.className.includes(styles.workspaceChange)).toBe(true)
     })
@@ -319,14 +303,15 @@ describe('Table', () => {
     }
 
     const renderExperimentsTable = (data: TableData = tableData) => {
-      const table = render(<ExperimentsTable tableData={data} model={model} />)
+      const view = render(<ExperimentsTable tableData={data} model={model} />)
 
-      mockDndElSpacing(table)
+      mockDndElSpacing(view)
 
       const makeGetDragEl = (text: string) => () =>
-        table.getByText(text).closest(DND_DRAGGABLE_DATA_ATTR)
+        // eslint-disable-next-line testing-library/no-node-access
+        screen.getByText(text).closest(DND_DRAGGABLE_DATA_ATTR)
 
-      return { makeGetDragEl, ...table }
+      return { makeGetDragEl, ...view }
     }
 
     const defaultCols = ['Experiment', 'Timestamp']
@@ -347,8 +332,8 @@ describe('Table', () => {
     it('should move a column from its current position to its new position', async () => {
       const { getByText, makeGetDragEl } = renderExperimentsTable()
 
-      let headers = await waitFor(() =>
-        screen.getAllByTestId('rendered-header').map(header => header.innerHTML)
+      let headers = (await screen.findAllByTestId('rendered-header')).map(
+        header => header.innerHTML
       )
 
       expect(headers).toEqual([...defaultCols, 'A', 'B', 'C'])
@@ -360,9 +345,10 @@ describe('Table', () => {
         positions: 1
       })
 
-      headers = await waitFor(() =>
-        screen.getAllByTestId('rendered-header').map(header => header.innerHTML)
+      headers = (await screen.findAllByTestId('rendered-header')).map(
+        header => header.innerHTML
       )
+
       expect(headers).toEqual([...defaultCols, 'A', 'C', 'B'])
 
       await makeDnd({
@@ -372,17 +358,18 @@ describe('Table', () => {
         positions: 2
       })
 
-      headers = await waitFor(() =>
-        screen.getAllByTestId('rendered-header').map(header => header.innerHTML)
+      headers = (await screen.findAllByTestId('rendered-header')).map(
+        header => header.innerHTML
       )
+
       expect(headers).toEqual([...defaultCols, 'C', 'B', 'A'])
     })
 
     it('should not move a column before the default columns', async () => {
       const { getByText, makeGetDragEl } = renderExperimentsTable()
 
-      const headers = await waitFor(() =>
-        screen.getAllByTestId('rendered-header').map(header => header.innerHTML)
+      const headers = (await screen.findAllByTestId('rendered-header')).map(
+        header => header.innerHTML
       )
 
       await makeDnd({
@@ -409,8 +396,8 @@ describe('Table', () => {
       }
       renderExperimentsTable(tableDataWithCustomColOrder)
 
-      const headers = await waitFor(() =>
-        screen.getAllByTestId('rendered-header').map(header => header.innerHTML)
+      const headers = (await screen.findAllByTestId('rendered-header')).map(
+        header => header.innerHTML
       )
 
       expect(headers).toEqual([...defaultCols, 'C', 'B', 'A'])

--- a/webview/src/plots/components/App.test.tsx
+++ b/webview/src/plots/components/App.test.tsx
@@ -97,9 +97,8 @@ describe('App', () => {
 
   it('should render the loading state when given no data', async () => {
     render(<App />)
-    const loadingState = await waitFor(() =>
-      screen.getByText('Loading Plots...')
-    )
+    const loadingState = await screen.findByText('Loading Plots...')
+
     expect(loadingState).toBeInTheDocument()
   })
 
@@ -112,9 +111,8 @@ describe('App', () => {
     })
     render(<App />)
     fireEvent(window, dataMessageWithoutPlots)
-    const emptyState = await waitFor(() =>
-      screen.getByText('No Plots to Display')
-    )
+    const emptyState = await screen.findByText('No Plots to Display')
+
     expect(emptyState).toBeInTheDocument()
   })
 
@@ -130,7 +128,7 @@ describe('App', () => {
     fireEvent(window, dataMessageWithPlots)
 
     expect(screen.queryByText('Loading Plots...')).not.toBeInTheDocument()
-    expect(screen.queryByText('Live Experiments Plots')).toBeInTheDocument()
+    expect(screen.getByText('Live Experiments Plots')).toBeInTheDocument()
     expect(screen.queryByText('Static Plots')).not.toBeInTheDocument()
   })
 
@@ -146,8 +144,8 @@ describe('App', () => {
     fireEvent(window, dataMessageWithPlots)
 
     expect(screen.queryByText('Loading Plots...')).not.toBeInTheDocument()
-    expect(screen.queryByText('Live Experiments Plots')).toBeInTheDocument()
-    expect(screen.queryByText('Static Plots')).toBeInTheDocument()
+    expect(screen.getByText('Live Experiments Plots')).toBeInTheDocument()
+    expect(screen.getByText('Static Plots')).toBeInTheDocument()
   })
 
   it('should toggle the live plots section in state when its header is clicked', async () => {
@@ -159,17 +157,19 @@ describe('App', () => {
     }
     mockGetState.mockReturnValue(initialState)
     render(<App />)
-    const summaryElement = await waitFor(() =>
-      screen.getByText('Live Experiments Plots')
-    )
+    const summaryElement = await screen.findByText('Live Experiments Plots')
+    const [plot] = await screen.findAllByLabelText('Vega visualization')
+    expect(plot).toBeInTheDocument()
+
     fireEvent.click(summaryElement, {
       bubbles: true,
       cancelable: true
     })
     await waitFor(() => expect(mockSetState).toBeCalledTimes(2))
-    expect((summaryElement.parentElement as HTMLDetailsElement).open).toBe(
-      false
-    )
+
+    expect(
+      screen.queryByLabelText('Vega visualization')
+    ).not.toBeInTheDocument()
     expect(mockSetState).toBeCalledWith({
       ...initialState,
       collapsedSections: {

--- a/webview/src/shared/components/hoverMenu/HoverMenu.test.tsx
+++ b/webview/src/shared/components/hoverMenu/HoverMenu.test.tsx
@@ -40,7 +40,7 @@ describe('HoverMenu', () => {
     )
     rerender(<HoverMenu>Bye!</HoverMenu>)
 
-    await waitForElementToBeRemoved(() => screen.getByTestId('hover-menu'))
+    await waitForElementToBeRemoved(() => screen.queryByTestId('hover-menu'))
 
     expect(screen.queryByTestId('hover-menu')).not.toBeInTheDocument()
   })

--- a/webview/src/shared/components/iconMenu/IconMenuItem.test.tsx
+++ b/webview/src/shared/components/iconMenu/IconMenuItem.test.tsx
@@ -61,7 +61,7 @@ describe('IconMenuItem', () => {
 
     fireEvent.mouseLeave(screen.getByTestId('icon-menu-item'))
 
-    await waitForElementToBeRemoved(() => screen.getByTestId('hover-menu'))
+    await waitForElementToBeRemoved(() => screen.queryByTestId('hover-menu'))
 
     expect(screen.queryByTestId('hover-menu')).not.toBeInTheDocument()
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -7076,6 +7076,13 @@ eslint-plugin-sort-keys-fix@^1.1.1:
     natural-compare "^1.4.0"
     requireindex "~1.2.0"
 
+eslint-plugin-testing-library@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.0.0.tgz#eb98bcecf44bbdb0df4e78bb58e87a05685b38e0"
+  integrity sha512-lojlPN8nsb7JTFYhJuLNwwI8kALRC0TBz5JRO1lvV7Ifzqu7IoddjDFRCxeM+0d2/zuEO7Sb5oc7ErDqhd4MBw==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^5.0.0"
+
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
# 2/2 `master` <- #1096 <- this

This PR adds `eslint-plugin-testing-library` and apply all of the necessary fixes to make the pipeline pass. The introduction of this plugin will help us to avoid some obvious traps when writing these tests and make our use of the library more consistent. 

Docs are [here](https://github.com/testing-library/eslint-plugin-testing-library).