### PR TITLE
Order root directory in tracked tree

### DIFF
--- a/extension/src/fileSystem/tree.ts
+++ b/extension/src/fileSystem/tree.ts
@@ -153,6 +153,13 @@ export class TrackedExplorerTree implements TreeDataProvider<PathItem> {
     return this.getRepoChildren(dvcRoot, resourceUri.fsPath)
   }
 
+  private async getRepoChildren(dvcRoot: string, path?: string) {
+    await this.repositories.isReady()
+    return this.sortDirectory(
+      this.repositories.getRepository(dvcRoot).getChildren(path || dvcRoot)
+    )
+  }
+
   private sortDirectory(contents: PathItem[]) {
     return contents.sort((a, b) => {
       const aIsDirectory = a.isDirectory
@@ -161,11 +168,6 @@ export class TrackedExplorerTree implements TreeDataProvider<PathItem> {
       }
       return aIsDirectory ? -1 : 1
     })
-  }
-
-  private async getRepoChildren(dvcRoot: string, path?: string) {
-    await this.repositories.isReady()
-    return this.repositories.getRepository(dvcRoot).getChildren(path || dvcRoot)
   }
 
   private registerCommands(workspaceChanged: EventEmitter<void>) {


### PR DESCRIPTION
Quick bug fix.

Whilst working with a new plots directory I noticed that the root elements were not sorted correctly:

![image](https://user-images.githubusercontent.com/37993418/149303492-3f185a85-3cb3-4831-9b4d-2e862e491b27.png)


This PR fixes the ordering to always have directories before files (as opposed to being alphabetically ordered).