### PR TITLE
Fix icon menu colors

### DIFF
--- a/webview/src/shared/components/iconMenu/IconMenuItem.tsx
+++ b/webview/src/shared/components/iconMenu/IconMenuItem.tsx
@@ -36,12 +36,7 @@ export const IconMenuItem: React.FC<IconMenuItemAllProps> = ({
         onClick={onClick}
         data-testid="icon-menu-item"
       >
-        <Icon
-          icon={icon}
-          className={styles.icon}
-          data-testid="icon-menu-item-icon"
-          width={15}
-        />
+        <Icon icon={icon} data-testid="icon-menu-item-icon" width={15} />
       </button>
     </Tippy>
   )

--- a/webview/src/shared/components/iconMenu/styles.module.scss
+++ b/webview/src/shared/components/iconMenu/styles.module.scss
@@ -42,7 +42,3 @@
     right: 5px;
   }
 }
-
-.icon {
-  fill: $fg-color;
-}


### PR DESCRIPTION
Since the wrapper component went from `div` to `button` there was now a default colour set on the `button` element that was overriding the `fill` property.