### PR TITLE
Get experiment names from model instead of CLI

### DIFF
--- a/extension/src/cli/args.ts
+++ b/extension/src/cli/args.ts
@@ -34,13 +34,11 @@ export enum ExperimentSubCommand {
   APPLY = 'apply',
   BRANCH = 'branch',
   GARBAGE_COLLECT = 'gc',
-  LIST = 'list',
   REMOVE = 'remove',
   RUN = 'run'
 }
 
 export enum ExperimentFlag {
-  NAMES_ONLY = '--names-only',
   QUEUE = '--queue',
   RESET = '--reset',
   RUN_ALL = '--run-all'

--- a/extension/src/cli/reader.test.ts
+++ b/extension/src/cli/reader.test.ts
@@ -60,25 +60,6 @@ describe('CliReader', () => {
     }
   )
 
-  describe('experimentListCurrent', () => {
-    it('should call the cli with the correct parameters to list all current experiments', async () => {
-      const cwd = __dirname
-      const experimentNames = ['exp-0180a', 'exp-c5444', 'exp-054c1']
-      mockedCreateProcess.mockReturnValueOnce(
-        getMockedProcess(experimentNames.join('\n'))
-      )
-
-      const experimentList = await cliReader.experimentListCurrent(cwd)
-      expect(experimentList).toEqual(experimentNames)
-      expect(mockedCreateProcess).toBeCalledWith({
-        args: ['exp', 'list', '--names-only'],
-        cwd,
-        env: mockedEnv,
-        executable: 'dvc'
-      })
-    })
-  })
-
   describe('experimentShow', () => {
     it('should match the expected output', async () => {
       const cwd = __dirname

--- a/extension/src/cli/reader.ts
+++ b/extension/src/cli/reader.ts
@@ -1,14 +1,6 @@
 import isEqual from 'lodash.isequal'
 import { Cli, typeCheckCommands } from '.'
-import {
-  Args,
-  Command,
-  ExperimentFlag,
-  ExperimentSubCommand,
-  Flag,
-  ListFlag,
-  SubCommand
-} from './args'
+import { Args, Command, Flag, ListFlag, SubCommand } from './args'
 import { retry } from './retry'
 import { trimAndSplit } from '../util/stdout'
 import { PlotsOutput } from '../plots/webview/contract'
@@ -101,7 +93,6 @@ export interface ExperimentsOutput {
 
 export const autoRegisteredCommands = {
   DIFF: 'diff',
-  EXPERIMENT_LIST_CURRENT: 'experimentListCurrent',
   EXPERIMENT_SHOW: 'experimentShow',
   LIST_DVC_ONLY_RECURSIVE: 'listDvcOnlyRecursive',
   PLOTS_SHOW: 'plotsShow',
@@ -113,16 +104,6 @@ export class CliReader extends Cli {
     autoRegisteredCommands,
     this
   )
-
-  public experimentListCurrent(cwd: string): Promise<string[]> {
-    return this.readProcess<string[]>(
-      cwd,
-      trimAndSplit,
-      Command.EXPERIMENT,
-      ExperimentSubCommand.LIST,
-      ExperimentFlag.NAMES_ONLY
-    )
-  }
 
   public experimentShow(cwd: string): Promise<ExperimentsOutput> {
     return this.readShowProcessJson<ExperimentsOutput>(cwd, Command.EXPERIMENT)

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -200,6 +200,10 @@ export class Experiments extends BaseRepository<TableData> {
     }
   }
 
+  public pickCurrentExperimentName() {
+    return pickExperimentName(this.experiments.getCurrentExperimentNames())
+  }
+
   public async pickParamsToQueue() {
     const base = await pickExperimentName(this.experiments.getExperimentNames())
 

--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -175,6 +175,14 @@ export class ExperimentsModel {
     ].filter(Boolean) as string[]
   }
 
+  public getCurrentExperimentNames() {
+    return [
+      ...this.flattenExperiments()
+        .filter(exp => !exp.queued)
+        .map(experiment => experiment.displayName)
+    ].filter(Boolean) as string[]
+  }
+
   public getExperimentParams(displayName: string) {
     const params =
       displayName === 'workspace'

--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -1,7 +1,6 @@
 import { EventEmitter, Memento } from 'vscode'
 import { Experiments } from '.'
 import { readToQueueFromCsv } from './model/queue'
-import { pickExperimentName } from './quickPick'
 import { TableData } from './webview/contract'
 import {
   CommandId,
@@ -184,7 +183,7 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
       return
     }
 
-    const experimentName = await this.pickExperimentName(cwd)
+    const experimentName = await this.pickCurrentExperimentName(cwd)
 
     if (!experimentName) {
       return
@@ -220,7 +219,7 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
       return
     }
 
-    const experimentName = await this.pickExperimentName(cwd)
+    const experimentName = await this.pickCurrentExperimentName(cwd)
 
     if (!experimentName) {
       return
@@ -283,12 +282,7 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
     return this.focusedWebviewDvcRoot || this.getOnlyOrPickProject()
   }
 
-  private pickExperimentName(cwd: string) {
-    return pickExperimentName(
-      this.internalCommands.executeCommand(
-        AvailableCommands.EXPERIMENT_LIST_CURRENT,
-        cwd
-      )
-    )
+  private pickCurrentExperimentName(cwd: string) {
+    return this.getRepository(cwd).pickCurrentExperimentName()
   }
 }


### PR DESCRIPTION
Follow up from https://github.com/iterative/vscode-dvc/pull/1159#discussion_r769849942