### PR TITLE
Drop to single data point on live plot tooltip

### DIFF
--- a/webview/src/plots/components/constants.ts
+++ b/webview/src/plots/components/constants.ts
@@ -31,7 +31,7 @@ export const createSpec = (
         },
 
         layer: [
-          { mark: 'line' },
+          { mark: { type: 'line' } },
           {
             mark: { type: 'point' },
             transform: [


### PR DESCRIPTION
As discussed in the planning meeting.

The tooltip now looks like this:

![image](https://user-images.githubusercontent.com/37993418/146103471-f9225380-37a0-4e98-8523-a3a3d970ce6d.png)

As opposed to:

![image](https://user-images.githubusercontent.com/37993418/146103514-c27b52a9-2355-42d1-a090-3346bf532111.png)

I think that we can run with this for the time being and revisit if it is raised as an issue later.

LMK what you think, happy to open a discussion ticket if anything thinks it is still needed.