### PR TITLE
Add autoResetResize to react-table options

### DIFF
--- a/webview/src/experiments/components/Experiments/index.tsx
+++ b/webview/src/experiments/components/Experiments/index.tsx
@@ -130,6 +130,7 @@ export const ExperimentsTable: React.FC<{
   const instance = useTable<Experiment>(
     {
       autoResetExpanded: false,
+      autoResetResize: false,
       columns,
       data,
       defaultColumn,


### PR DESCRIPTION
This PR fixes #1203, an issue I missed when manually QA'ing #1191 where any update to `tableData` would reset column widths.

This is actually an explicit feature of `react-table`'s `useColumnResize`, similarly to the `autoResetExpanded` option which we have disabled. Unlike `autoResetExpanded`, this one wasn't documented but I found it in the source code. :cartwheeling: 

Demo of column widths not resetting:

https://user-images.githubusercontent.com/9111807/149012003-7d5f52f6-41b3-4a2f-9c4e-82411f6543fc.mp4