### PR TITLE
Link modified checkpoint experiments in live plots

### DIFF
--- a/extension/src/experiments/model/collect.test.ts
+++ b/extension/src/experiments/model/collect.test.ts
@@ -1,6 +1,6 @@
 import { collectExperiments } from './collect'
 import { Experiment } from '../webview/contract'
-import ModifiedFixture from '../../test/fixtures/expShow/modified'
+import modifiedFixture from '../../test/fixtures/expShow/modified'
 
 describe('collectExperiments', () => {
   it('should return an empty array if no branches are present', () => {
@@ -94,7 +94,7 @@ describe('collectExperiments', () => {
   })
 
   it('should handle the continuation of a modified checkpoint', () => {
-    const { checkpointsByTip } = collectExperiments(ModifiedFixture)
+    const { checkpointsByTip } = collectExperiments(modifiedFixture)
 
     const modifiedExperiment = checkpointsByTip
       .get('55a07df59246a1a6280feb16dd022877178e80f6')

--- a/extension/src/plots/model/collect.test.ts
+++ b/extension/src/plots/model/collect.test.ts
@@ -1,12 +1,38 @@
+import omit from 'lodash.omit'
 import { collectLivePlotsData } from './collect'
 import expShowFixture from '../../test/fixtures/expShow/output'
+import modifiedFixture from '../../test/fixtures/expShow/modified'
 import livePlotsFixture from '../../test/fixtures/expShow/livePlots'
 import { ExperimentsOutput } from '../../cli/reader'
+import { definedAndNonEmpty } from '../../util/array'
 
 describe('collectLivePlotsData', () => {
   it('should return the expected data from the test fixture', () => {
     const data = collectLivePlotsData(expShowFixture)
     expect(data).toEqual(livePlotsFixture.plots)
+  })
+
+  it('should provide a continuous series for a modified experiment', () => {
+    const data = collectLivePlotsData(modifiedFixture)
+
+    expect(definedAndNonEmpty(data)).toBeTruthy()
+
+    data?.forEach(({ values }) => {
+      const initialExperiment = values.filter(
+        point => point.group === 'exp-908bd'
+      )
+      const modifiedExperiment = values.filter(
+        point => point.group === 'exp-01b3a'
+      )
+
+      const lastIterationInitial = initialExperiment?.slice(-1)[0]
+      const firstIterationModified = modifiedExperiment[0]
+
+      expect(lastIterationInitial).not.toEqual(firstIterationModified)
+      expect(omit(lastIterationInitial, 'group')).toEqual(
+        omit(firstIterationModified, 'group')
+      )
+    })
   })
 
   it('should return undefined given no input', () => {


### PR DESCRIPTION
# 2/2 `master` <- #1202 <- this

This PR adds a link in our live plots for modified checkpoint experiment based on a previous one. There will now be a continuous line shown between the two plots. This (indirectly) matches what is shown in the table and tree view.

## Screenshot

<img width="1680" alt="Screen Shot 2022-01-11 at 3 32 07 pm" src="https://user-images.githubusercontent.com/37993418/148882476-d4897d36-a689-43d5-89a1-8ff232415c1f.png">

## Demo

https://user-images.githubusercontent.com/37993418/148882975-74baf0ae-f67a-4908-b7a0-1ce2f2ca058d.mov

Closes #1182.