### PR TITLE
Fix static plot resize

### DIFF
--- a/webview/src/plots/components/styles.module.scss
+++ b/webview/src/plots/components/styles.module.scss
@@ -96,6 +96,11 @@ $gap: 20px;
   max-height: 200px;
 }
 
+.plot img, .plot svg {
+  max-width: 100%;
+  max-height: 100%;
+}
+
 .sectionRenamer {
   background-color: transparent;
   font-size: 1.25rem;


### PR DESCRIPTION

https://user-images.githubusercontent.com/3683420/146785045-30fe748f-bb2d-406b-b404-1d63d5e7981c.mov

Not a super impressive demo, but before the plots would overlap. It's still not  an optimal view of the plot, but I hope that if someone is looking at the plots with such a small window that they at least use the "large" size and not the regular as shown in the demo.