### PR TITLE
Use stable ids for react-table rows

### DIFF
--- a/webview/src/experiments/components/Experiments/index.tsx
+++ b/webview/src/experiments/components/Experiments/index.tsx
@@ -106,7 +106,11 @@ const reportResizedColumn = (state: TableState<Experiment>) => {
 export const ExperimentsTable: React.FC<{
   tableData: InitiallyUndefinedTableData
 }> = ({ tableData: initiallyUndefinedTableData }) => {
-  const getRowId = useCallback(({ id }: Experiment) => id, [])
+  const getRowId = useCallback(
+    (experiment: Experiment, _index, parent?: Row<Experiment>) =>
+      parent ? [parent.id, experiment.id].join('.') : experiment.id,
+    []
+  )
   const [tableData, columns, defaultColumn, initialState] =
     React.useMemo(() => {
       const tableData: TableData = {


### PR DESCRIPTION
Super simple PR that makes `react-table` use the ids from experiments as row ids instead of index-based ones. This means rows will be recognized as the same even when reordered.

Fixes #1300 

https://user-images.githubusercontent.com/9111807/152903702-675648d8-bcb1-4076-b047-dda868458f34.mp4


