### PR TITLE
Disable restricted mode in tests

### DIFF
--- a/extension/src/test/runTest.ts
+++ b/extension/src/test/runTest.ts
@@ -17,7 +17,11 @@ async function main() {
     await runTests({
       extensionDevelopmentPath,
       extensionTestsPath,
-      launchArgs: ['--disable-extensions', workspacePath],
+      launchArgs: [
+        '--disable-extensions',
+        '--disable-workspace-trust',
+        workspacePath
+      ],
       vscodeExecutablePath
     })
   } catch {


### PR DESCRIPTION
A recent update to VSCode Insiders disables the Git extension when the workspace is running in Restricted Mode (i.e. the user hasn't hit "trust workspace").

This PR adds a CLI flag to disable the trusted mode mechanism on our CI.