### PR TITLE
Collect experiment colors early

### DIFF
--- a/extension/src/experiments/model/collect.ts
+++ b/extension/src/experiments/model/collect.ts
@@ -203,6 +203,46 @@ export const collectExperiments = (
   return acc
 }
 
+const collectExperimentIds = (
+  acc: {
+    branchIds: string[]
+    experimentIds: string[]
+  },
+  experimentsObject: ExperimentsObject
+) => {
+  for (const [sha, experimentData] of Object.entries(experimentsObject)) {
+    const experimentFields = experimentData.data
+    if (!experimentFields?.name) {
+      continue
+    }
+    if (!isCheckpoint(experimentFields.checkpoint_tip, sha)) {
+      acc.experimentIds.push(experimentFields.name)
+    }
+  }
+}
+
+export const collectBranchAndExperimentIds = (branchesObject: {
+  [sha: string]: ExperimentsBranchOutput
+}) => {
+  const acc = { branchIds: [], experimentIds: [] } as {
+    branchIds: string[]
+    experimentIds: string[]
+  }
+  for (const { baseline, ...experimentsObject } of Object.values(
+    branchesObject
+  )) {
+    const experimentFields = baseline.data
+    if (!experimentFields?.name) {
+      continue
+    }
+
+    acc.branchIds.push(experimentFields.name)
+
+    collectExperimentIds(acc, experimentsObject)
+  }
+  return acc
+}
+
 export enum Status {
   SELECTED = 1,
   UNSELECTED = 0

--- a/extension/src/experiments/model/index.test.ts
+++ b/extension/src/experiments/model/index.test.ts
@@ -63,10 +63,11 @@ describe('ExperimentsModel', () => {
       path: testPath,
       value: '2'
     })
+    const baseline = buildTestExperiment(2, undefined, 'testBranch')
 
     await experimentsModel.transformAndSet({
       testBranch: {
-        baseline: buildTestExperiment(2),
+        baseline,
         test0: buildTestExperiment(0, 'tip'),
         test1: buildTestExperiment(1, 'tip'),
         tip: buildTestExperiment(2, 'tip', runningExperiment)
@@ -96,7 +97,7 @@ describe('ExperimentsModel', () => {
 
     const experimentWithNewCheckpoint = {
       testBranch: {
-        baseline: buildTestExperiment(2),
+        baseline,
         test0: buildTestExperiment(0, 'tip'),
         test1: buildTestExperiment(1, 'tip'),
         test2: buildTestExperiment(2, 'tip'),

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -459,9 +459,9 @@ suite('Experiments Test Suite', () => {
         mockMemento.keys(),
         'Memento starts with the colors and status keys'
       ).to.deep.equal([
-        'experimentsStatus:test',
         'experimentsColors:test',
-        'branchColors:test'
+        'branchColors:test',
+        'experimentsStatus:test'
       ])
       expect(
         mockMemento.get('experimentsColors:test'),

--- a/extension/src/test/suite/experiments/workspace.test.ts
+++ b/extension/src/test/suite/experiments/workspace.test.ts
@@ -288,9 +288,11 @@ suite('Workspace Experiments Test Suite', () => {
 
   describe('dvc.applyExperiment', () => {
     it('should ask the user to pick an experiment and then apply that experiment to the workspace', async () => {
-      const selectedExperimentName = 'test-branch'
+      const selectedExperiment = 'test-branch'
 
       const { experiments } = buildExperiments(disposable)
+
+      await experiments.isReady()
 
       stub(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -303,7 +305,7 @@ suite('Workspace Experiments Test Suite', () => {
         'getRepository'
       ).returns(experiments)
       const mockShowQuickPick = stub(window, 'showQuickPick').resolves({
-        value: { id: 'a123456', name: selectedExperimentName }
+        value: { id: selectedExperiment, name: selectedExperiment }
       } as QuickPickItemWithValue<{ id: string; name: string }>)
       const mockExperimentApply = stub(CliExecutor.prototype, 'experimentApply')
 
@@ -311,7 +313,7 @@ suite('Workspace Experiments Test Suite', () => {
 
       expect(mockExperimentApply).to.be.calledWith(
         dvcDemoPath,
-        selectedExperimentName
+        selectedExperiment
       )
       expect(mockShowQuickPick).to.be.calledWith(
         [
@@ -350,9 +352,11 @@ suite('Workspace Experiments Test Suite', () => {
 
   describe('dvc.removeExperiment', () => {
     it('should ask the user to pick an experiment and then remove that experiment from the workspace', async () => {
-      const mockExperimentName = 'exp-to-remove'
+      const mockExperiment = 'exp-to-remove'
 
       const { experiments } = buildExperiments(disposable)
+
+      await experiments.isReady()
 
       stub(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -366,7 +370,7 @@ suite('Workspace Experiments Test Suite', () => {
       ).returns(experiments)
 
       stub(window, 'showQuickPick').resolves({
-        value: { id: 'f1245699', name: mockExperimentName }
+        value: { id: mockExperiment, name: mockExperiment }
       } as QuickPickItemWithValue<{ id: string; name: string }>)
       const mockExperimentRemove = stub(
         CliExecutor.prototype,
@@ -375,10 +379,7 @@ suite('Workspace Experiments Test Suite', () => {
 
       await commands.executeCommand(RegisteredCliCommands.EXPERIMENT_REMOVE)
 
-      expect(mockExperimentRemove).to.be.calledWith(
-        dvcDemoPath,
-        mockExperimentName
-      )
+      expect(mockExperimentRemove).to.be.calledWith(dvcDemoPath, mockExperiment)
     })
   })
 })


### PR DESCRIPTION
# 1/5 `master` <- this <- #1309 <- #1310 <- #1311 <- #1312

Prerequisite of adding display color into the experiment data collection algorithm, once I've done that an `Experiment` will always have a `displayColor` associated with it. I will also be removing most of the `extension/src/plots/model/collect.ts` logic and pushing that data back into the `ExperimentsModel`.