### PR TITLE
Remove unnecessary event emitter / event chain in Repository

### DIFF
--- a/extension/src/repository/decorationProvider.ts
+++ b/extension/src/repository/decorationProvider.ts
@@ -114,7 +114,7 @@ export class DecorationProvider implements FileDecorationProvider {
     }
   }
 
-  public setState = (state: DecorationState) => {
+  public setState(state: DecorationState) {
     const urisToUpdate = this.getUnion(this.state, state)
     this.state = state
     this.decorationsChanged.fire(urisToUpdate)

--- a/extension/src/repository/index.ts
+++ b/extension/src/repository/index.ts
@@ -1,4 +1,4 @@
-import { Event, EventEmitter } from 'vscode'
+import { EventEmitter } from 'vscode'
 import { Disposable } from '@hediet/std/disposable'
 import { Deferred } from '@hediet/std/synchronization'
 import { DecorationProvider } from './decorationProvider'
@@ -9,7 +9,6 @@ import { InternalCommands } from '../commands/internal'
 
 export class Repository {
   public readonly dispose = Disposable.fn()
-  public readonly onDidChangeTreeData: Event<void>
 
   private readonly model: RepositoryModel
   private readonly deferred = new Deferred()
@@ -24,10 +23,9 @@ export class Repository {
   constructor(
     dvcRoot: string,
     internalCommands: InternalCommands,
-    decorationProvider = new DecorationProvider(),
-    treeDataChanged = new EventEmitter<void>()
+    treeDataChanged: EventEmitter<void>
   ) {
-    this.decorationProvider = this.dispose.track(decorationProvider)
+    this.decorationProvider = this.dispose.track(new DecorationProvider())
     this.dvcRoot = dvcRoot
     this.model = this.dispose.track(new RepositoryModel(dvcRoot))
     this.data = this.dispose.track(
@@ -38,8 +36,7 @@ export class Repository {
       new SourceControlManagement(this.dvcRoot, this.getState())
     )
 
-    this.treeDataChanged = this.dispose.track(treeDataChanged)
-    this.onDidChangeTreeData = this.treeDataChanged.event
+    this.treeDataChanged = treeDataChanged
 
     this.initialize()
   }

--- a/extension/src/repository/workspace.ts
+++ b/extension/src/repository/workspace.ts
@@ -31,7 +31,7 @@ export class WorkspaceRepositories extends BaseWorkspace<Repository> {
 
   public createRepository(dvcRoot: string): Repository {
     const repository = this.dispose.track(
-      new Repository(dvcRoot, this.internalCommands)
+      new Repository(dvcRoot, this.internalCommands, this.treeDataChanged)
     )
     getGitRepositoryRoot(dvcRoot).then(gitRoot =>
       repository.dispose.track(
@@ -40,9 +40,6 @@ export class WorkspaceRepositories extends BaseWorkspace<Repository> {
           getRepositoryListener(repository, dvcRoot)
         )
       )
-    )
-    repository.dispose.track(
-      repository.onDidChangeTreeData(() => this.treeDataChanged.fire())
     )
 
     this.setRepository(dvcRoot, repository)

--- a/extension/src/test/suite/repository/index.test.ts
+++ b/extension/src/test/suite/repository/index.test.ts
@@ -14,6 +14,7 @@ import {
   StatusOutput
 } from '../../../cli/reader'
 import { SourceControlManagement } from '../../../repository/sourceControlManagement'
+import { DecorationProvider } from '../../../repository/decorationProvider'
 
 suite('Repository Test Suite', () => {
   const disposable = Disposable.fn()
@@ -47,7 +48,8 @@ suite('Repository Test Suite', () => {
         mockDiff,
         mockGetAllUntracked,
         mockListDvcOnlyRecursive,
-        mockStatus
+        mockStatus,
+        treeDataChanged
       } = buildDependencies(disposable)
 
       mockListDvcOnlyRecursive.resolves([
@@ -86,7 +88,7 @@ suite('Repository Test Suite', () => {
       mockGetAllUntracked.resolves(untracked)
 
       const repository = disposable.track(
-        new Repository(dvcDemoPath, internalCommands)
+        new Repository(dvcDemoPath, internalCommands, treeDataChanged)
       )
       await repository.isReady()
 
@@ -126,7 +128,6 @@ suite('Repository Test Suite', () => {
   describe('update', () => {
     it('will not exclude changed outs from stages that are always changed', async () => {
       const {
-        decorationProvider,
         internalCommands,
         mockDiff,
         mockGetAllUntracked,
@@ -179,12 +180,7 @@ suite('Repository Test Suite', () => {
       mockGetAllUntracked.resolves(emptySet)
 
       const repository = disposable.track(
-        new Repository(
-          dvcDemoPath,
-          internalCommands,
-          decorationProvider,
-          treeDataChanged
-        )
+        new Repository(dvcDemoPath, internalCommands, treeDataChanged)
       )
       await repository.isReady()
 
@@ -246,7 +242,6 @@ suite('Repository Test Suite', () => {
       ])
 
       const {
-        decorationProvider,
         internalCommands,
         mockDiff,
         mockGetAllUntracked,
@@ -317,12 +312,7 @@ suite('Repository Test Suite', () => {
         .resolves(untracked)
 
       const repository = disposable.track(
-        new Repository(
-          dvcDemoPath,
-          internalCommands,
-          decorationProvider,
-          treeDataChanged
-        )
+        new Repository(dvcDemoPath, internalCommands, treeDataChanged)
       )
       await repository.isReady()
       mockNow.resetBehavior()
@@ -330,7 +320,10 @@ suite('Repository Test Suite', () => {
       const dataUpdateEvent = new Promise(resolve =>
         disposable.track(onDidChangeTreeData(() => resolve(undefined)))
       )
-      const setDecorationStateSpy = spy(decorationProvider, 'setState')
+      const setDecorationStateSpy = spy(
+        DecorationProvider.prototype,
+        'setState'
+      )
       const setScmStateSpy = spy(SourceControlManagement.prototype, 'setState')
 
       expect(repository.getState()).to.deep.equal(emptyState)

--- a/extension/src/test/suite/repository/util.ts
+++ b/extension/src/test/suite/repository/util.ts
@@ -5,7 +5,6 @@ import { buildInternalCommands } from '../util'
 import { Disposer } from '../../../extension'
 import * as Git from '../../../git'
 import { RepositoryData } from '../../../repository/data'
-import { DecorationProvider } from '../../../repository/decorationProvider'
 import * as Time from '../../../util/time'
 
 export const buildDependencies = (disposer: Disposer) => {
@@ -17,12 +16,10 @@ export const buildDependencies = (disposer: Disposer) => {
   const mockGetAllUntracked = stub(Git, 'getAllUntracked')
   const mockNow = stub(Time, 'getCurrentEpoch')
 
-  const decorationProvider = disposer.track(new DecorationProvider())
   const treeDataChanged = disposer.track(new EventEmitter<void>())
   const onDidChangeTreeData = treeDataChanged.event
 
   return {
-    decorationProvider,
     internalCommands,
     mockDiff,
     mockGetAllUntracked,


### PR DESCRIPTION
# 3/5 `master` <- #1120 <- #1122 <- this <- #1123 <- #1125 

Noticed this when preparing #1123. I had used a different `treeDataChanged` `EventEmitter`s between the `Repository` and `WorkspaceRepositories` classes. I think the original reason for doing this would have been something to do with testing but we haven't used the `Repository.onDidChangeTreeData` event anywhere so it can be removed.