### PR TITLE
Fix right-most spaces being unavailable for column ordering

### DIFF
--- a/webview/src/experiments/components/Experiments/index.tsx
+++ b/webview/src/experiments/components/Experiments/index.tsx
@@ -166,13 +166,6 @@ export const ExperimentsTable: React.FC<{
           expandedRowCount
         })
       })
-      hooks.allColumns.push((allColumns, { instance: { state } }) => {
-        const { columnOrder } = state
-        if (!columnOrder || columnOrder.length === 0) {
-          state.columnOrder = allColumns.map(col => col.id)
-        }
-        return allColumns
-      })
     }
   )
 

--- a/webview/src/experiments/components/Table/MergeHeaderGroups.tsx
+++ b/webview/src/experiments/components/Table/MergeHeaderGroups.tsx
@@ -3,33 +3,32 @@ import cx from 'classnames'
 import { SortDefinition } from 'dvc/src/experiments/model/sortBy'
 import { Experiment, MetricOrParam } from 'dvc/src/experiments/webview/contract'
 import { HeaderGroup } from 'react-table'
-import {
-  DragDropContext,
-  DragUpdate,
-  Droppable,
-  DropResult,
-  ResponderProvided
-} from 'react-beautiful-dnd'
+import { DragDropContext, Droppable, Responders } from 'react-beautiful-dnd'
 import { TableHeader } from './TableHeader'
 import styles from './styles.module.scss'
 
-export const MergedHeaderGroup: React.FC<{
-  headerGroup: HeaderGroup<Experiment>
-  columns: HeaderGroup<Experiment>[]
-  sorts: SortDefinition[]
-  orderedColumns: MetricOrParam[]
-  onDragUpdate?: (initial: DragUpdate, provided: ResponderProvided) => void
-  onDragEnd: (initial: DropResult, provided: ResponderProvided) => void
-}> = ({
+export const MergedHeaderGroup: React.FC<
+  {
+    headerGroup: HeaderGroup<Experiment>
+    columns: HeaderGroup<Experiment>[]
+    sorts: SortDefinition[]
+    orderedColumns: MetricOrParam[]
+  } & Responders
+> = ({
   headerGroup,
   sorts,
   columns,
   orderedColumns,
+  onDragStart,
   onDragUpdate,
   onDragEnd
 }) => {
   return (
-    <DragDropContext onDragUpdate={onDragUpdate} onDragEnd={onDragEnd}>
+    <DragDropContext
+      onDragStart={onDragStart}
+      onDragUpdate={onDragUpdate}
+      onDragEnd={onDragEnd}
+    >
       <Droppable droppableId="droppable" direction="horizontal">
         {provided => (
           <div

--- a/webview/src/experiments/components/Table/TableHead.tsx
+++ b/webview/src/experiments/components/Table/TableHead.tsx
@@ -1,6 +1,6 @@
 import { SortDefinition } from 'dvc/src/experiments/model/sortBy'
 import { Experiment, MetricOrParam } from 'dvc/src/experiments/webview/contract'
-import React from 'react'
+import React, { useRef } from 'react'
 import { HeaderGroup, TableInstance } from 'react-table'
 import { DragUpdate } from 'react-beautiful-dnd'
 import { MessageFromWebviewType } from 'dvc/src/webview/contract'
@@ -19,7 +19,8 @@ export const TableHead: React.FC<TableHeadProps> = ({
   instance: {
     headerGroups,
     setColumnOrder,
-    state: { columnOrder }
+    state: { columnOrder },
+    allColumns
   },
   columns,
   sorts
@@ -28,18 +29,23 @@ export const TableHead: React.FC<TableHeadProps> = ({
   const allHeaders: HeaderGroup<Experiment>[] = []
   headerGroups.forEach(headerGroup => allHeaders.push(...headerGroup.headers))
 
+  const fullColumnOrder = useRef<string[]>()
+
+  const onDragStart = () => {
+    fullColumnOrder.current = allColumns.map(column => column.id)
+  }
+
   const onDragUpdate = (column: DragUpdate) => {
     if (!column.destination) {
       return
     }
     const { draggableId, destination } = column
     if (destination.index > 1) {
-      const colOrder = [...columnOrder]
-      const oldIndex = colOrder.indexOf(draggableId)
-
-      colOrder.splice(oldIndex, 1)
-      colOrder.splice(destination.index, 0, draggableId)
-      setColumnOrder(colOrder)
+      const newColumnOrder = [...(fullColumnOrder.current as string[])]
+      const oldIndex = newColumnOrder.indexOf(draggableId)
+      newColumnOrder.splice(oldIndex, 1)
+      newColumnOrder.splice(destination.index, 0, draggableId)
+      setColumnOrder(newColumnOrder)
     }
   }
 
@@ -60,6 +66,7 @@ export const TableHead: React.FC<TableHeadProps> = ({
           headerGroup={headerGroup}
           columns={allHeaders}
           sorts={sorts}
+          onDragStart={onDragStart}
           onDragUpdate={onDragUpdate}
           onDragEnd={onDragEnd}
         />


### PR DESCRIPTION
This PR fixes #1278 by effectively undoing the `columnOrder` part of #1191, but this time using a `useRef`-based implementation as seen in [the original `react-beautiful-dnd`+`react-table` example](https://github.com/TanStack/react-table/issues/1570) we used.

Bug replication on `master`:

https://user-images.githubusercontent.com/9111807/152252034-4caa7125-23a5-4699-991f-5b83e6998640.mp4

Same scenario fixed on this PR:

https://user-images.githubusercontent.com/9111807/152252837-3eb63f4e-0627-4113-b111-66fd832c0e15.mp4

The initial problem is that `state.columnOrder` doesn't always contain every column, and if we only populate a full `columnOrder` on initialization then any columns added after are never put into that order and the result is that an amount of columns equal to however many were added become unavailable "slots" at the end. Thus, we need to ensure that an array with every column in order is always provided to `onDragUpdate`, and there are only two ways I can see this being doable:

1. Update `columnOrder` to contain all columns every time columns are updated.
2. Either update `columnOrder` or create a new array that contains all columns every time a drag is started.

This PR is option 2, but I actually made an attempt at both and option 1 strikes me as drastically less efficient because the correction logic in `visibleColumns` is run twice on every row update, even if columns don't change.