### PR TITLE
Change all instances of "columnsOrder" to "columnOrder"

### DIFF
--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -212,7 +212,7 @@ export class Experiments extends BaseRepository<TableData> {
   public getWebviewData() {
     return {
       changes: this.paramsAndMetrics.getChanges(),
-      columnOrder: this.paramsAndMetrics.getColumnsOrder(),
+      columnOrder: this.paramsAndMetrics.getColumnOrder(),
       columnWidths: this.paramsAndMetrics.getColumnWidths(),
       columns: this.paramsAndMetrics.getSelected(),
       rows: this.experiments.getRowData(),
@@ -242,7 +242,7 @@ export class Experiments extends BaseRepository<TableData> {
           case MessageFromWebviewType.COLUMN_REORDERED:
             return (
               message.payload &&
-              this.paramsAndMetrics.setColumnsOrder(
+              this.paramsAndMetrics.setColumnOrder(
                 message.payload as ColumnReorderPayload
               )
             )

--- a/extension/src/experiments/paramsAndMetrics/model.test.ts
+++ b/extension/src/experiments/paramsAndMetrics/model.test.ts
@@ -82,17 +82,17 @@ describe('ParamsAndMetricsModel', () => {
       const model = new ParamsAndMetricsModel(
         exampleDvcRoot,
         buildMockMemento({
-          [MementoPrefixes.COLUMNS_ORDER + exampleDvcRoot]: persistedState
+          [MementoPrefixes.COLUMN_ORDER + exampleDvcRoot]: persistedState
         })
       )
-      expect(model.getColumnsOrder()).toEqual(persistedState)
+      expect(model.getColumnOrder()).toEqual(persistedState)
     })
 
     it('should re-order the columns if a new columnOrder is set', () => {
       const model = new ParamsAndMetricsModel(
         exampleDvcRoot,
         buildMockMemento({
-          [MementoPrefixes.COLUMNS_ORDER + exampleDvcRoot]: [
+          [MementoPrefixes.COLUMN_ORDER + exampleDvcRoot]: [
             { path: 'A', width: 0 },
             { path: 'B', width: 0 },
             { path: 'C', width: 0 }
@@ -100,8 +100,8 @@ describe('ParamsAndMetricsModel', () => {
         })
       )
       const newState = ['C', 'B', 'A']
-      model.setColumnsOrder(newState)
-      expect(model.getColumnsOrder()).toEqual(newState)
+      model.setColumnOrder(newState)
+      expect(model.getColumnOrder()).toEqual(newState)
     })
   })
 
@@ -115,10 +115,10 @@ describe('ParamsAndMetricsModel', () => {
       const model = new ParamsAndMetricsModel(
         exampleDvcRoot,
         buildMockMemento({
-          [MementoPrefixes.COLUMNS_ORDER + exampleDvcRoot]: persistedState
+          [MementoPrefixes.COLUMN_ORDER + exampleDvcRoot]: persistedState
         })
       )
-      expect(model.getColumnsOrder()).toEqual(persistedState)
+      expect(model.getColumnOrder()).toEqual(persistedState)
     })
 
     it('should set the width to a column when calling setColumnWidth', () => {
@@ -130,7 +130,7 @@ describe('ParamsAndMetricsModel', () => {
       const model = new ParamsAndMetricsModel(
         exampleDvcRoot,
         buildMockMemento({
-          [MementoPrefixes.COLUMNS_ORDER + exampleDvcRoot]: persistedState
+          [MementoPrefixes.COLUMN_ORDER + exampleDvcRoot]: persistedState
         })
       )
       const changedColumnId = 'C'

--- a/extension/src/experiments/paramsAndMetrics/model.ts
+++ b/extension/src/experiments/paramsAndMetrics/model.ts
@@ -13,7 +13,7 @@ export enum Status {
 
 export const enum MementoPrefixes {
   STATUS = 'paramsAndMetricsStatus:',
-  COLUMNS_ORDER = 'paramsAndMetricsColumnsOrder:',
+  COLUMN_ORDER = 'paramsAndMetricsColumnOrder:',
   COLUMN_WIDTHS = 'paramsAndMetricsColumnWidths:'
 }
 
@@ -27,7 +27,7 @@ export class ParamsAndMetricsModel {
   private readonly dvcRoot: string
   private readonly workspaceState: Memento
 
-  private columnsOrderState: string[] = []
+  private columnOrderState: string[] = []
   private columnWidthsState: Record<string, number> = {}
   private paramsAndMetricsChanges: string[] = []
 
@@ -35,8 +35,8 @@ export class ParamsAndMetricsModel {
     this.dvcRoot = dvcRoot
     this.workspaceState = workspaceState
     this.status = workspaceState.get(MementoPrefixes.STATUS + dvcRoot, {})
-    this.columnsOrderState = workspaceState.get(
-      MementoPrefixes.COLUMNS_ORDER + dvcRoot,
+    this.columnOrderState = workspaceState.get(
+      MementoPrefixes.COLUMN_ORDER + dvcRoot,
       []
     )
     this.columnWidthsState = workspaceState.get(
@@ -45,8 +45,8 @@ export class ParamsAndMetricsModel {
     )
   }
 
-  public getColumnsOrder(): string[] {
-    return this.columnsOrderState
+  public getColumnOrder(): string[] {
+    return this.columnOrderState
   }
 
   public getColumnWidths(): Record<string, number> {
@@ -119,8 +119,8 @@ export class ParamsAndMetricsModel {
     return flatten<Status>(nestedStatuses)
   }
 
-  public setColumnsOrder(columnOrder: string[]) {
-    this.columnsOrderState = columnOrder
+  public setColumnOrder(columnOrder: string[]) {
+    this.columnOrderState = columnOrder
     this.persistColumnOrder()
   }
 
@@ -131,8 +131,8 @@ export class ParamsAndMetricsModel {
 
   private persistColumnOrder() {
     this.workspaceState.update(
-      MementoPrefixes.COLUMNS_ORDER + this.dvcRoot,
-      this.getColumnsOrder()
+      MementoPrefixes.COLUMN_ORDER + this.dvcRoot,
+      this.getColumnOrder()
     )
   }
 

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -169,7 +169,7 @@ suite('Experiments Test Suite', () => {
 
       const mockSetColumnReordered = stub(
         ParamsAndMetricsModel.prototype,
-        'setColumnsOrder'
+        'setColumnOrder'
       )
 
       const columnOrderSet = new Promise(resolve =>

--- a/webview/src/experiments/components/Table/TableHead.tsx
+++ b/webview/src/experiments/components/Table/TableHead.tsx
@@ -48,7 +48,7 @@ export const TableHead: React.FC<TableHeadProps> = ({
   }
 
   const onDragEnd = () => {
-    model.persistColumnsOrder(columnOrder)
+    model.persistColumnOrder(columnOrder)
   }
 
   return (

--- a/webview/src/experiments/model/index.ts
+++ b/webview/src/experiments/model/index.ts
@@ -76,7 +76,7 @@ export class Model {
     })
   }
 
-  public persistColumnsOrder(newOrder: string[]): void {
+  public persistColumnOrder(newOrder: string[]): void {
     const originalState = this.getState()
     const data = originalState.data as TableData
     vsCodeApi.setState({

--- a/webview/src/experiments/model/model.test.ts
+++ b/webview/src/experiments/model/model.test.ts
@@ -61,12 +61,12 @@ describe('Model', () => {
     })
   })
 
-  describe('createColumnsOrderRepresentation', () => {
+  describe('createColumnOrderRepresentation', () => {
     it('should send a message to notify of the changes if there is a new order set', () => {
       const sendMessageSpy = jest.spyOn(Model.prototype, 'sendMessage')
       sendMessageSpy.mockReset()
 
-      model.persistColumnsOrder(columnOrder)
+      model.persistColumnOrder(columnOrder)
 
       expect(sendMessageSpy).toHaveBeenCalledTimes(1)
       expect(sendMessageSpy).toHaveBeenCalledWith({


### PR DESCRIPTION
# #1116 <- this
`columnOrder` is what's given by `react-table`, changing our instances of `columnsOrder` keeps this piece of data consistently named across the codebase.

Only separate for diff reasons.