### PR TITLE
Add title attribute to rendered column headers

### DIFF
--- a/webview/src/experiments/react-table-config.d.ts
+++ b/webview/src/experiments/react-table-config.d.ts
@@ -38,6 +38,7 @@ declare module 'react-table' {
     D extends Record<string, unknown> = Record<string, unknown>
   > extends UseResizeColumnsColumnOptions<D> {
     group?: string
+    name?: string
   }
 
   export interface ColumnInstance<

--- a/webview/src/experiments/util/buildDynamicColumns.tsx
+++ b/webview/src/experiments/util/buildDynamicColumns.tsx
@@ -28,6 +28,12 @@ const Cell: React.FC<{ value: Value }> = ({ value }) => {
   )
 }
 
+const Header: React.FC<{ column: Column<Experiment> }> = ({
+  column: { name }
+}) => {
+  return <span title={name}>{name}</span>
+}
+
 const getCellComponent = (): React.FC<{ value: Value }> => Cell
 
 const buildAccessor: (valuePath: string[]) => Accessor<Experiment> =
@@ -48,11 +54,12 @@ const buildDynamicColumns = (
 
       const column: ColumnGroup<Experiment> | Column<Experiment> = {
         Cell,
-        Header: data.name,
+        Header,
         accessor: pathArray && buildAccessor(pathArray),
         columns: childColumns.length ? childColumns : undefined,
         group,
-        id: path
+        id: path,
+        name: data.name
       }
       return column
     })


### PR DESCRIPTION
# #1258 <- this

This PR adds HTML-native `title` tags to column headers, adding the feature of showing a full name when hovering over the column, even when the column is made so thin that it obscures the name.

To add this feature, the `react-table` config for headers was slightly modified such that the header text is in its own `name` field, while `Header` is a component that consumes it.

It doesn't apply to cells, but I can also do so there if we'd like.

https://user-images.githubusercontent.com/9111807/151453421-51573803-b9e1-43ad-a9bb-b22937d09934.mp4