### PR TITLE
Fix comparison header color

### DIFF
--- a/webview/src/plots/components/ComparisonTable/styles.module.scss
+++ b/webview/src/plots/components/ComparisonTable/styles.module.scss
@@ -5,6 +5,7 @@ $gap: 4px;
   position: sticky;
   top: -#{$gap};
   z-index: 2;
+  background-color: $bg-color;
 }
 
 .header {
@@ -107,3 +108,4 @@ $gap: 4px;
   width: 100%;
   height: auto;
 }
+


### PR DESCRIPTION
**Before**
<img width="1060" alt="Screen Shot 2022-03-04 at 1 18 48 PM" src="https://user-images.githubusercontent.com/3683420/156820449-e1d518cb-8d7b-40f7-a07c-dfbdc7421092.png">

**Now**
<img width="1051" alt="Screen Shot 2022-03-04 at 1 21 05 PM" src="https://user-images.githubusercontent.com/3683420/156820518-c706dc51-b719-47ea-9205-88ae1f787eac.png">

