### PR TITLE
Improve continuation label logic

### DIFF
--- a/extension/src/experiments/model/collect.test.ts
+++ b/extension/src/experiments/model/collect.test.ts
@@ -96,21 +96,29 @@ describe('collectExperiments', () => {
   it('should handle the continuation of a modified checkpoint', () => {
     const { checkpointsByTip } = collectExperiments(modifiedFixture)
 
-    const modifiedExperiment = checkpointsByTip
+    const modifiedCheckpointTip = checkpointsByTip
       .get('exp-01b3a')
       ?.filter(checkpoint => checkpoint.displayNameOrParent?.includes('('))
 
-    expect(modifiedExperiment).toHaveLength(1)
-    expect(modifiedExperiment?.[0].displayNameOrParent).toEqual('(3b0c6ac)')
-    expect(modifiedExperiment?.[0].label).toEqual('7e3cb21')
+    expect(modifiedCheckpointTip).toHaveLength(1)
+    expect(modifiedCheckpointTip?.[0].displayNameOrParent).toEqual('(3b0c6ac)')
+    expect(modifiedCheckpointTip?.[0].label).toEqual('7e3cb21')
+
+    const modifiedCheckpoint = checkpointsByTip
+      .get('exp-9bc1b')
+      ?.filter(checkpoint => checkpoint.displayNameOrParent?.includes('('))
+
+    expect(modifiedCheckpoint).toHaveLength(1)
+    expect(modifiedCheckpoint?.[0].displayNameOrParent).toEqual('(df39067)')
+    expect(modifiedCheckpoint?.[0].label).toEqual('98cb38c')
 
     checkpointsByTip.forEach(checkpoints => {
       const continuationCheckpoints = checkpoints.filter(checkpoint => {
         const { label, displayNameOrParent } = checkpoint
         return (
           displayNameOrParent?.includes('(') &&
-          label !== '7e3cb21' &&
-          displayNameOrParent !== '(3b0c6ac)'
+          !(label === '7e3cb21' && displayNameOrParent === '(3b0c6ac)') &&
+          !(label === '98cb38c' && displayNameOrParent === '(df39067)')
         )
       })
       expect(continuationCheckpoints).toHaveLength(0)

--- a/extension/src/test/fixtures/expShow/modified.ts
+++ b/extension/src/test/fixtures/expShow/modified.ts
@@ -55,6 +55,79 @@ const data = {
         name: 'main'
       }
     },
+    '80d3ef4c9c6f0a60bccc7ee33f74f778f459c608': {
+      data: {
+        checkpoint_tip: '80d3ef4c9c6f0a60bccc7ee33f74f778f459c608',
+        timestamp: '2022-02-14T09:36:24',
+        params: {
+          'params.yaml': { data: { seed: 473987, lr: 0.001, weight_decay: 0 } }
+        },
+        queued: false,
+        running: false,
+        executor: null,
+        metrics: {
+          'logs.json': {
+            data: { step: 11, loss: 1.8944456577301025, acc: 0.6476 }
+          }
+        },
+        name: 'exp-9bc1b',
+        checkpoint_parent: 'eb74cc07d7367659173b70aca487e91af847b99d'
+      }
+    },
+    eb74cc07d7367659173b70aca487e91af847b99d: {
+      data: {
+        checkpoint_tip: '80d3ef4c9c6f0a60bccc7ee33f74f778f459c608',
+        timestamp: '2022-02-14T09:36:11',
+        params: {
+          'params.yaml': { data: { seed: 473987, lr: 0.001, weight_decay: 0 } }
+        },
+        queued: false,
+        running: false,
+        executor: null,
+        metrics: {
+          'logs.json': {
+            data: { step: 10, loss: 1.9335600137710571, acc: 0.5902 }
+          }
+        },
+        checkpoint_parent: '737d95ac80116db88b053a1eea250406252dda7c'
+      }
+    },
+    '737d95ac80116db88b053a1eea250406252dda7c': {
+      data: {
+        checkpoint_tip: '80d3ef4c9c6f0a60bccc7ee33f74f778f459c608',
+        timestamp: '2022-02-14T09:35:57',
+        params: {
+          'params.yaml': { data: { seed: 473987, lr: 0.001, weight_decay: 0 } }
+        },
+        queued: false,
+        running: false,
+        executor: null,
+        metrics: {
+          'logs.json': {
+            data: { step: 9, loss: 1.9798905849456787, acc: 0.627 }
+          }
+        },
+        checkpoint_parent: '98cb38c1092abd0dfb2ff459eccb6432f89218fb'
+      }
+    },
+    '98cb38c1092abd0dfb2ff459eccb6432f89218fb': {
+      data: {
+        checkpoint_tip: '80d3ef4c9c6f0a60bccc7ee33f74f778f459c608',
+        timestamp: '2022-02-14T09:35:43',
+        params: {
+          'params.yaml': { data: { seed: 473987, lr: 0.001, weight_decay: 0 } }
+        },
+        queued: false,
+        running: false,
+        executor: null,
+        metrics: {
+          'logs.json': {
+            data: { step: 8, loss: 2.017061233520508, acc: 0.5586 }
+          }
+        },
+        checkpoint_parent: 'df390673456d69f098e99fedbcf4064b0e0a272a'
+      }
+    },
     f65419f2eec04e6a0376b6ee3939441fc5f50794: {
       data: {
         checkpoint_tip: 'f65419f2eec04e6a0376b6ee3939441fc5f50794',


### PR DESCRIPTION
# 3/4 `master` <- #1313 <- #1315 <- this <- #1317

This PR fixes the logic used to identify checkpoints that have been continued from a specific checkpoint name or hash (using `--rev`). Previously we would have only identified experiments that were started from checkpoint tips. We now have logic to identify experiments that were started from any available checkpoint.

### Screenshot

<img width="1680" alt="Screen Shot 2022-02-14 at 10 29 40 am" src="https://user-images.githubusercontent.com/37993418/153780344-dc7b26c5-080f-4cc7-807f-54e18cf7ea10.png">

☝🏻 I left the command that I had run to generate the data in the terminal.