### PR TITLE
Remove createCustomWindow

### DIFF
--- a/webview/jest.config.js
+++ b/webview/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
     '\\.(scss|css|less)$': 'identity-obj-proxy'
   },
   preset: 'ts-jest',
-  setupFiles: ['jest-canvas-mock'],
+  setupFiles: ['jest-canvas-mock', '<rootDir>/setup-tests.js'],
   testEnvironment: 'node',
   testTimeout: 10000
 }

--- a/webview/setup-tests.js
+++ b/webview/setup-tests.js
@@ -1,0 +1,4 @@
+/* eslint-disable */
+window = {
+  addEventListener: jest.fn()
+}

--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -16,13 +16,11 @@ import { vsCodeApi } from '../../shared/api'
 
 jest.mock('../../shared/api')
 
-const { postMessage, getState } = vsCodeApi
+const { postMessage } = vsCodeApi
 const mockPostMessage = mocked(postMessage)
-const mockGetState = mocked(getState)
 
 beforeEach(() => {
   jest.clearAllMocks()
-  mockGetState.mockReturnValueOnce({})
 })
 
 afterEach(() => {

--- a/webview/src/experiments/hooks/useColumnOrder.test.ts
+++ b/webview/src/experiments/hooks/useColumnOrder.test.ts
@@ -1,7 +1,6 @@
 import { ColumnDetail } from 'dvc/src/experiments/webview/contract'
 import { useColumnOrder } from './useColumnsOrder'
 import { Model } from '../model'
-import { createCustomWindow } from '../../test/util'
 
 jest.mock('react', () => ({
   useMemo: (fn: (...args: unknown[]) => unknown) => fn()
@@ -9,10 +8,6 @@ jest.mock('react', () => ({
 jest.mock('../../shared/api')
 
 describe('useColumnsOrder', () => {
-  beforeAll(() => {
-    createCustomWindow()
-  })
-
   it('should return re-sorted columns with groups and generated parents', () => {
     const columns = [
       {

--- a/webview/src/experiments/hooks/useColumnResize.test.ts
+++ b/webview/src/experiments/hooks/useColumnResize.test.ts
@@ -1,14 +1,9 @@
 import { useColumnResize } from './useColumnResize'
 import { Model } from '../model'
-import { createCustomWindow } from '../../test/util'
 
 jest.mock('../../shared/api')
 
 describe('useColumnResize', () => {
-  beforeAll(() => {
-    createCustomWindow()
-  })
-
   it('should return the columns width', () => {
     const model = new Model()
     const expectedColumnsWidth = [

--- a/webview/src/experiments/model/model.test.ts
+++ b/webview/src/experiments/model/model.test.ts
@@ -1,7 +1,6 @@
 import { MessageFromWebviewType } from 'dvc/src/webview/contract'
 import { runInAction } from 'mobx'
 import { Model } from '.'
-import { createCustomWindow } from '../../test/util'
 
 jest.mock('../../shared/api')
 
@@ -16,10 +15,6 @@ describe('Model', () => {
   let model: Model
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let modelAsAny: any
-
-  beforeAll(() => {
-    createCustomWindow()
-  })
 
   beforeEach(() => {
     jest.resetAllMocks()


### PR DESCRIPTION
# #1104 <- this

As far as I know, `setupFiles` is the preferred method to do this sort of thing, especially where `createCustomWindow` does so little after #1104.

If `createCustomWindow` is how we want to add this mock, we can just use #1104 without this.