### PR TITLE
Add ability to pause data updates

### DIFF
--- a/extension/src/data/index.ts
+++ b/extension/src/data/index.ts
@@ -43,11 +43,12 @@ export abstract class BaseData<T extends PlotsOutput | ExperimentsOutput> {
     dvcRoot: string,
     internalCommands: InternalCommands,
     updateCommandId: CommandId,
+    updatesPaused: EventEmitter<boolean>,
     staticFiles: string[] = []
   ) {
     this.dvcRoot = dvcRoot
     this.processManager = this.dispose.track(
-      new ProcessManager(new EventEmitter(), {
+      new ProcessManager(updatesPaused, {
         name: 'update',
         process: () => this.update()
       })

--- a/extension/src/experiments/data/index.ts
+++ b/extension/src/experiments/data/index.ts
@@ -1,4 +1,5 @@
 import { join, resolve } from 'path'
+import { EventEmitter } from 'vscode'
 import { collectFiles } from './collect'
 import { DOT_GIT, EXPERIMENTS_GIT_REFS, GIT_REFS } from './constants'
 import { createNecessaryFileSystemWatcher } from '../../fileSystem/watcher'
@@ -8,12 +9,18 @@ import { ExperimentsOutput } from '../../cli/reader'
 import { BaseData } from '../../data'
 
 export class ExperimentsData extends BaseData<ExperimentsOutput> {
-  constructor(dvcRoot: string, internalCommands: InternalCommands) {
-    super(dvcRoot, internalCommands, AvailableCommands.EXPERIMENT_SHOW, [
-      'dvc.lock',
-      'dvc.yaml',
-      'params.yaml'
-    ])
+  constructor(
+    dvcRoot: string,
+    internalCommands: InternalCommands,
+    updatesPaused: EventEmitter<boolean>
+  ) {
+    super(
+      dvcRoot,
+      internalCommands,
+      AvailableCommands.EXPERIMENT_SHOW,
+      updatesPaused,
+      ['dvc.lock', 'dvc.yaml', 'params.yaml']
+    )
 
     this.watchExpGitRefs()
   }

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -48,9 +48,10 @@ export class Experiments extends BaseRepository<TableData> {
   constructor(
     dvcRoot: string,
     internalCommands: InternalCommands,
+    updatesPaused: EventEmitter<boolean>,
     resourceLocator: ResourceLocator,
     workspaceState: Memento,
-    data = new ExperimentsData(dvcRoot, internalCommands)
+    data?: ExperimentsData
   ) {
     super(dvcRoot, resourceLocator.beaker)
 
@@ -66,7 +67,9 @@ export class Experiments extends BaseRepository<TableData> {
       new ParamsAndMetricsModel(dvcRoot, workspaceState)
     )
 
-    this.data = this.dispose.track(data)
+    this.data = this.dispose.track(
+      data || new ExperimentsData(dvcRoot, internalCommands, updatesPaused)
+    )
 
     this.dispose.track(this.data.onDidUpdate(data => this.setState(data)))
 

--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -204,11 +204,16 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
     }
   }
 
-  public createRepository(dvcRoot: string, resourceLocator: ResourceLocator) {
+  public createRepository(
+    dvcRoot: string,
+    updatesPaused: EventEmitter<boolean>,
+    resourceLocator: ResourceLocator
+  ) {
     const experiments = this.dispose.track(
       new Experiments(
         dvcRoot,
         this.internalCommands,
+        updatesPaused,
         resourceLocator,
         this.workspaceState
       )

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -69,6 +69,10 @@ export class Extension implements IExtension {
     new EventEmitter()
   )
 
+  private updatesPaused: EventEmitter<boolean> = this.dispose.track(
+    new EventEmitter<boolean>()
+  )
+
   private readonly onDidChangeWorkspace: Event<void> =
     this.workspaceChanged.event
 
@@ -301,10 +305,14 @@ export class Extension implements IExtension {
     this.resetMembers()
 
     await Promise.all([
-      this.repositories.create(this.dvcRoots),
+      this.repositories.create(this.dvcRoots, this.updatesPaused),
       this.trackedExplorerTree.initialize(this.dvcRoots),
-      this.experiments.create(this.dvcRoots, this.resourceLocator),
-      this.plots.create(this.dvcRoots, this.resourceLocator)
+      this.experiments.create(
+        this.dvcRoots,
+        this.updatesPaused,
+        this.resourceLocator
+      ),
+      this.plots.create(this.dvcRoots, this.updatesPaused, this.resourceLocator)
     ])
 
     this.experiments.linkRepositories(this.plots)

--- a/extension/src/plots/data/index.ts
+++ b/extension/src/plots/data/index.ts
@@ -1,10 +1,20 @@
+import { EventEmitter } from 'vscode'
 import { AvailableCommands, InternalCommands } from '../../commands/internal'
 import { BaseData } from '../../data'
 import { PlotsOutput } from '../../plots/webview/contract'
 
 export class PlotsData extends BaseData<PlotsOutput> {
-  constructor(dvcRoot: string, internalCommands: InternalCommands) {
-    super(dvcRoot, internalCommands, AvailableCommands.PLOTS_SHOW)
+  constructor(
+    dvcRoot: string,
+    internalCommands: InternalCommands,
+    updatesPaused: EventEmitter<boolean>
+  ) {
+    super(
+      dvcRoot,
+      internalCommands,
+      AvailableCommands.PLOTS_SHOW,
+      updatesPaused
+    )
   }
 
   public collectFiles(data: PlotsOutput) {

--- a/extension/src/plots/index.ts
+++ b/extension/src/plots/index.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'vscode'
 import isEmpty from 'lodash.isempty'
 import {
   ImagePlot,
@@ -31,11 +32,14 @@ export class Plots extends BaseRepository<TPlotsData> {
   constructor(
     dvcRoot: string,
     internalCommands: InternalCommands,
+    updatesPaused: EventEmitter<boolean>,
     webviewIcon: Resource
   ) {
     super(dvcRoot, webviewIcon)
 
-    this.data = this.dispose.track(new PlotsData(dvcRoot, internalCommands))
+    this.data = this.dispose.track(
+      new PlotsData(dvcRoot, internalCommands, updatesPaused)
+    )
 
     this.dispose.track(this.data.onDidUpdate(data => this.setStaticPlots(data)))
 

--- a/extension/src/plots/workspace.ts
+++ b/extension/src/plots/workspace.ts
@@ -1,12 +1,22 @@
+import { EventEmitter } from 'vscode'
 import { Plots } from '.'
 import { PlotsData } from './webview/contract'
 import { ResourceLocator } from '../resourceLocator'
 import { BaseWorkspaceWebviews } from '../webview/workspace'
 
 export class WorkspacePlots extends BaseWorkspaceWebviews<Plots, PlotsData> {
-  public createRepository(dvcRoot: string, resourceLocator: ResourceLocator) {
+  public createRepository(
+    dvcRoot: string,
+    updatesPaused: EventEmitter<boolean>,
+    resourceLocator: ResourceLocator
+  ) {
     const plots = this.dispose.track(
-      new Plots(dvcRoot, this.internalCommands, resourceLocator.scatterGraph)
+      new Plots(
+        dvcRoot,
+        this.internalCommands,
+        updatesPaused,
+        resourceLocator.scatterGraph
+      )
     )
 
     this.setRepository(dvcRoot, plots)

--- a/extension/src/processManager.ts
+++ b/extension/src/processManager.ts
@@ -35,10 +35,6 @@ export class ProcessManager {
   }
 
   public async run(name: string): Promise<void> {
-    if (this.paused) {
-      return this.queue(name)
-    }
-
     this.checkCanRun(name)
     const { process, lastStarted } = this.processes[name]
 
@@ -46,7 +42,7 @@ export class ProcessManager {
       return
     }
 
-    if (this.anyOngoing()) {
+    if (this.anyOngoing() || this.paused) {
       return this.queue(name)
     }
 

--- a/extension/src/repository/data/index.ts
+++ b/extension/src/repository/data/index.ts
@@ -30,11 +30,15 @@ export class RepositoryData {
     new EventEmitter()
   )
 
-  constructor(dvcRoot: string, internalCommands: InternalCommands) {
+  constructor(
+    dvcRoot: string,
+    internalCommands: InternalCommands,
+    updatesPaused: EventEmitter<boolean>
+  ) {
     this.dvcRoot = dvcRoot
     this.processManager = this.dispose.track(
       new ProcessManager(
-        new EventEmitter<boolean>(),
+        updatesPaused,
         { name: 'partialUpdate', process: () => this.partialUpdate() },
         { name: 'fullUpdate', process: () => this.fullUpdate() }
       )

--- a/extension/src/repository/index.ts
+++ b/extension/src/repository/index.ts
@@ -23,15 +23,16 @@ export class Repository {
   constructor(
     dvcRoot: string,
     internalCommands: InternalCommands,
+    updatesPaused: EventEmitter<boolean>,
     treeDataChanged: EventEmitter<void>
   ) {
-    this.decorationProvider = this.dispose.track(new DecorationProvider())
     this.dvcRoot = dvcRoot
     this.model = this.dispose.track(new RepositoryModel(dvcRoot))
     this.data = this.dispose.track(
-      new RepositoryData(dvcRoot, internalCommands)
+      new RepositoryData(dvcRoot, internalCommands, updatesPaused)
     )
 
+    this.decorationProvider = this.dispose.track(new DecorationProvider())
     this.sourceControlManagement = this.dispose.track(
       new SourceControlManagement(this.dvcRoot, this.getState())
     )

--- a/extension/src/repository/workspace.ts
+++ b/extension/src/repository/workspace.ts
@@ -29,9 +29,17 @@ export class WorkspaceRepositories extends BaseWorkspace<Repository> {
     return cwd
   }
 
-  public createRepository(dvcRoot: string): Repository {
+  public createRepository(
+    dvcRoot: string,
+    updatesPaused: EventEmitter<boolean>
+  ): Repository {
     const repository = this.dispose.track(
-      new Repository(dvcRoot, this.internalCommands, this.treeDataChanged)
+      new Repository(
+        dvcRoot,
+        this.internalCommands,
+        updatesPaused,
+        this.treeDataChanged
+      )
     )
     getGitRepositoryRoot(dvcRoot).then(gitRoot =>
       repository.dispose.track(

--- a/extension/src/test/suite/experiments/data/index.test.ts
+++ b/extension/src/test/suite/experiments/data/index.test.ts
@@ -1,6 +1,6 @@
 import { join, sep } from 'path'
 import { afterEach, beforeEach, describe, it, suite } from 'mocha'
-import { FileSystemWatcher } from 'vscode'
+import { EventEmitter, FileSystemWatcher } from 'vscode'
 import { expect } from 'chai'
 import { stub, restore } from 'sinon'
 import { Disposable } from '../../../../extension'
@@ -36,7 +36,11 @@ suite('Experiments Data Test Suite', () => {
       )
 
       const data = disposable.track(
-        new ExperimentsData(dvcDemoPath, internalCommands)
+        new ExperimentsData(
+          dvcDemoPath,
+          internalCommands,
+          disposable.track(new EventEmitter<boolean>())
+        )
       )
 
       await Promise.all([
@@ -65,7 +69,11 @@ suite('Experiments Data Test Suite', () => {
       ).returns(mockWatcher)
 
       const data = disposable.track(
-        new ExperimentsData(dvcDemoPath, internalCommands)
+        new ExperimentsData(
+          dvcDemoPath,
+          internalCommands,
+          disposable.track(new EventEmitter<boolean>())
+        )
       )
 
       await data.isReady()
@@ -104,7 +112,11 @@ suite('Experiments Data Test Suite', () => {
       })
 
       const data = disposable.track(
-        new ExperimentsData(dvcDemoPath, internalCommands)
+        new ExperimentsData(
+          dvcDemoPath,
+          internalCommands,
+          disposable.track(new EventEmitter<boolean>())
+        )
       )
 
       await data.isReady()

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -204,6 +204,8 @@ suite('Experiments Test Suite', () => {
         new Map()
       )
 
+      const updatesPaused = disposable.track(new EventEmitter<boolean>())
+
       const resourceLocator = disposable.track(
         new ResourceLocator(extensionUri)
       )
@@ -212,6 +214,7 @@ suite('Experiments Test Suite', () => {
         new Experiments(
           dvcDemoPath,
           internalCommands,
+          updatesPaused,
           resourceLocator,
           buildMockMemento(),
           buildMockData()
@@ -386,6 +389,7 @@ suite('Experiments Test Suite', () => {
         new Experiments(
           'test',
           {} as InternalCommands,
+          {} as EventEmitter<boolean>,
           {} as ResourceLocator,
           mockMemento,
           buildMockData()
@@ -545,6 +549,7 @@ suite('Experiments Test Suite', () => {
         new Experiments(
           'test',
           {} as InternalCommands,
+          {} as EventEmitter<boolean>,
           {} as ResourceLocator,
           mockMemento,
           buildMockData()

--- a/extension/src/test/suite/extension.test.ts
+++ b/extension/src/test/suite/extension.test.ts
@@ -261,7 +261,7 @@ suite('Extension Test Suite', () => {
       expect(mockDiff, 'should have updated the repository data').to.have.been
         .called
       expect(mockStatus).to.have.been.called
-      expect(mockExperimentShow, 'should have update the experiments data').to
+      expect(mockExperimentShow, 'should have updated the experiments data').to
         .have.been.called
 
       expect(

--- a/extension/src/test/suite/plots/util.ts
+++ b/extension/src/test/suite/plots/util.ts
@@ -11,10 +11,8 @@ import { WorkspacePlots } from '../../../plots/workspace'
 import { WorkspaceExperiments } from '../../../experiments/workspace'
 
 export const buildPlots = async (disposer: Disposer, plotsShow = {}) => {
-  const { experiments, internalCommands, resourceLocator } = buildExperiments(
-    disposer,
-    expShowFixture
-  )
+  const { experiments, internalCommands, updatesPaused, resourceLocator } =
+    buildExperiments(disposer, expShowFixture)
 
   const messageSpy = spy(BaseWebview.prototype, 'show')
   const mockPlotsShow = stub(CliReader.prototype, 'plotsShow').resolves(
@@ -22,7 +20,12 @@ export const buildPlots = async (disposer: Disposer, plotsShow = {}) => {
   )
 
   const plots = disposer.track(
-    new Plots(dvcDemoPath, internalCommands, resourceLocator.scatterGraph)
+    new Plots(
+      dvcDemoPath,
+      internalCommands,
+      updatesPaused,
+      resourceLocator.scatterGraph
+    )
   )
   plots.setExperiments(experiments)
   await plots.isReady()

--- a/extension/src/test/suite/processManager.test.ts
+++ b/extension/src/test/suite/processManager.test.ts
@@ -88,7 +88,7 @@ suite('Process Manager Test Suite', () => {
 
     it('should send all calls to the queue when processes are paused', async () => {
       const mockUpdate = stub()
-      const processesPaused = new EventEmitter<boolean>()
+      const processesPaused = disposable.track(new EventEmitter<boolean>())
       const processManager = disposable.track(
         new ProcessManager(processesPaused, {
           name: 'update',

--- a/extension/src/test/suite/repository/index.test.ts
+++ b/extension/src/test/suite/repository/index.test.ts
@@ -49,6 +49,7 @@ suite('Repository Test Suite', () => {
         mockGetAllUntracked,
         mockListDvcOnlyRecursive,
         mockStatus,
+        updatesPaused,
         treeDataChanged
       } = buildDependencies(disposable)
 
@@ -88,7 +89,12 @@ suite('Repository Test Suite', () => {
       mockGetAllUntracked.resolves(untracked)
 
       const repository = disposable.track(
-        new Repository(dvcDemoPath, internalCommands, treeDataChanged)
+        new Repository(
+          dvcDemoPath,
+          internalCommands,
+          updatesPaused,
+          treeDataChanged
+        )
       )
       await repository.isReady()
 
@@ -135,7 +141,8 @@ suite('Repository Test Suite', () => {
         mockNow,
         mockStatus,
         onDidChangeTreeData,
-        treeDataChanged
+        treeDataChanged,
+        updatesPaused
       } = buildDependencies(disposable)
       mockNow.returns(100)
 
@@ -180,7 +187,12 @@ suite('Repository Test Suite', () => {
       mockGetAllUntracked.resolves(emptySet)
 
       const repository = disposable.track(
-        new Repository(dvcDemoPath, internalCommands, treeDataChanged)
+        new Repository(
+          dvcDemoPath,
+          internalCommands,
+          updatesPaused,
+          treeDataChanged
+        )
       )
       await repository.isReady()
 
@@ -249,6 +261,7 @@ suite('Repository Test Suite', () => {
         mockNow,
         mockStatus,
         onDidChangeTreeData,
+        updatesPaused,
         treeDataChanged
       } = buildDependencies(disposable)
 
@@ -312,7 +325,12 @@ suite('Repository Test Suite', () => {
         .resolves(untracked)
 
       const repository = disposable.track(
-        new Repository(dvcDemoPath, internalCommands, treeDataChanged)
+        new Repository(
+          dvcDemoPath,
+          internalCommands,
+          updatesPaused,
+          treeDataChanged
+        )
       )
       await repository.isReady()
       mockNow.resetBehavior()

--- a/extension/src/test/suite/repository/util.ts
+++ b/extension/src/test/suite/repository/util.ts
@@ -18,6 +18,7 @@ export const buildDependencies = (disposer: Disposer) => {
 
   const treeDataChanged = disposer.track(new EventEmitter<void>())
   const onDidChangeTreeData = treeDataChanged.event
+  const updatesPaused = disposer.track(new EventEmitter<boolean>())
 
   return {
     internalCommands,
@@ -27,7 +28,8 @@ export const buildDependencies = (disposer: Disposer) => {
     mockNow,
     mockStatus,
     onDidChangeTreeData,
-    treeDataChanged
+    treeDataChanged,
+    updatesPaused
   }
 }
 
@@ -38,7 +40,8 @@ export const buildRepositoryData = async (disposer: Disposer) => {
     mockGetAllUntracked,
     mockListDvcOnlyRecursive,
     mockNow,
-    mockStatus
+    mockStatus,
+    updatesPaused
   } = buildDependencies(disposer)
 
   mockDiff.resolves({})
@@ -47,7 +50,9 @@ export const buildRepositoryData = async (disposer: Disposer) => {
   mockNow.returns(150)
   mockStatus.resolves({})
 
-  const data = disposer.track(new RepositoryData(dvcDemoPath, internalCommands))
+  const data = disposer.track(
+    new RepositoryData(dvcDemoPath, internalCommands, updatesPaused)
+  )
   await data.isReady()
 
   mockDiff.resetHistory()

--- a/extension/src/workspace/index.ts
+++ b/extension/src/workspace/index.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'vscode'
 import { Disposable } from '@hediet/std/disposable'
 import { Deferred } from '@hediet/std/synchronization'
 import { InternalCommands } from '../commands/internal'
@@ -25,9 +26,13 @@ export abstract class BaseWorkspace<
     return this.initialized
   }
 
-  public create(dvcRoots: string[], optional?: U): T[] {
+  public create(
+    dvcRoots: string[],
+    updatesPaused: EventEmitter<boolean>,
+    optional?: U
+  ): T[] {
     const repositories = dvcRoots.map(dvcRoot =>
-      this.createRepository(dvcRoot, optional)
+      this.createRepository(dvcRoot, updatesPaused, optional)
     )
 
     Promise.all(repositories.map(repository => repository.isReady())).then(() =>
@@ -66,5 +71,9 @@ export abstract class BaseWorkspace<
     this.repositories[dvcRoot] = repository
   }
 
-  abstract createRepository(dvcRoot: string, arg?: U): T
+  abstract createRepository(
+    dvcRoot: string,
+    updatesPaused: EventEmitter<boolean>,
+    arg?: U
+  ): T
 }


### PR DESCRIPTION
# 4/5 `master` <- #1120 <-  #1122 <- #1124 <- this <- #1125

Follow up from https://github.com/iterative/vscode-dvc/pull/1120/files#r762631396 i.e the "temporary fix" (`waitForLock`) which was implemented so that we could queue experiments without error because they were running into the locks created by `status`, `diff`, `exp show`, etc. 

This will mitigate the issue of updates running whenever we perform an action running within the extension but there is nothing that comes to mind for something that we can do about updates running when a user uses the CLI directly.

Also relates to https://github.com/iterative/vscode-dvc/issues/948#issuecomment-969397663.