### PR TITLE
Display names next to experiments

### DIFF
--- a/webview/src/experiments/components/Experiments/index.tsx
+++ b/webview/src/experiments/components/Experiments/index.tsx
@@ -70,7 +70,9 @@ const getColumns = (columns: MetricOrParam[]): Column<Experiment>[] =>
               {getExperimentDisplayName(value, name, isBranchRow)}
             </span>
             {!isBranchRow && name && (
-              <span className={styles.experimentCellSecondaryName}>{name}</span>
+              <span className={styles.experimentCellSecondaryName}>
+                [{name}]
+              </span>
             )}
           </div>
         )

--- a/webview/src/stories/Table.stories.tsx
+++ b/webview/src/stories/Table.stories.tsx
@@ -20,11 +20,11 @@ const tableData: TableData = {
     ...row,
     subRows: row.subRows?.map(experiment => ({
       ...experiment,
-      selected: experiment.name !== 'test-branch',
+      selected: experiment.displayName !== 'test-branch',
       subRows: experiment.subRows?.map(checkpoint => ({
         ...checkpoint,
         running: checkpoint.running || checkpoint.displayName === '23250b3',
-        selected: experiment.name !== 'test-branch'
+        selected: experiment.displayName !== 'test-branch'
       }))
     }))
   })),


### PR DESCRIPTION
Fixes #1172 

This PR changes *only* the webview to display experiment names differently:

- Workspace and branch rows are the same
- All other rows (Experiments) now always display the id truncated to a length of 7 as the primary name, if the `name` property exists, it is displayed beside this experiment id. This secondary name is on the same line by default, collapses to a second row if there is not enough space for that, and finally truncates with an ellipsis like any other field.

This PR originally changed `displayName` from the `collectExperiments` function to a similar behavior, but that ended up breaking most other functions of experiments because we apparently use `displayName` for a _lot_ more than just displaying- live plots don't render, and experiments cannot be selected from a quickpick. In order to avoid this PR becoming a repo-wide ordeal, I opted to change it such that it completely lies within the webview. 

We'll have to make some larger changes in the future to have this reflected in other places like the Experiments TreeView and QuickPicks. It seems like this will require us to drop `displayName` as a concept.

Demo:

https://user-images.githubusercontent.com/9111807/147031575-7d43dfde-89c3-4516-bb26-8d933a46d98c.mp4