### PR TITLE
Eliminate checkpoint race condition when updating live plots

### DIFF
--- a/extension/src/plots/model/collect.test.ts
+++ b/extension/src/plots/model/collect.test.ts
@@ -81,9 +81,9 @@ describe('collectBranchRevision', () => {
 })
 
 describe('collectMutableRevisions', () => {
-  it('should return all of the running non-checkpoint experiments from the test fixture', () => {
-    const mutable = collectMutableRevisions(expShowFixture)
-    expect(mutable).toEqual(['workspace'])
+  it('should always return an empty array when checkpoints are present', () => {
+    const mutable = collectMutableRevisions(expShowFixture, true)
+    expect(mutable).toEqual([])
   })
 
   it('should return all running experiments when there are no checkpoints', () => {
@@ -131,7 +131,7 @@ describe('collectMutableRevisions', () => {
       }
     }
 
-    const mutable = collectMutableRevisions(experimentsRunningInTemp)
+    const mutable = collectMutableRevisions(experimentsRunningInTemp, false)
     expect(mutable).toEqual(['6ee95de', 'ebaa07e'])
   })
 })

--- a/extension/src/plots/model/collect.ts
+++ b/extension/src/plots/model/collect.ts
@@ -289,7 +289,14 @@ const collectMutableFromExperiment = (
   })
 }
 
-export const collectMutableRevisions = (data: ExperimentsOutput): string[] => {
+export const collectMutableRevisions = (
+  data: ExperimentsOutput,
+  hasCheckpoints: boolean
+): string[] => {
+  if (hasCheckpoints) {
+    return []
+  }
+
   const acc: string[] = []
 
   if (data.workspace.baseline.data?.running) {

--- a/extension/src/plots/model/index.ts
+++ b/extension/src/plots/model/index.ts
@@ -93,7 +93,7 @@ export class PlotsModel {
         collectLivePlotsData(data),
         collectRevisions(data),
         collectBranchRevision(data),
-        collectMutableRevisions(data)
+        collectMutableRevisions(data, this.experiments.hasCheckpoints())
       ])
 
     const { branchNames, revisionsByTip, revisionsByBranch } = revisions

--- a/extension/src/test/suite/experiments/util.ts
+++ b/extension/src/test/suite/experiments/util.ts
@@ -7,6 +7,7 @@ import expShowFixture from '../../fixtures/expShow/output'
 import { buildMockMemento, dvcDemoPath } from '../../util'
 import { buildDependencies, buildMockData } from '../util'
 import { ExperimentsData } from '../../../experiments/data'
+import { FileSystemData } from '../../../fileSystem/data'
 
 export const buildExperiments = (
   disposer: Disposer,
@@ -29,7 +30,8 @@ export const buildExperiments = (
       updatesPaused,
       resourceLocator,
       buildMockMemento(),
-      buildMockData<ExperimentsData>()
+      buildMockData<ExperimentsData>(),
+      buildMockData<FileSystemData>()
     )
   )
 


### PR DESCRIPTION
# 3/3 `master` <- #1281 <- #1282 <- this

This PR wires together the two classes created in the previous PRs with everything else in the extension. This change means that we no longer have a race condition when checkpoint experiments start as we block the plots file watcher from firing when checkpoints experiments are running. 

We do this by adding logic to `collectMutableRevisions` to return an empty array when the experiments are checkpoint based. This makes sense because all revisions are immutable when we are dealing with checkpoints.

### Demo

https://user-images.githubusercontent.com/37993418/152309829-e8cc725b-04d2-4f78-9715-cea35a9ec36d.mov


