### PR TITLE
Keep copy of static plots data inside of plots model

### DIFF
--- a/extension/src/plots/data/index.ts
+++ b/extension/src/plots/data/index.ts
@@ -3,8 +3,11 @@ import { AvailableCommands, InternalCommands } from '../../commands/internal'
 import { BaseData } from '../../data'
 import { PlotsOutput } from '../../plots/webview/contract'
 import { sameContents } from '../../util/array'
+import { PlotsModel } from '../model'
 
 export class PlotsData extends BaseData<PlotsOutput> {
+  private model?: PlotsModel
+
   constructor(
     dvcRoot: string,
     internalCommands: InternalCommands,
@@ -26,12 +29,17 @@ export class PlotsData extends BaseData<PlotsOutput> {
     this.args = undefined
   }
 
-  public setRevisions(...args: string[]) {
+  public setRevisions() {
+    const args = this.model?.getRevisions() || []
     if (this.args && sameContents(args, this.args)) {
       return
     }
 
     this.args = args
     this.managedUpdate()
+  }
+
+  public setModel(model: PlotsModel) {
+    this.model = model
   }
 }

--- a/extension/src/plots/model/index.ts
+++ b/extension/src/plots/model/index.ts
@@ -5,6 +5,7 @@ import {
   defaultSectionCollapsed,
   LivePlotData,
   PlotSize,
+  PlotsOutput,
   Section,
   SectionCollapsed
 } from '../../plots/webview/contract'
@@ -37,6 +38,7 @@ export class PlotsModel {
   private sectionCollapsed: SectionCollapsed
   private sectionNames: Record<Section, string>
   private revisions: string[] = []
+  private plotsDiff?: PlotsOutput
 
   constructor(
     dvcRoot: string,
@@ -68,7 +70,7 @@ export class PlotsModel {
     )
   }
 
-  public async transformAndSet(data: ExperimentsOutput) {
+  public async transformAndSetExperiments(data: ExperimentsOutput) {
     const [livePlots, revisions] = await Promise.all([
       collectLivePlotsData(data),
       collectRevisions(data)
@@ -76,6 +78,14 @@ export class PlotsModel {
 
     this.livePlots = livePlots
     this.revisions = revisions
+  }
+
+  public transformAndSetPlots(data: PlotsOutput) {
+    this.plotsDiff = data
+  }
+
+  public getPlotsDiff() {
+    return this.plotsDiff
   }
 
   public getLivePlots() {

--- a/extension/src/test/suite/experiments/model/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/tree.test.ts
@@ -83,7 +83,8 @@ suite('Experiments Tree Test Suite', () => {
 
       const initialData = {
         sectionCollapsed: defaultSectionCollapsed,
-        ...getExpectedLivePlotsData(expectedDomain, expectedRange)
+        ...getExpectedLivePlotsData(expectedDomain, expectedRange),
+        static: null
       }
 
       while (expectedDomain.length) {

--- a/extension/src/test/suite/plots/index.test.ts
+++ b/extension/src/test/suite/plots/index.test.ts
@@ -47,13 +47,10 @@ suite('Plots Test Suite', () => {
       expect(managedUpdateSpy, 'should call the cli when the webview is loaded')
         .to.be.called
 
-      expect(messageSpy).to.be.calledWith({
-        static: staticPlotsFixture
-      })
-
       const expectedPlotsData: TPlotsData = {
         live: livePlotsFixture,
-        sectionCollapsed: defaultSectionCollapsed
+        sectionCollapsed: defaultSectionCollapsed,
+        static: staticPlotsFixture
       }
 
       expect(messageSpy).to.be.calledWith(expectedPlotsData)


### PR DESCRIPTION
# 3/3 `master` <- #1228 <- #1230 <- this

This PR moves us away from pushing data updates directly out of the `PlotsData` class into the webview. We now use the same pattern in both the `Plots` and `Experiments` classes. I.e we keep a copy of the data in the model and pull it out whenever a change occurs. 

Next steps:

1. Split out vega data from the templates and separate out the images as well (i.e use collection which was set-up in #1228)
2. Only call `diff` for revisions that we don't have.
3. Wire up toggling experiments on/off.
4. Rework data that is being sent to the webview.
5. Cleanup in-memory cache when revisions are no longer needed.
6. Use files to cache revision data.
7. Cleanup files when they are no longer needed.