### PR TITLE
Match repository to experiments folder structure

### DIFF
--- a/extension/src/fileSystem/tree.ts
+++ b/extension/src/fileSystem/tree.ts
@@ -24,7 +24,7 @@ import { getWarningResponse } from '../vscode/modal'
 import { Response } from '../vscode/response'
 import { Resource } from '../repository/commands'
 import { WorkspaceRepositories } from '../repository/workspace'
-import { PathItem } from '../repository/collect'
+import { PathItem } from '../repository/data/collect'
 
 export class TrackedExplorerTree implements TreeDataProvider<PathItem> {
   public readonly dispose = Disposable.fn()

--- a/extension/src/repository/data/collect.test.ts
+++ b/extension/src/repository/data/collect.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import { Uri } from 'vscode'
 import { collectTree } from './collect'
-import { dvcDemoPath } from '../test/util'
+import { dvcDemoPath } from '../../test/util'
 
 describe('collectTree', () => {
   const makeUri = (...paths: string[]): Uri =>

--- a/extension/src/repository/data/collect.ts
+++ b/extension/src/repository/data/collect.ts
@@ -1,7 +1,7 @@
 import { join, sep } from 'path'
 import { Uri } from 'vscode'
-import { Resource } from './commands'
-import { addToMapSet } from '../util/map'
+import { Resource } from '../commands'
+import { addToMapSet } from '../../util/map'
 
 export type PathItem = Resource & {
   isDirectory: boolean

--- a/extension/src/repository/data/index.ts
+++ b/extension/src/repository/data/index.ts
@@ -1,11 +1,11 @@
 import { Event, EventEmitter } from 'vscode'
 import { Disposable } from '@hediet/std/disposable'
 import { Deferred } from '@hediet/std/synchronization'
-import { AvailableCommands, InternalCommands } from '../commands/internal'
-import { DiffOutput, ListOutput, StatusOutput } from '../cli/reader'
-import { isAnyDvcYaml } from '../fileSystem'
-import { getAllUntracked } from '../git'
-import { ProcessManager } from '../processManager'
+import { AvailableCommands, InternalCommands } from '../../commands/internal'
+import { DiffOutput, ListOutput, StatusOutput } from '../../cli/reader'
+import { isAnyDvcYaml } from '../../fileSystem'
+import { getAllUntracked } from '../../git'
+import { ProcessManager } from '../../processManager'
 
 export type Data = {
   diffFromHead: DiffOutput

--- a/extension/src/repository/model/index.test.ts
+++ b/extension/src/repository/model/index.test.ts
@@ -1,9 +1,9 @@
 import { join, resolve, sep } from 'path'
 import { Disposable, Disposer } from '@hediet/std/disposable'
 import { mocked } from 'ts-jest/utils'
-import { RepositoryModel } from './model'
-import { ListOutput, StatusOutput } from '../cli/reader'
-import { dvcDemoPath } from '../test/util'
+import { RepositoryModel } from '.'
+import { ListOutput, StatusOutput } from '../../cli/reader'
+import { dvcDemoPath } from '../../test/util'
 
 jest.mock('@hediet/std/disposable')
 

--- a/extension/src/repository/model/index.ts
+++ b/extension/src/repository/model/index.ts
@@ -1,9 +1,9 @@
 import { dirname, resolve } from 'path'
 import isEqual from 'lodash.isequal'
 import { Disposable } from '@hediet/std/disposable'
-import { collectTree, PathItem } from './collect'
-import { SourceControlManagementModel } from './sourceControlManagement'
-import { DecorationModel } from './decorationProvider'
+import { collectTree, PathItem } from '../data/collect'
+import { SourceControlManagementModel } from '../sourceControlManagement'
+import { DecorationModel } from '../decorationProvider'
 import {
   ChangedType,
   DiffOutput,
@@ -14,8 +14,8 @@ import {
   Status,
   StatusesOrAlwaysChanged,
   StatusOutput
-} from '../cli/reader'
-import { isDirectory } from '../fileSystem'
+} from '../../cli/reader'
+import { isDirectory } from '../../fileSystem'
 
 type OutputData = {
   diffFromCache: StatusOutput

--- a/extension/src/test/suite/repository/data/index.test.ts
+++ b/extension/src/test/suite/repository/data/index.test.ts
@@ -2,9 +2,9 @@ import { join } from 'path'
 import { afterEach, beforeEach, describe, it, suite } from 'mocha'
 import { expect } from 'chai'
 import { restore } from 'sinon'
-import { buildRepositoryData } from './util'
-import { Disposable } from '../../../extension'
-import { dvcDemoPath } from '../../util'
+import { buildRepositoryData } from '../util'
+import { Disposable } from '../../../../extension'
+import { dvcDemoPath } from '../../../util'
 
 suite('Repository Data Test Suite', () => {
   const disposable = Disposable.fn()


### PR DESCRIPTION
# 2/5 `master` <- #1120 <- this <- #1124 <- #1123 <- #1125 

This PR moves files in the repository folder into folders that match their experiments counterparts. This increases the uniformity of the codebase.