### PR TITLE
Match on click behaviour in webview to native tree

### DIFF
--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -163,7 +163,7 @@ describe('App', () => {
       expect(screen.getByText(experimentLabel)).toBeInTheDocument()
       expect(screen.getByText(checkpointLabel)).toBeInTheDocument()
 
-      fireEvent.click(screen.getByText(experimentLabel))
+      fireEvent.click(screen.getByTestId(`${experimentLabel}-chevron`))
 
       expect(screen.getByText(experimentLabel)).toBeInTheDocument()
       expect(screen.queryByText(checkpointLabel)).not.toBeInTheDocument()
@@ -211,7 +211,7 @@ describe('App', () => {
       expect(screen.getByText(experimentLabel)).toBeInTheDocument()
       expect(screen.getByText(checkpointLabel)).toBeInTheDocument()
 
-      fireEvent.click(screen.getByText(experimentLabel))
+      fireEvent.click(screen.getByTestId(`${experimentLabel}-chevron`))
 
       expect(screen.getByText(experimentLabel)).toBeInTheDocument()
       expect(screen.queryByText(checkpointLabel)).not.toBeInTheDocument()
@@ -260,11 +260,10 @@ describe('App', () => {
           }
         })
       )
-      const testClick = (id: string) => {
+      const testClick = (label: string, id = label) => {
         mockPostMessage.mockReset()
-        const bullet = screen.getByTestId(`${id}-bullet`)
 
-        fireEvent.click(bullet)
+        fireEvent.click(screen.getByText(label))
 
         expect(mockPostMessage).toBeCalledTimes(1)
         expect(mockPostMessage).toBeCalledWith({
@@ -275,8 +274,9 @@ describe('App', () => {
 
       testClick('workspace')
       testClick('main')
-      testClick('exp-e7a67')
-      testClick('e821416bfafb4bc28b3e0a8ddb322505b0ad2361')
+      testClick('[exp-e7a67]', 'exp-e7a67')
+      testClick('22e40e1', '22e40e1fa3c916ac567f69b85969e3066a91dda4')
+      testClick('e821416', 'e821416bfafb4bc28b3e0a8ddb322505b0ad2361')
     })
   })
 })


### PR DESCRIPTION
Follow on from #1350. This is a second option for `onClick` behaviour in the experiments webview. This behaviour matches that shown in the native sidebar tree.

### Demo

https://user-images.githubusercontent.com/37993418/155654579-4f80cd39-1068-49a5-a5f3-c3663d35f3f2.mov

This would be my preferred option but LMK what you think.

For the benefit of anyone that isn't @sroy3 reading this we paired on #1350 this morning and decided that would be the easiest thing to do to get the initial behaviour in. I have revisited by myself this afternoon (while she is hopefully sleeping).

**Note**: Implementation more than likely doesn't follow best practices. Happy to be corrected 👍🏻 .