### PR TITLE
Use svgr for clock icon in experiments table

### DIFF
--- a/webview/icons/clock.svg
+++ b/webview/icons/clock.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M14 8C14 11.3137 11.3137 14 8 14C4.68629 14 2 11.3137 2 8C2 4.68629 4.68629 2 8 2C11.3137 2 14 4.68629 14 8ZM15 8C15 11.866 11.866 15 8 15C4.13401 15 1 11.866 1 8C1 4.13401 4.13401 1 8 1C11.866 1 15 4.13401 15 8ZM7 4V9V9.5H7.5H10V8.5H8V4H7Z" fill="currentColor"/>
+</svg>

--- a/webview/src/experiments/components/Table/Table.test.tsx
+++ b/webview/src/experiments/components/Table/Table.test.tsx
@@ -41,7 +41,11 @@ describe('Table', () => {
   const basicCellProps = {
     getCellProps: getProps,
     row: {
-      id: 'workspace'
+      id: 'workspace',
+      original: {
+        queued: false,
+        running: false
+      }
     }
   }
   const instance = {

--- a/webview/src/experiments/components/Table/index.tsx
+++ b/webview/src/experiments/components/Table/index.tsx
@@ -6,6 +6,7 @@ import { SortDefinition } from 'dvc/src/experiments/model/sortBy'
 import styles from './styles.module.scss'
 import { TableHead } from './TableHead'
 import { Model } from '../../model'
+import ClockIcon from '../../../shared/components/icons/Clock'
 export interface InstanceProp {
   instance: TableInstance<Experiment>
 }
@@ -76,7 +77,9 @@ const FirstCell: React.FC<{
           />
         )}
       </span>
-      <span className={styles.bullet} style={{ color: bulletColor }} />
+      <span className={styles.bullet} style={{ color: bulletColor }}>
+        {cell.row.original.queued && <ClockIcon />}
+      </span>
       {cell.isPlaceholder ? null : cell.render('Cell')}
     </div>
   )

--- a/webview/src/experiments/components/Table/styles.module.scss
+++ b/webview/src/experiments/components/Table/styles.module.scss
@@ -60,6 +60,9 @@ $spinner-color-light: #000;
   flex: 0 0 24px;
   text-align: center;
   position: relative;
+  .queuedExperiment & svg {
+    height: 12px;
+  }
 
   &::before {
     display: inline-block;
@@ -83,16 +86,7 @@ $spinner-color-light: #000;
       border: 1px solid currentColor;
     }
     .queuedExperiment & {
-      width: 12px;
-      height: 12px;
-      background-image: url('dvc/resources/dark/clock.svg');
-      background-size: contain;
-
-      @at-root {
-        :global(.vscode-light) & {
-          background-image: url('dvc/resources/light/clock.svg');
-        }
-      }
+      display: none;
     }
     .runningExperiment & {
       width: 4px;

--- a/webview/src/shared/components/icons/Clock.tsx
+++ b/webview/src/shared/components/icons/Clock.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+
+function SvgClock(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M14 8A6 6 0 112 8a6 6 0 0112 0zm1 0A7 7 0 111 8a7 7 0 0114 0zM7 4v5.5h3v-1H8V4H7z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}
+
+export default SvgClock

--- a/webview/src/shared/components/icons/index.tsx
+++ b/webview/src/shared/components/icons/index.tsx
@@ -1,2 +1,3 @@
 export { default as Check } from './Check'
+export { default as Clock } from './Clock'
 export { default as Copy } from './Copy'


### PR DESCRIPTION
Fixes #1082 

This PR replaces the CSS `background-image` svg with an SVGR-based one for queued experiments bullets. I also can't seem to get the clock bullets on master, not sure if that's webpack weirdness or they've just been broken this whole time and we haven't noticed.

After this, all webview SVGs will be imported the same way, via SVGR.

Old:
![old dark queued experiment](https://user-images.githubusercontent.com/9111807/143953517-c12af26f-ca5e-4080-a98d-0f7d193ddfa1.png)
![old light queued experiment](https://user-images.githubusercontent.com/9111807/143953469-369c7227-505e-4ff9-abd7-e292a5d78869.png)

New:
![new dark queued experiment](https://user-images.githubusercontent.com/9111807/143953173-22d162fd-ef67-4961-befb-37d2e3ea418b.png)
![new light queued experiment](https://user-images.githubusercontent.com/9111807/143953329-10bf37f9-b87e-4414-a264-39ba263f4108.png)
