### PR TITLE
Rename experiment displayId to label

### DIFF
--- a/extension/src/experiments/model/collect.test.ts
+++ b/extension/src/experiments/model/collect.test.ts
@@ -102,14 +102,14 @@ describe('collectExperiments', () => {
 
     expect(modifiedExperiment).toHaveLength(1)
     expect(modifiedExperiment?.[0].displayNameOrParent).toEqual('(3b0c6ac)')
-    expect(modifiedExperiment?.[0].displayId).toEqual('7e3cb21')
+    expect(modifiedExperiment?.[0].label).toEqual('7e3cb21')
 
     checkpointsByTip.forEach(checkpoints => {
       const continuationCheckpoints = checkpoints.filter(checkpoint => {
-        const { displayId, displayNameOrParent } = checkpoint
+        const { label, displayNameOrParent } = checkpoint
         return (
           displayNameOrParent?.includes('(') &&
-          displayId !== '7e3cb21' &&
+          label !== '7e3cb21' &&
           displayNameOrParent !== '(3b0c6ac)'
         )
       })

--- a/extension/src/experiments/model/collect.ts
+++ b/extension/src/experiments/model/collect.ts
@@ -13,7 +13,7 @@ import { hasKey } from '../../util/object'
 
 type ExperimentsObject = { [sha: string]: ExperimentFieldsOrError }
 
-export const getDisplayId = (sha: string) => sha.slice(0, 7)
+export const getLabel = (sha: string) => sha.slice(0, 7)
 
 export const isCheckpoint = (
   checkpointTip: string | undefined,
@@ -44,7 +44,7 @@ const getDisplayNameOrParent = (
     parentTip &&
     experimentsObject[parentTip]?.data?.checkpoint_tip === parentTip
   ) {
-    return `(${getDisplayId(parentTip)})`
+    return `(${getLabel(parentTip)})`
   }
   if (name) {
     return `[${name}]`
@@ -78,14 +78,14 @@ const transformMetricsAndParams = (
 const transformExperimentData = (
   id: string,
   experimentFields: ExperimentFields,
-  displayId: string | undefined,
+  label: string | undefined,
   sha?: string,
   displayNameOrParent?: string
 ): Experiment => {
   const experiment = {
     id,
     ...omit(experimentFields, ['metrics', 'params']),
-    displayId
+    label
   } as Experiment
 
   if (displayNameOrParent) {
@@ -109,7 +109,7 @@ const transformExperimentOrCheckpointData = (
   transformExperimentData(
     getId(sha, experimentFields),
     experimentFields,
-    getDisplayId(sha),
+    getLabel(sha),
     sha,
     displayNameOrParent
   )
@@ -179,7 +179,7 @@ const collectFromBranchesObject = (
     )
 
     if (branch) {
-      collectFromExperimentsObject(acc, experimentsObject, branch.displayId)
+      collectFromExperimentsObject(acc, experimentsObject, branch.label)
 
       acc.branches.push(branch)
     }

--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -289,7 +289,7 @@ export class ExperimentsModel {
   }
 
   private getExperimentsByBranch(branch: Experiment) {
-    const experiments = this.experimentsByBranch.get(branch.displayId)
+    const experiments = this.experimentsByBranch.get(branch.label)
     if (!experiments) {
       return
     }
@@ -321,9 +321,9 @@ export class ExperimentsModel {
 
   private setExperimentRevisions() {
     this.revisions = this.flattenExperiments().reduce((acc, exp) => {
-      const { id, displayId } = exp
-      if (displayId) {
-        acc[id] = displayId
+      const { id, label } = exp
+      if (label) {
+        acc[id] = label
       }
       return acc
     }, {} as Record<string, string>)

--- a/extension/src/experiments/model/quickPick.test.ts
+++ b/extension/src/experiments/model/quickPick.test.ts
@@ -19,13 +19,13 @@ describe('pickExperiments', () => {
 
   it('should return the selected experiment ids', async () => {
     const selectedExperiment = {
-      displayId: 'exp-789',
       id: '7c366f6',
+      label: 'exp-789',
       selected: false
     }
     const mockedExperiments = [
-      { displayId: 'exp-123', id: '73de3fe', selected: false },
-      { displayId: 'exp-456', id: '0be657c', selected: true },
+      { id: '73de3fe', label: 'exp-123', selected: false },
+      { id: '0be657c', label: 'exp-456', selected: true },
       selectedExperiment
     ] as Experiment[]
 

--- a/extension/src/experiments/model/quickPicks.ts
+++ b/extension/src/experiments/model/quickPicks.ts
@@ -13,7 +13,7 @@ export const pickExperiments = (
   return quickPickManyValues<Experiment>(
     experiments.map(experiment => ({
       description: experiment.displayNameOrParent,
-      label: experiment.displayId,
+      label: experiment.label,
       picked: experiment.selected,
       value: experiment
     })),

--- a/extension/src/experiments/model/sortBy/index.test.ts
+++ b/extension/src/experiments/model/sortBy/index.test.ts
@@ -5,13 +5,13 @@ import { Experiment } from '../../webview/contract'
 
 describe('sortExperiments', () => {
   const testId = 'f0778b3eb6a390d6f6731c735a2a4561d1792c3a'
-  const testDisplayId = 'f0778b3'
+  const testLabel = 'f0778b3'
   const testTimestamp = '2021-01-14T10:57:59'
   const irrelevantExperimentData = {
     checkpoint_parent: 'f81f1b5a1248b9d9f595fb53136298c69f908e66',
     checkpoint_tip: 'd3f4a0d3661c5977540d2205d819470cf0d2145a',
-    displayId: testDisplayId,
     id: testId,
+    label: testLabel,
     queued: false,
     timestamp: testTimestamp
   }

--- a/extension/src/experiments/model/tree.test.ts
+++ b/extension/src/experiments/model/tree.test.ts
@@ -98,9 +98,9 @@ describe('ExperimentsTree', () => {
       mockedGetExperiments.mockReturnValueOnce([])
       mockedGetExperiments.mockReturnValueOnce([])
       mockedGetExperiments.mockReturnValueOnce([
-        { displayId: 'workspace' },
-        { displayId: 'main' },
-        { displayId: '90aea7f' }
+        { label: 'workspace' },
+        { label: 'main' },
+        { label: '90aea7f' }
       ])
 
       const rootElements = await experimentsTree.getChildren()
@@ -121,31 +121,31 @@ describe('ExperimentsTree', () => {
       const experiments = [
         {
           displayColor: '#b180d7',
-          displayId: '90aea7f',
           hasChildren: true,
           id: 'exp-12345',
+          label: '90aea7f',
           selected: true
         },
         {
           displayColor: '#1a1c19',
-          displayId: 'f0778b3',
           hasChildren: false,
           id: 'exp-67899',
+          label: 'f0778b3',
           running: true,
           selected: true
         },
         {
           displayColor: '#4063e2',
-          displayId: 'e350702',
           hasChildren: false,
           id: 'exp-abcdef',
+          label: 'e350702',
           running: false,
           selected: false
         },
         {
-          displayId: 'f81f1b5',
           hasChildren: false,
           id: 'f81f1b5',
+          label: 'f81f1b5',
           queued: true
         }
       ]
@@ -222,8 +222,8 @@ describe('ExperimentsTree', () => {
       )
 
       const checkpoints = [
-        { displayId: 'aaaaaaa', id: 'aaaaaaaaaaaaaaaaa' },
-        { displayId: 'bbbbbbb', id: 'bbbbbbbbbbbbbbbbb' }
+        { id: 'aaaaaaaaaaaaaaaaa', label: 'aaaaaaa' },
+        { id: 'bbbbbbbbbbbbbbbbb', label: 'bbbbbbb' }
       ]
       mockedGetCheckpoints.mockReturnValueOnce(checkpoints)
 

--- a/extension/src/experiments/model/tree.ts
+++ b/extension/src/experiments/model/tree.ts
@@ -163,7 +163,7 @@ export class ExperimentsTree
         dvcRoot,
         iconPath: this.getExperimentIcon(experiment),
         id: experiment.id,
-        label: experiment.displayId
+        label: experiment.label
       }))
   }
 
@@ -191,7 +191,7 @@ export class ExperimentsTree
     selected
   }: {
     displayColor?: string
-    displayId: string
+    label: string
     running?: boolean
     queued?: boolean
     selected?: boolean
@@ -220,7 +220,7 @@ export class ExperimentsTree
         this.getIconName(checkpoint.selected)
       ),
       id: checkpoint.id,
-      label: checkpoint.displayId
+      label: checkpoint.label
     }))
   }
 

--- a/extension/src/experiments/quickPick.test.ts
+++ b/extension/src/experiments/quickPick.test.ts
@@ -14,72 +14,72 @@ beforeEach(() => {
 })
 
 const mockedExp = {
-  displayId: 'abcdefb',
   displayNameOrParent: '[exp-0580a]',
   id: 'abcdefb',
+  label: 'abcdefb',
   name: 'exp-0580a'
 }
 
 const mockedExpList = [
   mockedExp,
   {
-    displayId: 'abcdefa',
     displayNameOrParent: '[exp-c54c4]',
     id: 'abcdefa',
+    label: 'abcdefa',
     name: 'exp-c54c4'
   },
   {
-    displayId: 'abcdef1',
     displayNameOrParent: '[exp-054f1]',
     id: 'abcdef1',
+    label: 'abcdef1',
     name: 'exp-054f1'
   },
   {
-    displayId: 'abcdef2',
     displayNameOrParent: '[exp-ae4fa]',
     id: 'abcdef2',
+    label: 'abcdef2',
     name: 'exp-ae4fa'
   },
   {
-    displayId: 'abcdef3',
     displayNameOrParent: '[exp-1324e]',
     id: 'abcdef3',
+    label: 'abcdef3',
     name: 'exp-1324e'
   },
   {
-    displayId: 'abcdef4',
     displayNameOrParent: '[exp-3bd24]',
     id: 'abcdef4',
+    label: 'abcdef4',
     name: 'exp-3bd24'
   },
   {
-    displayId: 'abcdef5',
     displayNameOrParent: '[exp-5d170]',
     id: 'abcdef5',
+    label: 'abcdef5',
     name: 'exp-5d170'
   },
   {
-    displayId: 'abcdef6',
     displayNameOrParent: '[exp-9fe22]',
     id: 'abcdef6',
+    label: 'abcdef6',
     name: 'exp-9fe22'
   },
   {
-    displayId: 'abcdef7',
     displayNameOrParent: '[exp-b707b]',
     id: 'abcdef7',
+    label: 'abcdef7',
     name: 'exp-b707b'
   },
   {
-    displayId: 'abcdef8',
     displayNameOrParent: '[exp-47694]',
     id: 'abcdef8',
+    label: 'abcdef8',
     name: 'exp-47694'
   },
   {
-    displayId: 'abcdef9',
     displayNameOrParent: '[exp-59807]',
     id: 'abcdef9',
+    label: 'abcdef9',
     name: 'exp-59807'
   }
 ]

--- a/extension/src/experiments/quickPick.ts
+++ b/extension/src/experiments/quickPick.ts
@@ -4,7 +4,7 @@ import { reportError } from '../vscode/reporting'
 
 export const pickExperiment = (
   experiments: {
-    displayId: string
+    label: string
     displayNameOrParent?: string
     id: string
     name?: string
@@ -14,10 +14,10 @@ export const pickExperiment = (
     reportError('There are no experiments to select.')
   } else {
     return quickPickValue<{ id: string; name: string }>(
-      experiments.map(({ displayId, displayNameOrParent, id, name }) => ({
+      experiments.map(({ label, displayNameOrParent, id, name }) => ({
         description: displayNameOrParent,
-        label: displayId,
-        value: { id, name: name || displayId }
+        label,
+        value: { id, name: name || label }
       })),
       { title: 'Select an experiment' }
     )

--- a/extension/src/experiments/webview/contract.ts
+++ b/extension/src/experiments/webview/contract.ts
@@ -7,7 +7,7 @@ export interface MetricsOrParams {
 
 export interface Experiment extends BaseExperimentFields {
   id: string
-  displayId: string
+  label: string
   displayNameOrParent?: string
   params?: MetricsOrParams
   metrics?: MetricsOrParams

--- a/extension/src/plots/model/collect.ts
+++ b/extension/src/plots/model/collect.ts
@@ -22,7 +22,7 @@ import {
 } from '../../experiments/metricsAndParams/paths'
 import { MetricsOrParams } from '../../experiments/webview/contract'
 import { addToMapArray, addToMapCount } from '../../util/map'
-import { getDisplayId, isCheckpoint } from '../../experiments/model/collect'
+import { getLabel, isCheckpoint } from '../../experiments/model/collect'
 
 type LivePlotAccumulator = Map<string, LivePlotValues>
 
@@ -219,9 +219,9 @@ const collectExperimentOrCheckpoint = (
   sha: string,
   checkpointTip: string | undefined
 ) => {
-  const id = getDisplayId(sha)
+  const id = getLabel(sha)
   if (isCheckpoint(checkpointTip, sha)) {
-    addToMapArray(acc.revisionsByTip, getDisplayId(checkpointTip), id)
+    addToMapArray(acc.revisionsByTip, getLabel(checkpointTip), id)
   } else {
     addToMapArray(acc.revisionsByBranch, branchName, id)
   }
@@ -267,7 +267,7 @@ export const collectRevisions = (
 
 export const collectBranchRevision = (data: ExperimentsOutput): string => {
   const branchSha = Object.keys(data).find(id => id !== 'workspace') as string
-  return getDisplayId(branchSha)
+  return getLabel(branchSha)
 }
 
 const collectMutableFromExperiment = (
@@ -285,7 +285,7 @@ const collectMutableFromExperiment = (
       return
     }
 
-    acc.push(getDisplayId(sha))
+    acc.push(getLabel(sha))
   })
 }
 

--- a/extension/src/test/fixtures/expShow/rows.ts
+++ b/extension/src/test/fixtures/expShow/rows.ts
@@ -32,7 +32,7 @@ const data: RowData[] = [
       }
     },
     displayColor: '#945dd6',
-    displayId: 'workspace',
+    label: 'workspace',
     selected: true,
     id: 'workspace'
   },
@@ -64,7 +64,7 @@ const data: RowData[] = [
     },
     id: 'main',
     name: 'main',
-    displayId: 'main',
+    label: 'main',
     displayColor: '#13adc7',
     selected: true,
     sha: '53c3851f46955fa3e2b8f6e1c52999acc8c9ea77',
@@ -98,7 +98,7 @@ const data: RowData[] = [
         },
         name: 'exp-e7a67',
         checkpoint_parent: 'd1343a87c6ee4a2e82d19525964d2fb2cb6756c9',
-        displayId: '4fb124a',
+        label: '4fb124a',
         displayNameOrParent: '[exp-e7a67]',
         displayColor: colorsList[0],
         id: 'exp-e7a67',
@@ -132,7 +132,7 @@ const data: RowData[] = [
               }
             },
             checkpoint_parent: '1ee5f2ecb0fa4d83cbf614386536344cf894dd53',
-            displayId: 'd1343a8',
+            label: 'd1343a8',
             displayColor: colorsList[0],
             id: 'd1343a87c6ee4a2e82d19525964d2fb2cb6756c9',
             selected: false,
@@ -167,7 +167,7 @@ const data: RowData[] = [
             },
             checkpoint_parent: '53c3851f46955fa3e2b8f6e1c52999acc8c9ea77',
             displayColor: colorsList[0],
-            displayId: '1ee5f2e',
+            label: '1ee5f2e',
             id: '1ee5f2ecb0fa4d83cbf614386536344cf894dd53',
             selected: false,
             sha: '1ee5f2ecb0fa4d83cbf614386536344cf894dd53'
@@ -205,7 +205,7 @@ const data: RowData[] = [
         name: 'test-branch',
         checkpoint_parent: '217312476f8854dda1865450b737eb6bc7a3ba1b',
         displayColor: colorsList[1],
-        displayId: '42b8736',
+        label: '42b8736',
         displayNameOrParent: '[test-branch]',
         id: 'test-branch',
         sha: '42b8736b08170529903cd203a1f40382a4b4a8cd',
@@ -239,7 +239,7 @@ const data: RowData[] = [
             },
             checkpoint_parent: '9523bde67538cf31230efaff2dbc47d38a944ab5',
             displayColor: colorsList[1],
-            displayId: '2173124',
+            label: '2173124',
             id: '217312476f8854dda1865450b737eb6bc7a3ba1b',
             selected: false,
             sha: '217312476f8854dda1865450b737eb6bc7a3ba1b'
@@ -273,7 +273,7 @@ const data: RowData[] = [
             },
             checkpoint_parent: '53c3851f46955fa3e2b8f6e1c52999acc8c9ea77',
             displayColor: colorsList[1],
-            displayId: '9523bde',
+            label: '9523bde',
             id: '9523bde67538cf31230efaff2dbc47d38a944ab5',
             selected: false,
             sha: '9523bde67538cf31230efaff2dbc47d38a944ab5'
@@ -311,7 +311,7 @@ const data: RowData[] = [
         name: 'exp-83425',
         checkpoint_parent: '22e40e1fa3c916ac567f69b85969e3066a91dda4',
         displayColor: colorsList[2],
-        displayId: '1ba7bcd',
+        label: '1ba7bcd',
         displayNameOrParent: '[exp-83425]',
         id: 'exp-83425',
         sha: '1ba7bcd6ce6154e72e18b155475663ecbbd1f49d',
@@ -345,7 +345,7 @@ const data: RowData[] = [
             },
             checkpoint_parent: '91116c1eae4b79cb1f5ab0312dfd9b3e43608e15',
             displayColor: colorsList[2],
-            displayId: '22e40e1',
+            label: '22e40e1',
             id: '22e40e1fa3c916ac567f69b85969e3066a91dda4',
             selected: false,
             sha: '22e40e1fa3c916ac567f69b85969e3066a91dda4'
@@ -379,7 +379,7 @@ const data: RowData[] = [
             },
             checkpoint_parent: 'e821416bfafb4bc28b3e0a8ddb322505b0ad2361',
             displayColor: colorsList[2],
-            displayId: '91116c1',
+            label: '91116c1',
             id: '91116c1eae4b79cb1f5ab0312dfd9b3e43608e15',
             selected: false,
             sha: '91116c1eae4b79cb1f5ab0312dfd9b3e43608e15'
@@ -413,7 +413,7 @@ const data: RowData[] = [
             },
             checkpoint_parent: 'c658f8b14ac819ac2a5ea0449da6c15dbe8eb880',
             displayColor: colorsList[2],
-            displayId: 'e821416',
+            label: 'e821416',
             id: 'e821416bfafb4bc28b3e0a8ddb322505b0ad2361',
             selected: false,
             sha: 'e821416bfafb4bc28b3e0a8ddb322505b0ad2361'
@@ -447,7 +447,7 @@ const data: RowData[] = [
             },
             checkpoint_parent: '23250b33e3d6dd0e136262d1d26a2face031cb03',
             displayColor: colorsList[2],
-            displayId: 'c658f8b',
+            label: 'c658f8b',
             id: 'c658f8b14ac819ac2a5ea0449da6c15dbe8eb880',
             selected: false,
             sha: 'c658f8b14ac819ac2a5ea0449da6c15dbe8eb880'
@@ -481,7 +481,7 @@ const data: RowData[] = [
             },
             checkpoint_parent: '53c3851f46955fa3e2b8f6e1c52999acc8c9ea77',
             displayColor: colorsList[2],
-            displayId: '23250b3',
+            label: '23250b3',
             id: '23250b33e3d6dd0e136262d1d26a2face031cb03',
             selected: false,
             sha: '23250b33e3d6dd0e136262d1d26a2face031cb03'
@@ -505,7 +505,7 @@ const data: RowData[] = [
           }
         },
         queued: true,
-        displayId: '90aea7f',
+        label: '90aea7f',
         id: '90aea7f2482117a55dfcadcdb901aaa6610fbbc9',
         sha: '90aea7f2482117a55dfcadcdb901aaa6610fbbc9'
       }

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -63,7 +63,7 @@ suite('Experiments Test Suite', () => {
 
       const runs = experiments.getExperiments()
 
-      expect(runs.map(experiment => experiment.displayId)).to.deep.equal([
+      expect(runs.map(experiment => experiment.label)).to.deep.equal([
         'workspace',
         'main',
         '4fb124a',
@@ -86,9 +86,10 @@ suite('Experiments Test Suite', () => {
 
       const checkpoints = experiments.getCheckpoints('exp-e7a67')
 
-      expect(
-        checkpoints?.map(checkpoint => checkpoint.displayId)
-      ).to.deep.equal(['d1343a8', '1ee5f2e'])
+      expect(checkpoints?.map(checkpoint => checkpoint.label)).to.deep.equal([
+        'd1343a8',
+        '1ee5f2e'
+      ])
     })
   })
 
@@ -253,35 +254,35 @@ suite('Experiments Test Suite', () => {
         rows: [
           {
             displayColor: getWorkspaceColor(),
-            displayId: 'workspace',
             id: 'workspace',
+            label: 'workspace',
             params: { 'params.yaml': { test: 10 } },
             selected: true
           },
           {
             displayColor: '#13adc7',
-            displayId: 'testBranch',
             id: 'testBranch',
+            label: 'testBranch',
             name: 'testBranch',
             params: { 'params.yaml': { test: 10 } },
             selected: true,
             sha: 'testBranch',
             subRows: [
               {
-                displayId: 'testExp',
                 id: 'testExp1',
+                label: 'testExp',
                 params: { 'params.yaml': { test: 2 } },
                 sha: 'testExp1'
               },
               {
-                displayId: 'testExp',
                 id: 'testExp2',
+                label: 'testExp',
                 params: { 'params.yaml': { test: 1 } },
                 sha: 'testExp2'
               },
               {
-                displayId: 'testExp',
                 id: 'testExp3',
+                label: 'testExp',
                 params: { 'params.yaml': { test: 3 } },
                 sha: 'testExp3'
               }
@@ -318,35 +319,35 @@ suite('Experiments Test Suite', () => {
         rows: [
           {
             displayColor: getWorkspaceColor(),
-            displayId: 'workspace',
             id: 'workspace',
+            label: 'workspace',
             params: { 'params.yaml': { test: 10 } },
             selected: true
           },
           {
             displayColor: '#13adc7',
-            displayId: 'testBranch',
             id: 'testBranch',
+            label: 'testBranch',
             name: 'testBranch',
             params: { 'params.yaml': { test: 10 } },
             selected: true,
             sha: 'testBranch',
             subRows: [
               {
-                displayId: 'testExp',
                 id: 'testExp2',
+                label: 'testExp',
                 params: { 'params.yaml': { test: 1 } },
                 sha: 'testExp2'
               },
               {
-                displayId: 'testExp',
                 id: 'testExp1',
+                label: 'testExp',
                 params: { 'params.yaml': { test: 2 } },
                 sha: 'testExp1'
               },
               {
-                displayId: 'testExp',
                 id: 'testExp3',
+                label: 'testExp',
                 params: { 'params.yaml': { test: 3 } },
                 sha: 'testExp3'
               }

--- a/webview/src/experiments/components/Experiments/index.tsx
+++ b/webview/src/experiments/components/Experiments/index.tsx
@@ -49,14 +49,12 @@ const getColumns = (columns: MetricOrParam[]): Column<Experiment>[] =>
     {
       Cell: ({
         row: {
-          original: { displayId, displayNameOrParent }
+          original: { label, displayNameOrParent }
         }
       }: Cell<Experiment>) => {
         return (
           <div className={styles.experimentCellContents}>
-            <span className={styles.experimentCellPrimaryName}>
-              {displayId}
-            </span>
+            <span className={styles.experimentCellPrimaryName}>{label}</span>
             {displayNameOrParent && (
               <span className={styles.experimentCellSecondaryName}>
                 {displayNameOrParent}

--- a/webview/src/experiments/components/Table/Table.test.tsx
+++ b/webview/src/experiments/components/Table/Table.test.tsx
@@ -88,9 +88,9 @@ describe('Table', () => {
             render: () => new Date('2021-09-09').toString()
           }
         ],
-        displayId: 'workspace',
         getRowProps: getProps,
         id: 'workspace',
+        label: 'workspace',
         original: {
           queued: false,
           running: false

--- a/webview/src/stories/Table.stories.tsx
+++ b/webview/src/stories/Table.stories.tsx
@@ -21,11 +21,11 @@ const tableData: TableData = {
     ...row,
     subRows: row.subRows?.map(experiment => ({
       ...experiment,
-      selected: experiment.displayId !== '42b8736',
+      selected: experiment.label !== '42b8736',
       subRows: experiment.subRows?.map(checkpoint => ({
         ...checkpoint,
-        running: checkpoint.running || checkpoint.displayId === '23250b3',
-        selected: experiment.displayId !== '42b8736'
+        running: checkpoint.running || checkpoint.label === '23250b3',
+        selected: experiment.label !== '42b8736'
       }))
     }))
   })),


### PR DESCRIPTION
# 2/2 `master` <- #1304 <- this

Genuine housekeeping of a weird variable name. We are now using the name that VS Code expects for the variable.