### PR TITLE
Give y axis in live plots an adaptive scale

### DIFF
--- a/webview/src/plots/components/constants.ts
+++ b/webview/src/plots/components/constants.ts
@@ -17,7 +17,7 @@ export const createSpec = (
       {
         encoding: {
           color: { field: 'group', legend: null, scale, type: 'nominal' },
-          y: { field: 'y', title, type: 'quantitative' }
+          y: { field: 'y', scale: { zero: false }, title, type: 'quantitative' }
         },
         layer: [
           { mark: 'line' },


### PR DESCRIPTION
From [this feedback](https://iterativeai.slack.com/archives/C01APS0FHDM/p1638432623095400?thread_ts=1638400988.092600&cid=C01APS0FHDM).

"One more thought: would be good to allow to change limits on X axis (automatically, maybe?), so we can really see the differences between lines when that difference (around 0.4 here) is much less than absolute value (~2.2 here)"

![image](https://user-images.githubusercontent.com/37993418/144509395-98a9515f-be60-49bd-b780-0b3faf7b3df1.png)

### Screenshot:

![Screen Shot 2021-12-03 at 8 51 10 am](https://user-images.githubusercontent.com/37993418/144509210-4fae5e00-9cbf-45e5-b300-fe98c33ce622.png)


