### PR TITLE
Switch away from pyyaml in demo project

### DIFF
--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -2,3 +2,4 @@ dvc[s3]>=2.8.2
 dvclive
 torch
 torchvision
+ruamel.yaml

--- a/demo/train.py
+++ b/demo/train.py
@@ -1,6 +1,6 @@
 """Model training and evaluation."""
 import json
-import yaml
+from ruamel.yaml import YAML
 import os
 import torch
 import torch.nn.functional as F
@@ -91,8 +91,9 @@ def main():
     if os.path.exists("model.pt"):
         model.load_state_dict(torch.load("model.pt"))
     # Load params.
+    yaml = YAML(typ="safe")
     with open("params.yaml") as f:
-        params = yaml.safe_load(f)
+        params = yaml.load(f)
     torch.manual_seed(params["seed"])
     # Load train and test data.
     mnist_train = torchvision.datasets.MNIST("data", download=True)


### PR DESCRIPTION
Relates to iterative/dvc#5971.

Tl;dr is when we use pyyaml we read yaml as 1.1. We need to use 1.2 to avoid the type errors shown in #1159. We can ensure we use 1.2 by switching to the library in this PR. Doesn't solve the root cause but patches it for us for now. We will need to document this in our walkthrough I think.

cc @dberenbaum