### PR TITLE
Increase timeout of test for windows

### DIFF
--- a/extension/src/test/suite/cli/runner.test.ts
+++ b/extension/src/test/suite/cli/runner.test.ts
@@ -157,6 +157,6 @@ suite('CLI Runner Test Suite', () => {
       expect(error.message).to.have.length.greaterThan(0)
       expect(command).to.equal('sleep 1 && then die')
       expect(exitCode).to.be.greaterThan(0)
-    })
+    }).timeout(5000)
   })
 })


### PR DESCRIPTION
I've seen this one fail a few times on windows, especially on #1350