### PR TITLE
Add ability to select checkpoints

### DIFF
--- a/extension/src/experiments/model/tree.test.ts
+++ b/extension/src/experiments/model/tree.test.ts
@@ -239,6 +239,11 @@ describe('ExperimentsTree', () => {
       expect(children).toEqual([
         {
           collapsibleState: 0,
+          command: {
+            arguments: [{ dvcRoot: 'repo', id: 'aaaaaaaaaaaaaaaaa' }],
+            command: 'dvc.views.experimentsTree.toggleStatus',
+            title: 'toggle'
+          },
           dvcRoot: 'repo',
           iconPath: new ThemeIcon('circle-filled'),
           id: 'aaaaaaaaaaaaaaaaa',
@@ -246,6 +251,11 @@ describe('ExperimentsTree', () => {
         },
         {
           collapsibleState: 0,
+          command: {
+            arguments: [{ dvcRoot: 'repo', id: 'bbbbbbbbbbbbbbbbb' }],
+            command: 'dvc.views.experimentsTree.toggleStatus',
+            title: 'toggle'
+          },
           dvcRoot: 'repo',
           iconPath: new ThemeIcon('circle-filled'),
           id: 'bbbbbbbbbbbbbbbbb',

--- a/extension/src/experiments/model/tree.ts
+++ b/extension/src/experiments/model/tree.ts
@@ -213,6 +213,11 @@ export class ExperimentsTree
       this.experiments.getRepository(dvcRoot).getCheckpoints(id) || []
     ).map(checkpoint => ({
       collapsibleState: TreeItemCollapsibleState.None,
+      command: {
+        arguments: [{ dvcRoot, id: checkpoint.id }],
+        command: RegisteredCommands.EXPERIMENT_TOGGLE,
+        title: 'toggle'
+      },
       description: checkpoint.displayNameOrParent,
       dvcRoot,
       iconPath: this.getUriOrIcon(


### PR DESCRIPTION
# 4/5 `master` <- #1307 <- #1309 <- #1310 <- this <- #1312

This PR gives users the ability to select checkpoints. As you can see from the demo there is currently no limit to the number of experiments that can be selected

### Demo

https://user-images.githubusercontent.com/37993418/153524632-d3e43a59-575b-49fc-9c00-36484837dcf0.mov


