### PR TITLE
Reinstate plots file watcher

### DIFF
--- a/extension/src/data/index.ts
+++ b/extension/src/data/index.ts
@@ -1,10 +1,13 @@
+import { join } from 'path'
 import { EventEmitter, Event } from 'vscode'
 import { Disposable } from '@hediet/std/disposable'
 import { Deferred } from '@hediet/std/synchronization'
+import { createFileSystemWatcher } from '../fileSystem/watcher'
 import { ProcessManager } from '../processManager'
-import { InternalCommands } from '../commands/internal'
+import { CommandId, InternalCommands } from '../commands/internal'
 import { ExperimentsOutput } from '../cli/reader'
 import { PlotsOutput } from '../plots/webview/contract'
+import { definedAndNonEmpty, sameContents, uniqueValues } from '../util/array'
 
 export abstract class BaseData<T extends PlotsOutput | ExperimentsOutput> {
   public readonly dispose = Disposable.fn()
@@ -12,19 +15,38 @@ export abstract class BaseData<T extends PlotsOutput | ExperimentsOutput> {
 
   protected readonly dvcRoot: string
   protected readonly processManager: ProcessManager
-  protected readonly internalCommands: InternalCommands
-  protected readonly deferred = new Deferred()
 
+  protected args?: string[]
+
+  private collectedFiles: string[] = []
+  private readonly staticFiles: string[]
+
+  private readonly deferred = new Deferred()
   private readonly initialized = this.deferred.promise
+
+  private readonly internalCommands: InternalCommands
 
   private readonly updated: EventEmitter<T> = this.dispose.track(
     new EventEmitter()
   )
 
+  private readonly collectedFilesChanged = this.dispose.track(
+    new EventEmitter<void>()
+  )
+
+  private readonly onDidChangeCollectedFiles: Event<void> =
+    this.collectedFilesChanged.event
+
+  private watcher?: Disposable
+
+  private readonly updateCommandId: CommandId
+
   constructor(
     dvcRoot: string,
     internalCommands: InternalCommands,
-    updatesPaused: EventEmitter<boolean>
+    updateCommandId: CommandId,
+    updatesPaused: EventEmitter<boolean>,
+    staticFiles: string[] = []
   ) {
     this.dvcRoot = dvcRoot
     this.processManager = this.dispose.track(
@@ -35,7 +57,11 @@ export abstract class BaseData<T extends PlotsOutput | ExperimentsOutput> {
     )
 
     this.internalCommands = internalCommands
+    this.updateCommandId = updateCommandId
     this.onDidUpdate = this.updated.event
+    this.staticFiles = staticFiles
+
+    this.initialize()
   }
 
   public isReady() {
@@ -46,9 +72,72 @@ export abstract class BaseData<T extends PlotsOutput | ExperimentsOutput> {
     return this.processManager.run('update')
   }
 
-  protected notifyChanged(data: T) {
+  private initialize() {
+    const waitForInitialData = this.dispose.track(
+      this.onDidUpdate(() => {
+        this.watcher = this.watchFiles()
+
+        this.dispose.track(
+          this.onDidChangeCollectedFiles(() => {
+            const watcher = this.watchFiles()
+            this.dispose.untrack(this.watcher)
+            this.watcher?.dispose()
+            this.watcher = watcher
+          })
+        )
+        this.dispose.untrack(waitForInitialData)
+        waitForInitialData.dispose()
+        this.deferred.resolve()
+      })
+    )
+    this.managedUpdate()
+  }
+
+  private async update(): Promise<void> {
+    const data = await this.internalCommands.executeCommand<T>(
+      this.updateCommandId,
+      this.dvcRoot,
+      ...(this.args || [])
+    )
+
+    const files = this.collectFiles(data)
+
+    this.compareFiles(files)
+
+    return this.notifyChanged(data)
+  }
+
+  private compareFiles(files: string[]) {
+    if (sameContents(this.collectedFiles, files)) {
+      return
+    }
+
+    this.collectedFiles = files
+    this.collectedFilesChanged.fire()
+  }
+
+  private notifyChanged(data: T) {
     this.updated.fire(data)
   }
 
-  abstract update(): Promise<unknown>
+  private watchFiles() {
+    const files = uniqueValues([...this.staticFiles, ...this.collectedFiles])
+    if (!definedAndNonEmpty(files)) {
+      return
+    }
+
+    return this.dispose.track(
+      createFileSystemWatcher(
+        join(this.dvcRoot, '**', `{${files.join(',')}}`),
+        path => {
+          if (!path) {
+            return
+          }
+          this.managedUpdate()
+        }
+      )
+    )
+  }
+
+  abstract collectFiles(data: T): string[]
 }

--- a/extension/src/experiments/data/index.ts
+++ b/extension/src/experiments/data/index.ts
@@ -1,12 +1,8 @@
 import { join, relative } from 'path'
-import { Disposable } from '@hediet/std/disposable'
-import { Event, EventEmitter } from 'vscode'
+import { EventEmitter } from 'vscode'
 import { collectFiles } from './collect'
 import { EXPERIMENTS_GIT_REFS } from './constants'
-import {
-  createFileSystemWatcher,
-  createNecessaryFileSystemWatcher
-} from '../../fileSystem/watcher'
+import { createNecessaryFileSystemWatcher } from '../../fileSystem/watcher'
 import {
   DOT_GIT,
   DOT_GIT_HEAD,
@@ -16,105 +12,30 @@ import {
 import { AvailableCommands, InternalCommands } from '../../commands/internal'
 import { ExperimentsOutput } from '../../cli/reader'
 import { BaseData } from '../../data'
-import {
-  definedAndNonEmpty,
-  sameContents,
-  uniqueValues
-} from '../../util/array'
 
 export class ExperimentsData extends BaseData<ExperimentsOutput> {
-  private collectedFiles: string[] = []
-  private readonly staticFiles: string[]
-  private watcher?: Disposable
-
-  private readonly collectedFilesChanged = this.dispose.track(
-    new EventEmitter<void>()
-  )
-
-  private readonly onDidChangeCollectedFiles: Event<void> =
-    this.collectedFilesChanged.event
-
   constructor(
     dvcRoot: string,
     internalCommands: InternalCommands,
     updatesPaused: EventEmitter<boolean>
   ) {
-    super(dvcRoot, internalCommands, updatesPaused)
-
-    this.staticFiles = ['dvc.lock', 'dvc.yaml', 'params.yaml']
+    super(
+      dvcRoot,
+      internalCommands,
+      AvailableCommands.EXPERIMENT_SHOW,
+      updatesPaused,
+      ['dvc.lock', 'dvc.yaml', 'params.yaml']
+    )
 
     this.watchExpGitRefs()
-    this.initialize()
+  }
+
+  public collectFiles(data: ExperimentsOutput) {
+    return collectFiles(data)
   }
 
   public forceUpdate() {
     return this.processManager.forceRunQueued()
-  }
-
-  public async update(): Promise<void> {
-    const data = await this.internalCommands.executeCommand<ExperimentsOutput>(
-      AvailableCommands.EXPERIMENT_SHOW,
-      this.dvcRoot
-    )
-
-    const files = this.collectFiles(data)
-
-    this.compareFiles(files)
-
-    return this.notifyChanged(data)
-  }
-
-  private collectFiles(data: ExperimentsOutput) {
-    return collectFiles(data)
-  }
-
-  private compareFiles(files: string[]) {
-    if (sameContents(this.collectedFiles, files)) {
-      return
-    }
-
-    this.collectedFiles = files
-    this.collectedFilesChanged.fire()
-  }
-
-  private watchFiles() {
-    const files = uniqueValues([...this.staticFiles, ...this.collectedFiles])
-    if (!definedAndNonEmpty(files)) {
-      return
-    }
-
-    return this.dispose.track(
-      createFileSystemWatcher(
-        join(this.dvcRoot, '**', `{${files.join(',')}}`),
-        path => {
-          if (!path) {
-            return
-          }
-          this.managedUpdate()
-        }
-      )
-    )
-  }
-
-  private initialize() {
-    const waitForInitialData = this.dispose.track(
-      this.onDidUpdate(() => {
-        this.watcher = this.watchFiles()
-
-        this.dispose.track(
-          this.onDidChangeCollectedFiles(() => {
-            const watcher = this.watchFiles()
-            this.dispose.untrack(this.watcher)
-            this.watcher?.dispose()
-            this.watcher = watcher
-          })
-        )
-        this.dispose.untrack(waitForInitialData)
-        waitForInitialData.dispose()
-        this.deferred.resolve()
-      })
-    )
-    this.managedUpdate()
   }
 
   private async watchExpGitRefs(): Promise<void> {

--- a/extension/src/plots/data/index.ts
+++ b/extension/src/plots/data/index.ts
@@ -5,48 +5,33 @@ import { PlotsOutput } from '../../plots/webview/contract'
 import { sameContents } from '../../util/array'
 
 export class PlotsData extends BaseData<PlotsOutput> {
-  private revisions?: string[]
-
   constructor(
     dvcRoot: string,
     internalCommands: InternalCommands,
     updatesPaused: EventEmitter<boolean>
   ) {
-    super(dvcRoot, internalCommands, updatesPaused)
+    super(
+      dvcRoot,
+      internalCommands,
+      AvailableCommands.PLOTS_DIFF,
+      updatesPaused
+    )
+  }
 
-    this.initialize()
+  public collectFiles(data: PlotsOutput) {
+    return Object.keys(data)
   }
 
   public clearRevisions() {
-    this.revisions = undefined
+    this.args = undefined
   }
 
-  public setRevisions(...revisions: string[]) {
-    if (this.revisions && sameContents(revisions, this.revisions)) {
+  public setRevisions(...args: string[]) {
+    if (this.args && sameContents(args, this.args)) {
       return
     }
 
-    this.revisions = revisions
+    this.args = args
     this.managedUpdate()
-  }
-
-  public async update(): Promise<void> {
-    const data = await this.internalCommands.executeCommand<PlotsOutput>(
-      AvailableCommands.PLOTS_DIFF,
-      this.dvcRoot,
-      ...(this.revisions || [])
-    )
-
-    return this.notifyChanged(data)
-  }
-
-  private initialize() {
-    const waitForInitialData = this.dispose.track(
-      this.onDidUpdate(() => {
-        this.dispose.untrack(waitForInitialData)
-        waitForInitialData.dispose()
-        this.deferred.resolve()
-      })
-    )
   }
 }

--- a/extension/src/test/suite/plots/index.test.ts
+++ b/extension/src/test/suite/plots/index.test.ts
@@ -45,7 +45,7 @@ suite('Plots Test Suite', () => {
 
       expect(mockPlotsDiff).to.be.called
       expect(managedUpdateSpy, 'should call the cli when the webview is loaded')
-        .to.be.calledOnce
+        .to.be.called
 
       expect(messageSpy).to.be.calledWith({
         static: staticPlotsFixture


### PR DESCRIPTION
# 2/3 `master` <- #1228 <- this <- #1231

This PR reinstates the file system watcher for plots files. We do actually need this because updates can be made in the workspace which do not lead to changes in the experiments data (i.e `dvc checkout` after garbage collecting experiments). We are also moving towards keeping a copy of the data in the extension and away from the push system that is currently in place. I am going to put a copy of the `plotsModel` into `plotsData` so that we only call for updates when we don't already have the desired revision available.