### PR TITLE
Request all missing experiments

### DIFF
--- a/extension/src/plots/model/index.ts
+++ b/extension/src/plots/model/index.ts
@@ -164,15 +164,20 @@ export class PlotsModel {
   }
 
   public getMissingRevisions() {
-    return uniqueValues(
-      this.getSelectedRevisions().filter(
-        rev =>
-          ![
-            ...Object.keys(this.comparisonData),
-            ...Object.keys(this.revisionData),
-            'workspace'
-          ].includes(rev)
+    const cachedRevisions = [
+      ...Object.keys(this.comparisonData),
+      ...Object.keys(this.revisionData)
+    ]
+
+    const selectableRevisions = [
+      ...this.branchNames,
+      ...flatten(
+        this.branchNames.map(branch => this.revisionsByBranch.get(branch) || [])
       )
+    ]
+
+    return uniqueValues(
+      selectableRevisions.filter(rev => !cachedRevisions.includes(rev))
     )
   }
 

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -40,6 +40,8 @@ import {
   getWorkspaceColor
 } from '../../../experiments/model/colors'
 import { InternalCommands } from '../../../commands/internal'
+import { FileSystemData } from '../../../fileSystem/data'
+import { ExperimentsData } from '../../../experiments/data'
 
 suite('Experiments Test Suite', () => {
   const disposable = Disposable.fn()
@@ -224,7 +226,8 @@ suite('Experiments Test Suite', () => {
           updatesPaused,
           resourceLocator,
           buildMockMemento(),
-          buildMockData()
+          buildMockData<ExperimentsData>(),
+          buildMockData<FileSystemData>()
         )
       )
 
@@ -412,7 +415,8 @@ suite('Experiments Test Suite', () => {
           {} as EventEmitter<boolean>,
           {} as ResourceLocator,
           mockMemento,
-          buildMockData()
+          buildMockData<ExperimentsData>(),
+          buildMockData<FileSystemData>()
         )
       )
       testRepository.setState(expShowFixture)
@@ -589,7 +593,8 @@ suite('Experiments Test Suite', () => {
           {} as EventEmitter<boolean>,
           {} as ResourceLocator,
           mockMemento,
-          buildMockData()
+          buildMockData<ExperimentsData>(),
+          buildMockData<FileSystemData>()
         )
       )
       testRepository.setState(expShowFixture)

--- a/extension/src/test/suite/plots/util.ts
+++ b/extension/src/test/suite/plots/util.ts
@@ -11,6 +11,8 @@ import { PlotsModel } from '../../../plots/model'
 import { PlotsData } from '../../../plots/data'
 import { Experiments } from '../../../experiments'
 import { buildDependencies, buildMockData } from '../util'
+import { FileSystemData } from '../../../fileSystem/data'
+import { ExperimentsData } from '../../../experiments/data'
 
 export const buildPlots = async (
   disposer: Disposer,
@@ -37,7 +39,8 @@ export const buildPlots = async (
         updatesPaused,
         resourceLocator,
         buildMockMemento(),
-        buildMockData()
+        buildMockData<ExperimentsData>(),
+        buildMockData<FileSystemData>()
       )
     ),
     disposer.track(

--- a/extension/src/test/suite/util.ts
+++ b/extension/src/test/suite/util.ts
@@ -24,6 +24,7 @@ import { BaseWebview } from '../../webview'
 import { ExperimentsData } from '../../experiments/data'
 import { ResourceLocator } from '../../resourceLocator'
 import { DEFAULT_DEBOUNCE_WINDOW_MS } from '../../processManager'
+import { FileSystemData } from '../../fileSystem/data'
 
 export const extensionUri = Uri.file(resolve(__dirname, '..', '..', '..'))
 
@@ -129,7 +130,7 @@ export const buildInternalCommands = (disposer: Disposer) => {
   return { cliReader, cliRunner, internalCommands }
 }
 
-export const buildMockData = <T = ExperimentsData>() =>
+export const buildMockData = <T extends ExperimentsData | FileSystemData>() =>
   ({
     dispose: stub(),
     onDidUpdate: stub()


### PR DESCRIPTION
This PR updates the logic inside the `PlotsModel` to always request missing experiment revisions but to leave out checkpoints. Plugs the first bug from #1277:

> If an experiment is running and we unselect the experiment then we get unexpected behaviour in the plots because we use getSelectedRevisions to determine which revisions are missing.

### Demo

https://user-images.githubusercontent.com/37993418/152444038-7ad85737-1851-40c0-8ca5-9641cd2336f5.mov

Once I have added the tree to select revisions I will revisit this logic so that we never request more than 6 revisions at the one time. My initial thought is that if we can persist the selected revisions between sessions, then check them against the `exp show` data on startup. If there isn't a match then we can dump the preference and have nothing selected as a baseline. Will be easier to work out the behaviour once we have a tree in place.