### PR TITLE
Add colors onto experiments during collection

### DIFF
--- a/extension/src/experiments/model/accumulator.ts
+++ b/extension/src/experiments/model/accumulator.ts
@@ -6,9 +6,19 @@ export class ExperimentsAccumulator {
   public checkpointsByTip: Map<string, Experiment[]> = new Map()
   public experimentsByBranch: Map<string, Experiment[]> = new Map()
 
-  constructor(workspace?: Experiment) {
+  public branchColors: Map<string, string>
+  public experimentColors: Map<string, string>
+
+  constructor(
+    workspace: Experiment | undefined,
+    branchColors: Map<string, string>,
+    experimentColors: Map<string, string>
+  ) {
     if (workspace) {
       this.workspace = workspace
     }
+
+    this.branchColors = branchColors
+    this.experimentColors = experimentColors
   }
 }

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -272,18 +272,21 @@ suite('Experiments Test Suite', () => {
                 id: 'testExp1',
                 label: 'testExp',
                 params: { 'params.yaml': { test: 2 } },
+                selected: true,
                 sha: 'testExp1'
               },
               {
                 id: 'testExp2',
                 label: 'testExp',
                 params: { 'params.yaml': { test: 1 } },
+                selected: true,
                 sha: 'testExp2'
               },
               {
                 id: 'testExp3',
                 label: 'testExp',
                 params: { 'params.yaml': { test: 3 } },
+                selected: true,
                 sha: 'testExp3'
               }
             ]
@@ -337,18 +340,21 @@ suite('Experiments Test Suite', () => {
                 id: 'testExp2',
                 label: 'testExp',
                 params: { 'params.yaml': { test: 1 } },
+                selected: true,
                 sha: 'testExp2'
               },
               {
                 id: 'testExp1',
                 label: 'testExp',
                 params: { 'params.yaml': { test: 2 } },
+                selected: true,
                 sha: 'testExp1'
               },
               {
                 id: 'testExp3',
                 label: 'testExp',
                 params: { 'params.yaml': { test: 3 } },
+                selected: true,
                 sha: 'testExp3'
               }
             ]


### PR DESCRIPTION
# 2/5 `master` <- #1307 <- this <- #1310 <- #1311 <-#1312

This PR pushes the addition of a displayColor into `collectExperiments` in `extension/src/experiments/model/collect.ts`. This means that we no longer have to "add" the color when pulling the experiments data out of the model. We can easily do this because the color is immutable once it has been collected.