### PR TITLE
Mention non-support for VSCodium in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,3 @@ The DVC Extension for Visual Studio Code collects usage data and sends it to
 Azure to help improve our products and services. This extension respects the
 `telemetry.enableTelemetry` setting which you can learn more about at
 https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting.
-
-## VSCode Forks
-
-While the DVC Extension can work with VSCode forks like
-[VSCodium](https://vscodium.com/), our team only supports the official Microsoft
-build and it's possible that issues can arise. The Python extension in
-particular has problems with VSCodium, and often causes our extension's
-integration with it to fail.

--- a/extension/resources/walkthrough/setup-workspace.md
+++ b/extension/resources/walkthrough/setup-workspace.md
@@ -12,4 +12,10 @@ This can be done via the welcome view underneath the `DVC Tracked` view in the
 side bar's explorer view container or `DVC: Setup The Workspace` from the
 command palette.
 
+In some situations, like when using [VSCodium](https://vscodium.com/), the
+Python extension integration will fail. If this happens and you need to use DVC
+from inside a virtual environment, try using the "Yes, and I want to select the
+Python interpreter" option to specify a Python interpreter for DVC outside of
+the Python extension.
+
 Once you have setup your workspace the rest of the walkthrough will appear.


### PR DESCRIPTION
This PR mentions in the README that we do not suppport VSCodium, and that it has known issues with the Python extension that we integrate with.

Fixes #1318 