### PR TITLE
Consolidate memento prefix enum

### DIFF
--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -15,17 +15,11 @@ import { definedAndNonEmpty, flatten } from '../../util/array'
 import { ExperimentsOutput } from '../../cli/reader'
 import { hasKey } from '../../util/object'
 import { setContextValue } from '../../vscode/context'
+import { MementoPrefix } from '../../vscode/memento'
 
 export enum Status {
   SELECTED = 1,
   UNSELECTED = 0
-}
-
-export const enum MementoPrefixes {
-  COLORS = 'colors:',
-  FILTER_BY = 'filterBy:',
-  SORT_BY = 'sortBy:',
-  STATUS = 'status:'
 }
 
 export class ExperimentsModel {
@@ -289,7 +283,7 @@ export class ExperimentsModel {
 
   private persistSorts() {
     return this.workspaceState.update(
-      MementoPrefixes.SORT_BY + this.dvcRoot,
+      MementoPrefix.EXPERIMENTS_SORT_BY + this.dvcRoot,
       this.currentSorts
     )
   }
@@ -299,21 +293,24 @@ export class ExperimentsModel {
       this.setSelectedToFilters()
     }
     return this.workspaceState.update(
-      MementoPrefixes.FILTER_BY + this.dvcRoot,
+      MementoPrefix.EXPERIMENTS_FILTER_BY + this.dvcRoot,
       [...this.filters]
     )
   }
 
   private persistColors() {
-    return this.workspaceState.update(MementoPrefixes.COLORS + this.dvcRoot, {
-      assigned: [...this.colors.assigned],
-      available: this.colors.available
-    })
+    return this.workspaceState.update(
+      MementoPrefix.EXPERIMENTS_COLORS + this.dvcRoot,
+      {
+        assigned: [...this.colors.assigned],
+        available: this.colors.available
+      }
+    )
   }
 
   private persistStatus() {
     return this.workspaceState.update(
-      MementoPrefixes.STATUS + this.dvcRoot,
+      MementoPrefix.EXPERIMENTS_STATUS + this.dvcRoot,
       this.status
     )
   }
@@ -330,7 +327,7 @@ export class ExperimentsModel {
     const { assigned, available } = workspaceState.get<{
       assigned: [string, string][]
       available: string[]
-    }>(MementoPrefixes.COLORS + dvcRoot, {
+    }>(MementoPrefix.EXPERIMENTS_COLORS + dvcRoot, {
       assigned: [],
       available: copyOriginalColors()
     })
@@ -341,17 +338,17 @@ export class ExperimentsModel {
         available: available
       },
       currentSorts: workspaceState.get<SortDefinition[]>(
-        MementoPrefixes.SORT_BY + dvcRoot,
+        MementoPrefix.EXPERIMENTS_SORT_BY + dvcRoot,
         []
       ),
       filters: new Map(
         workspaceState.get<[string, FilterDefinition][]>(
-          MementoPrefixes.FILTER_BY + dvcRoot,
+          MementoPrefix.EXPERIMENTS_FILTER_BY + dvcRoot,
           []
         )
       ),
       status: workspaceState.get<Record<string, Status>>(
-        MementoPrefixes.STATUS + dvcRoot,
+        MementoPrefix.EXPERIMENTS_STATUS + dvcRoot,
         {}
       )
     }

--- a/extension/src/experiments/paramsAndMetrics/model.test.ts
+++ b/extension/src/experiments/paramsAndMetrics/model.test.ts
@@ -1,6 +1,7 @@
-import { MementoPrefixes, ParamsAndMetricsModel, Status } from './model'
+import { ParamsAndMetricsModel, Status } from './model'
 import { joinParamOrMetricPath } from './paths'
 import { buildMockMemento } from '../../test/util'
+import { MementoPrefix } from '../../vscode/memento'
 
 describe('ParamsAndMetricsModel', () => {
   const exampleDvcRoot = 'test'
@@ -53,7 +54,7 @@ describe('ParamsAndMetricsModel', () => {
       const model = new ParamsAndMetricsModel(
         exampleDvcRoot,
         buildMockMemento({
-          [MementoPrefixes.STATUS + exampleDvcRoot]: {
+          [MementoPrefix.PARAMS_AND_METRICS_STATUS + exampleDvcRoot]: {
             [paramsDotYamlPath]: Status.INDETERMINATE,
             [testParamPath]: Status.UNSELECTED
           }
@@ -82,7 +83,8 @@ describe('ParamsAndMetricsModel', () => {
       const model = new ParamsAndMetricsModel(
         exampleDvcRoot,
         buildMockMemento({
-          [MementoPrefixes.COLUMN_ORDER + exampleDvcRoot]: persistedState
+          [MementoPrefix.PARAMS_AND_METRICS_COLUMN_ORDER + exampleDvcRoot]:
+            persistedState
         })
       )
       expect(model.getColumnOrder()).toEqual(persistedState)
@@ -92,7 +94,7 @@ describe('ParamsAndMetricsModel', () => {
       const model = new ParamsAndMetricsModel(
         exampleDvcRoot,
         buildMockMemento({
-          [MementoPrefixes.COLUMN_ORDER + exampleDvcRoot]: [
+          [MementoPrefix.PARAMS_AND_METRICS_COLUMN_ORDER + exampleDvcRoot]: [
             { path: 'A', width: 0 },
             { path: 'B', width: 0 },
             { path: 'C', width: 0 }
@@ -115,7 +117,8 @@ describe('ParamsAndMetricsModel', () => {
       const model = new ParamsAndMetricsModel(
         exampleDvcRoot,
         buildMockMemento({
-          [MementoPrefixes.COLUMN_ORDER + exampleDvcRoot]: persistedState
+          [MementoPrefix.PARAMS_AND_METRICS_COLUMN_ORDER + exampleDvcRoot]:
+            persistedState
         })
       )
       expect(model.getColumnOrder()).toEqual(persistedState)
@@ -130,7 +133,8 @@ describe('ParamsAndMetricsModel', () => {
       const model = new ParamsAndMetricsModel(
         exampleDvcRoot,
         buildMockMemento({
-          [MementoPrefixes.COLUMN_ORDER + exampleDvcRoot]: persistedState
+          [MementoPrefix.PARAMS_AND_METRICS_COLUMN_ORDER + exampleDvcRoot]:
+            persistedState
         })
       )
       const changedColumnId = 'C'

--- a/extension/src/experiments/paramsAndMetrics/model.ts
+++ b/extension/src/experiments/paramsAndMetrics/model.ts
@@ -4,17 +4,12 @@ import { collectChanges, collectParamsAndMetrics } from './collect'
 import { ParamOrMetric } from '../webview/contract'
 import { flatten } from '../../util/array'
 import { ExperimentsOutput } from '../../cli/reader'
+import { MementoPrefix } from '../../vscode/memento'
 
 export enum Status {
   SELECTED = 2,
   INDETERMINATE = 1,
   UNSELECTED = 0
-}
-
-export const enum MementoPrefixes {
-  STATUS = 'paramsAndMetricsStatus:',
-  COLUMN_ORDER = 'paramsAndMetricsColumnOrder:',
-  COLUMN_WIDTHS = 'paramsAndMetricsColumnWidths:'
 }
 
 export class ParamsAndMetricsModel {
@@ -34,13 +29,16 @@ export class ParamsAndMetricsModel {
   constructor(dvcRoot: string, workspaceState: Memento) {
     this.dvcRoot = dvcRoot
     this.workspaceState = workspaceState
-    this.status = workspaceState.get(MementoPrefixes.STATUS + dvcRoot, {})
+    this.status = workspaceState.get(
+      MementoPrefix.PARAMS_AND_METRICS_STATUS + dvcRoot,
+      {}
+    )
     this.columnOrderState = workspaceState.get(
-      MementoPrefixes.COLUMN_ORDER + dvcRoot,
+      MementoPrefix.PARAMS_AND_METRICS_COLUMN_ORDER + dvcRoot,
       []
     )
     this.columnWidthsState = workspaceState.get(
-      MementoPrefixes.COLUMN_WIDTHS + dvcRoot,
+      MementoPrefix.PARAMS_AND_METRICS_COLUMN_WIDTHS + dvcRoot,
       {}
     )
   }
@@ -131,14 +129,14 @@ export class ParamsAndMetricsModel {
 
   private persistColumnOrder() {
     this.workspaceState.update(
-      MementoPrefixes.COLUMN_ORDER + this.dvcRoot,
+      MementoPrefix.PARAMS_AND_METRICS_COLUMN_ORDER + this.dvcRoot,
       this.getColumnOrder()
     )
   }
 
   private persistColumnWidths() {
     this.workspaceState.update(
-      MementoPrefixes.COLUMN_WIDTHS + this.dvcRoot,
+      MementoPrefix.PARAMS_AND_METRICS_COLUMN_WIDTHS + this.dvcRoot,
       this.columnWidthsState
     )
   }
@@ -215,7 +213,7 @@ export class ParamsAndMetricsModel {
 
   private persistStatus() {
     return this.workspaceState.update(
-      MementoPrefixes.STATUS + this.dvcRoot,
+      MementoPrefix.PARAMS_AND_METRICS_STATUS + this.dvcRoot,
       this.status
     )
   }

--- a/extension/src/plots/model/index.test.ts
+++ b/extension/src/plots/model/index.test.ts
@@ -1,16 +1,17 @@
-import { PlotsModel, MementoPrefixes } from '.'
+import { PlotsModel } from '.'
 import { PlotSize } from '../webview/contract'
 import { buildMockMemento } from '../../test/util'
 import { Experiments } from '../../experiments'
+import { MementoPrefix } from '../../vscode/memento'
 
 describe('experimentsModel', () => {
   let model: PlotsModel
   const exampleDvcRoot = 'test'
   const persistedSelectedMetrics = ['loss', 'accuracy']
   const memento = buildMockMemento({
-    [MementoPrefixes.SELECTED_METRICS + exampleDvcRoot]:
+    [MementoPrefix.PLOT_SELECTED_METRICS + exampleDvcRoot]:
       persistedSelectedMetrics,
-    [MementoPrefixes.PLOT_SIZE + exampleDvcRoot]: PlotSize.REGULAR
+    [MementoPrefix.PLOT_SIZE + exampleDvcRoot]: PlotSize.REGULAR
   })
 
   beforeEach(() => {
@@ -41,7 +42,7 @@ describe('experimentsModel', () => {
 
     expect(mementoUpdateSpy).toHaveBeenCalledTimes(1)
     expect(mementoUpdateSpy).toHaveBeenCalledWith(
-      MementoPrefixes.SELECTED_METRICS + exampleDvcRoot,
+      MementoPrefix.PLOT_SELECTED_METRICS + exampleDvcRoot,
       newSelectedMetrics
     )
   })
@@ -61,7 +62,7 @@ describe('experimentsModel', () => {
 
     expect(mementoUpdateSpy).toHaveBeenCalledTimes(1)
     expect(mementoUpdateSpy).toHaveBeenCalledWith(
-      MementoPrefixes.PLOT_SIZE + exampleDvcRoot,
+      MementoPrefix.PLOT_SIZE + exampleDvcRoot,
       PlotSize.SMALL
     )
   })

--- a/extension/src/plots/model/index.ts
+++ b/extension/src/plots/model/index.ts
@@ -10,12 +10,7 @@ import {
 import { definedAndNonEmpty } from '../../util/array'
 import { ExperimentsOutput } from '../../cli/reader'
 import { Experiments } from '../../experiments'
-
-export const enum MementoPrefixes {
-  SECTION_COLLAPSED = 'sectionCollapsed:',
-  SELECTED_METRICS = 'selectedMetrics:',
-  PLOT_SIZE = 'plotSize:'
-}
+import { MementoPrefix } from '../../vscode/memento'
 
 export class PlotsModel {
   public readonly dispose = Disposable.fn()
@@ -39,17 +34,17 @@ export class PlotsModel {
     this.workspaceState = workspaceState
 
     this.selectedMetrics = workspaceState.get(
-      MementoPrefixes.SELECTED_METRICS + dvcRoot,
+      MementoPrefix.PLOT_SELECTED_METRICS + dvcRoot,
       undefined
     )
 
     this.plotSize = workspaceState.get(
-      MementoPrefixes.PLOT_SIZE + dvcRoot,
+      MementoPrefix.PLOT_SIZE + dvcRoot,
       PlotSize.REGULAR
     )
 
     this.sectionCollapsed = workspaceState.get(
-      MementoPrefixes.SECTION_COLLAPSED + dvcRoot,
+      MementoPrefix.PLOT_SECTION_COLLAPSED + dvcRoot,
       defaultSectionCollapsed
     )
   }
@@ -133,21 +128,21 @@ export class PlotsModel {
 
   private persistSelectedMetrics() {
     return this.workspaceState.update(
-      MementoPrefixes.SELECTED_METRICS + this.dvcRoot,
+      MementoPrefix.PLOT_SELECTED_METRICS + this.dvcRoot,
       this.getSelectedMetrics()
     )
   }
 
   private persistPlotSize() {
     this.workspaceState.update(
-      MementoPrefixes.PLOT_SIZE + this.dvcRoot,
+      MementoPrefix.PLOT_SIZE + this.dvcRoot,
       this.getPlotSize()
     )
   }
 
   private persistCollapsibleState() {
     this.workspaceState.update(
-      MementoPrefixes.SECTION_COLLAPSED + this.dvcRoot,
+      MementoPrefix.PLOT_SECTION_COLLAPSED + this.dvcRoot,
       this.sectionCollapsed
     )
   }

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -400,16 +400,16 @@ suite('Experiments Test Suite', () => {
       expect(
         mementoSpy,
         'workspaceContext is called for sort initialization'
-      ).to.be.calledWith('sortBy:test', [])
+      ).to.be.calledWith('experimentsSortBy:test', [])
       expect(
         mementoSpy,
         'workspaceContext is called for filter initialization'
-      ).to.be.calledWith('filterBy:test', [])
+      ).to.be.calledWith('experimentsFilterBy:test', [])
       expect(
         mementoSpy,
         'workspaceContext is called for color initialization'
-      ).to.be.calledWith('colors:test', match.has('assigned'))
-      expect(mementoSpy).to.be.calledWith('status:test', {})
+      ).to.be.calledWith('experimentsColors:test', match.has('assigned'))
+      expect(mementoSpy).to.be.calledWith('experimentsStatus:test', {})
 
       expect(
         testRepository.getSorts(),
@@ -418,13 +418,13 @@ suite('Experiments Test Suite', () => {
       expect(
         mockMemento.keys(),
         'Memento starts with the colors and status keys'
-      ).to.deep.equal(['status:test', 'colors:test'])
+      ).to.deep.equal(['experimentsStatus:test', 'experimentsColors:test'])
       expect(
-        mockMemento.get('colors:test'),
+        mockMemento.get('experimentsColors:test'),
         'the correct colors are persisted'
       ).to.deep.equal(expectedColors)
       expect(
-        mockMemento.get('status:test'),
+        mockMemento.get('experimentsStatus:test'),
         'the correct statuses are persisted'
       ).to.deep.equal({
         '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d': 1,
@@ -438,7 +438,7 @@ suite('Experiments Test Suite', () => {
       await testRepository.addSort()
 
       expect(
-        mockMemento.get('sortBy:test'),
+        mockMemento.get('experimentsSortBy:test'),
         'first sort is added to memento'
       ).to.deep.equal([firstSortDefinition])
 
@@ -446,7 +446,7 @@ suite('Experiments Test Suite', () => {
       await testRepository.addSort()
 
       expect(
-        mockMemento.get('sortBy:test'),
+        mockMemento.get('experimentsSortBy:test'),
         'second sort is added to the memento'
       ).to.deep.equal(sortDefinitions)
 
@@ -455,26 +455,26 @@ suite('Experiments Test Suite', () => {
       mockPickFilter.onFirstCall().resolves(firstFilterDefinition)
       await testRepository.addFilter()
       expect(
-        mockMemento.get('filterBy:test'),
+        mockMemento.get('experimentsFilterBy:test'),
         'first filter should be added to memento after addFilter'
       ).to.deep.equal([firstFilterMapEntry])
 
       mockPickFilter.onSecondCall().resolves(secondFilterDefinition)
       await testRepository.addFilter()
       expect(
-        mockMemento.get('filterBy:test'),
+        mockMemento.get('experimentsFilterBy:test'),
         'second filter should be added to memento after addFilter'
       ).to.deep.equal(filterMapEntries)
 
       testRepository.removeFilter(firstFilterId)
       expect(
-        mockMemento.get('filterBy:test'),
+        mockMemento.get('experimentsFilterBy:test'),
         'first filter should be removed from memento after removeFilter'
       ).to.deep.equal([secondFilterMapEntry])
 
       testRepository.removeSort(firstSortDefinition.path)
       expect(
-        mockMemento.get('sortBy:test'),
+        mockMemento.get('experimentsSortBy:test'),
         'first sort should be removed from memento after removeSortByPath'
       ).to.deep.equal([secondSortDefinition])
 
@@ -483,7 +483,7 @@ suite('Experiments Test Suite', () => {
       mockRemoveSorts.onFirstCall().resolves([secondSortDefinition])
       await testRepository.removeSorts()
       expect(
-        mockMemento.get('sortBy:test'),
+        mockMemento.get('experimentsSortBy:test'),
         'all sorts should be removed from memento after removeSorts'
       ).to.deep.equal([])
 
@@ -491,7 +491,7 @@ suite('Experiments Test Suite', () => {
       mockPickFilter.onFirstCall().resolves(firstFilterDefinition)
       await testRepository.addFilter()
       expect(
-        mockMemento.get('filterBy:test'),
+        mockMemento.get('experimentsFilterBy:test'),
         'first filter should be re-added'
       ).to.deep.equal([secondFilterMapEntry, firstFilterMapEntry])
 
@@ -501,7 +501,7 @@ suite('Experiments Test Suite', () => {
         .resolves([firstFilterDefinition, secondFilterDefinition])
       await testRepository.removeFilters()
       expect(
-        mockMemento.get('filterBy:test'),
+        mockMemento.get('experimentsFilterBy:test'),
         'both filters should be removed from memento after removeFilters is run against them'
       ).to.deep.equal([])
 
@@ -509,7 +509,7 @@ suite('Experiments Test Suite', () => {
         '4fb124aebddb2adf1545030907687fa9a4c80e70'
       )
       expect(
-        mockMemento.get('status:test'),
+        mockMemento.get('experimentsStatus:test'),
         'the correct statuses have been recorded in the memento'
       ).to.deep.equal({
         '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d': 1,
@@ -517,7 +517,7 @@ suite('Experiments Test Suite', () => {
         '4fb124aebddb2adf1545030907687fa9a4c80e70': 0
       })
       expect(
-        mockMemento.get('colors:test'),
+        mockMemento.get('experimentsColors:test'),
         'the correct colors are persisted'
       ).to.deep.equal(expectedColors)
     })
@@ -531,13 +531,13 @@ suite('Experiments Test Suite', () => {
       const available = ['#000000', '#FFFFFF', '#ABCDEF']
 
       const mockMemento = buildMockMemento({
-        'colors:test': {
+        'experimentsColors:test': {
           assigned,
           available
         },
-        'filterBy:test': filterMapEntries,
-        'sortBy:test': sortDefinitions,
-        'status:test': {
+        'experimentsFilterBy:test': filterMapEntries,
+        'experimentsSortBy:test': sortDefinitions,
+        'experimentsStatus:test': {
           '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d': 1,
           '42b8736b08170529903cd203a1f40382a4b4a8cd': 1,
           '4fb124aebddb2adf1545030907687fa9a4c80e70': 0
@@ -557,9 +557,9 @@ suite('Experiments Test Suite', () => {
       )
       testRepository.setState(expShowFixture)
       await testRepository.isReady()
-      expect(mementoSpy).to.be.calledWith('sortBy:test', [])
-      expect(mementoSpy).to.be.calledWith('filterBy:test', [])
-      expect(mementoSpy).to.be.calledWith('status:test', {})
+      expect(mementoSpy).to.be.calledWith('experimentsSortBy:test', [])
+      expect(mementoSpy).to.be.calledWith('experimentsFilterBy:test', [])
+      expect(mementoSpy).to.be.calledWith('experimentsStatus:test', {})
       expect(testRepository.getSorts()).to.deep.equal(sortDefinitions)
       expect(testRepository.getFilters()).to.deep.equal([
         firstFilterDefinition,

--- a/extension/src/vscode/memento.ts
+++ b/extension/src/vscode/memento.ts
@@ -1,0 +1,12 @@
+export enum MementoPrefix {
+  EXPERIMENTS_COLORS = 'experimentsColors:',
+  EXPERIMENTS_FILTER_BY = 'experimentsFilterBy:',
+  EXPERIMENTS_SORT_BY = 'experimentsSortBy:',
+  EXPERIMENTS_STATUS = 'experimentsStatus:',
+  PARAMS_AND_METRICS_COLUMN_ORDER = 'paramsAndMetricsColumnOrder:',
+  PARAMS_AND_METRICS_COLUMN_WIDTHS = 'paramsAndMetricsColumnWidths:',
+  PARAMS_AND_METRICS_STATUS = 'paramsAndMetricsStatus:',
+  PLOT_SECTION_COLLAPSED = 'plotSectionCollapsed:',
+  PLOT_SELECTED_METRICS = 'plotSelectedMetrics:',
+  PLOT_SIZE = 'plotSize:'
+}


### PR DESCRIPTION
# 3/3 `master` <- #1146 <- #1147 <- this

This PR consolidates the distinct `MementoPrefixes` enums into one. The main reason for doing this is to ensure that we don't see collisions down the track and end up with some gnarly bug.