### PR TITLE
Rename live to checkpoint

### DIFF
--- a/extension/src/plots/index.ts
+++ b/extension/src/plots/index.ts
@@ -82,34 +82,34 @@ export class Plots extends BaseRepository<TPlotsData> {
   public async sendInitialWebviewData() {
     await this.isReady()
     this.webview?.show({
+      checkpoint: this.getCheckpointPlots(),
       comparison: this.getComparisonPlots(),
-      live: this.getLivePlots(),
       sectionCollapsed: this.plots?.getSectionCollapsed(),
       template: this.getTemplatePlots()
     })
   }
 
-  private sendLivePlotsData() {
+  private sendCheckpointPlotsData() {
     this.webview?.show({
-      live: this.getLivePlots()
+      checkpoint: this.getCheckpointPlots()
     })
   }
 
-  private getLivePlots() {
-    return this.plots?.getLivePlots() || null
+  private getCheckpointPlots() {
+    return this.plots?.getCheckpointPlots() || null
   }
 
   private async sendPlots() {
     if (definedAndNonEmpty(this.plots?.getMissingRevisions())) {
-      this.sendLivePlotsData()
+      this.sendCheckpointPlotsData()
       return this.data.managedUpdate()
     }
 
     await this.isReady()
 
     this.webview?.show({
+      checkpoint: this.getCheckpointPlots(),
       comparison: this.getComparisonPlots(),
-      live: this.getLivePlots(),
       template: this.getTemplatePlots()
     })
   }

--- a/extension/src/plots/model/collect.test.ts
+++ b/extension/src/plots/model/collect.test.ts
@@ -1,24 +1,28 @@
 import omit from 'lodash.omit'
 import isEmpty from 'lodash.isempty'
-import { collectData, collectLivePlotsData, collectTemplates } from './collect'
+import {
+  collectData,
+  collectCheckpointPlotsData,
+  collectTemplates
+} from './collect'
 import plotsDiffFixture from '../../test/fixtures/plotsDiff/output'
 import expShowFixture from '../../test/fixtures/expShow/output'
 import modifiedFixture from '../../test/fixtures/expShow/modified'
-import livePlotsFixture from '../../test/fixtures/expShow/livePlots'
+import checkpointPlotsFixture from '../../test/fixtures/expShow/checkpointPlots'
 import { ExperimentsOutput } from '../../cli/reader'
 import { definedAndNonEmpty, sameContents } from '../../util/array'
 import { TemplatePlot } from '../webview/contract'
 
 const LogsLossTsv = (plotsDiffFixture['logs/loss.tsv'][0] || {}) as TemplatePlot
 
-describe('collectLivePlotsData', () => {
+describe('collectCheckpointPlotsData', () => {
   it('should return the expected data from the test fixture', () => {
-    const data = collectLivePlotsData(expShowFixture)
-    expect(data).toStrictEqual(livePlotsFixture.plots)
+    const data = collectCheckpointPlotsData(expShowFixture)
+    expect(data).toStrictEqual(checkpointPlotsFixture.plots)
   })
 
   it('should provide a continuous series for a modified experiment', () => {
-    const data = collectLivePlotsData(modifiedFixture)
+    const data = collectCheckpointPlotsData(modifiedFixture)
 
     expect(definedAndNonEmpty(data)).toBeTruthy()
 
@@ -56,7 +60,7 @@ describe('collectLivePlotsData', () => {
   })
 
   it('should return undefined given no input', () => {
-    const data = collectLivePlotsData({} as ExperimentsOutput)
+    const data = collectCheckpointPlotsData({} as ExperimentsOutput)
     expect(data).toBeUndefined()
   })
 })

--- a/extension/src/plots/model/collect.ts
+++ b/extension/src/plots/model/collect.ts
@@ -1,8 +1,8 @@
 import omit from 'lodash.omit'
 import { VisualizationSpec } from 'react-vega'
 import {
-  LivePlotValues,
-  LivePlotData,
+  CheckpointPlotValues,
+  CheckpointPlotData,
   isImagePlot,
   ImagePlot,
   TemplatePlot
@@ -22,13 +22,13 @@ import {
 import { MetricsOrParams } from '../../experiments/webview/contract'
 import { addToMapArray } from '../../util/map'
 
-type LivePlotAccumulator = {
+type CheckpointPlotAccumulator = {
   iterations: Record<string, number>
-  plots: Map<string, LivePlotValues>
+  plots: Map<string, CheckpointPlotValues>
 }
 
 const collectFromMetricsFile = (
-  acc: LivePlotAccumulator,
+  acc: CheckpointPlotAccumulator,
   name: string,
   iteration: number,
   key: string | undefined,
@@ -93,7 +93,7 @@ const isValid = (data: MetricsAndDetailsOrUndefined): data is ValidData =>
   !!(data?.checkpoint_tip && data?.checkpoint_parent && data?.metrics)
 
 const collectFromMetrics = (
-  acc: LivePlotAccumulator,
+  acc: CheckpointPlotAccumulator,
   experimentName: string,
   iteration: number,
   metrics: MetricsOrParams
@@ -111,12 +111,12 @@ const collectFromMetrics = (
 }
 
 const getLastIteration = (
-  acc: LivePlotAccumulator,
+  acc: CheckpointPlotAccumulator,
   checkpointParent: string
 ): number => acc.iterations[checkpointParent] || 0
 
 const collectIteration = (
-  acc: LivePlotAccumulator,
+  acc: CheckpointPlotAccumulator,
   sha: string,
   checkpointParent: string
 ): number => {
@@ -126,7 +126,7 @@ const collectIteration = (
 }
 
 const linkModified = (
-  acc: LivePlotAccumulator,
+  acc: CheckpointPlotAccumulator,
   experimentName: string,
   checkpointTip: string,
   checkpointParent: string,
@@ -146,7 +146,7 @@ const linkModified = (
 }
 
 const collectFromExperimentsObject = (
-  acc: LivePlotAccumulator,
+  acc: CheckpointPlotAccumulator,
   experimentsObject: { [sha: string]: ExperimentFieldsOrError }
 ) => {
   for (const [sha, experimentData] of Object.entries(
@@ -181,12 +181,12 @@ const collectFromExperimentsObject = (
   }
 }
 
-export const collectLivePlotsData = (
+export const collectCheckpointPlotsData = (
   data: ExperimentsOutput
-): LivePlotData[] | undefined => {
+): CheckpointPlotData[] | undefined => {
   const acc = {
     iterations: {},
-    plots: new Map<string, LivePlotValues>()
+    plots: new Map<string, CheckpointPlotValues>()
   }
 
   for (const { baseline, ...experimentsObject } of Object.values(
@@ -203,7 +203,7 @@ export const collectLivePlotsData = (
     return
   }
 
-  const plotsData: LivePlotData[] = []
+  const plotsData: CheckpointPlotData[] = []
 
   acc.plots.forEach((value, key) => {
     plotsData.push({ title: decodeMetricOrParam(key), values: value })

--- a/extension/src/plots/model/index.test.ts
+++ b/extension/src/plots/model/index.test.ts
@@ -54,40 +54,42 @@ describe('plotsModel', () => {
   })
 
   it('should change the plotSize when calling setPlotSize', () => {
-    expect(model.getPlotSize(Section.LIVE_PLOTS)).toStrictEqual(
+    expect(model.getPlotSize(Section.CHECKPOINT_PLOTS)).toStrictEqual(
       PlotSize.REGULAR
     )
 
-    model.setPlotSize(Section.LIVE_PLOTS, PlotSize.LARGE)
+    model.setPlotSize(Section.CHECKPOINT_PLOTS, PlotSize.LARGE)
 
-    expect(model.getPlotSize(Section.LIVE_PLOTS)).toStrictEqual(PlotSize.LARGE)
+    expect(model.getPlotSize(Section.CHECKPOINT_PLOTS)).toStrictEqual(
+      PlotSize.LARGE
+    )
   })
 
   it('should update the persisted plot size when calling setPlotSize', () => {
     const mementoUpdateSpy = jest.spyOn(memento, 'update')
 
-    model.setPlotSize(Section.LIVE_PLOTS, PlotSize.SMALL)
+    model.setPlotSize(Section.CHECKPOINT_PLOTS, PlotSize.SMALL)
 
     expect(mementoUpdateSpy).toHaveBeenCalledTimes(1)
     expect(mementoUpdateSpy).toHaveBeenCalledWith(
       MementoPrefix.PLOT_SIZES + exampleDvcRoot,
-      { ...DEFAULT_SECTION_SIZES, [Section.LIVE_PLOTS]: PlotSize.SMALL }
+      { ...DEFAULT_SECTION_SIZES, [Section.CHECKPOINT_PLOTS]: PlotSize.SMALL }
     )
   })
 
   it('should change the the sectionName of a section when calling setSectionName', () => {
-    expect(model.getSectionName(Section.LIVE_PLOTS)).toStrictEqual(
-      DEFAULT_SECTION_NAMES[Section.LIVE_PLOTS]
+    expect(model.getSectionName(Section.CHECKPOINT_PLOTS)).toStrictEqual(
+      DEFAULT_SECTION_NAMES[Section.CHECKPOINT_PLOTS]
     )
     expect(model.getSectionName(Section.TEMPLATE_PLOTS)).toStrictEqual(
       DEFAULT_SECTION_NAMES[Section.TEMPLATE_PLOTS]
     )
 
-    const newLivePlotsName = 'Live Section'
-    model.setSectionName(Section.LIVE_PLOTS, newLivePlotsName)
+    const newCheckpointPlotsName = 'Previously called live'
+    model.setSectionName(Section.CHECKPOINT_PLOTS, newCheckpointPlotsName)
 
-    expect(model.getSectionName(Section.LIVE_PLOTS)).toStrictEqual(
-      newLivePlotsName
+    expect(model.getSectionName(Section.CHECKPOINT_PLOTS)).toStrictEqual(
+      newCheckpointPlotsName
     )
     expect(model.getSectionName(Section.TEMPLATE_PLOTS)).toStrictEqual(
       DEFAULT_SECTION_NAMES[Section.TEMPLATE_PLOTS]
@@ -104,13 +106,13 @@ describe('plotsModel', () => {
     const mementoUpdateSpy = jest.spyOn(memento, 'update')
 
     const newName = 'Important Plots'
-    model.setSectionName(Section.LIVE_PLOTS, newName)
+    model.setSectionName(Section.CHECKPOINT_PLOTS, newName)
 
     expect(mementoUpdateSpy).toHaveBeenCalledTimes(1)
     expect(mementoUpdateSpy).toHaveBeenCalledWith(
       MementoPrefix.PLOT_SECTION_NAMES + exampleDvcRoot,
       {
-        [Section.LIVE_PLOTS]: newName,
+        [Section.CHECKPOINT_PLOTS]: newName,
         [Section.TEMPLATE_PLOTS]: DEFAULT_SECTION_NAMES[Section.TEMPLATE_PLOTS],
         [Section.COMPARISON_TABLE]:
           DEFAULT_SECTION_NAMES[Section.COMPARISON_TABLE]
@@ -123,10 +125,10 @@ describe('plotsModel', () => {
 
     expect(model.getSectionCollapsed()).toStrictEqual(DEFAULT_SECTION_COLLAPSED)
 
-    model.setSectionCollapsed({ [Section.LIVE_PLOTS]: true })
+    model.setSectionCollapsed({ [Section.CHECKPOINT_PLOTS]: true })
 
     const expectedSectionCollapsed = {
-      [Section.LIVE_PLOTS]: true,
+      [Section.CHECKPOINT_PLOTS]: true,
       [Section.TEMPLATE_PLOTS]: false,
       [Section.COMPARISON_TABLE]: false
     }

--- a/extension/src/plots/model/index.ts
+++ b/extension/src/plots/model/index.ts
@@ -4,19 +4,19 @@ import { Disposable } from '@hediet/std/disposable'
 import { TopLevelSpec } from 'vega-lite'
 import { VisualizationSpec } from 'react-vega'
 import {
+  collectCheckpointPlotsData,
   collectData,
-  collectLivePlotsData,
   collectTemplates,
   ComparisonData,
   RevisionData
 } from './collect'
 import {
+  CheckpointPlotData,
   ComparisonRevisionData,
   ComparisonPlots,
   DEFAULT_SECTION_COLLAPSED,
   DEFAULT_SECTION_NAMES,
   DEFAULT_SECTION_SIZES,
-  LivePlotData,
   PlotSize,
   PlotsType,
   Section,
@@ -39,7 +39,7 @@ export class PlotsModel {
   private readonly experiments: Experiments
   private readonly workspaceState: Memento
 
-  private livePlots?: LivePlotData[]
+  private checkpointPlots?: CheckpointPlotData[]
   private selectedMetrics?: string[]
   private plotSizes: Record<Section, PlotSize>
   private sectionCollapsed: SectionCollapsed
@@ -85,9 +85,9 @@ export class PlotsModel {
   }
 
   public transformAndSetExperiments(data: ExperimentsOutput) {
-    const livePlots = collectLivePlotsData(data)
+    const checkpointPlots = collectCheckpointPlotsData(data)
 
-    this.livePlots = livePlots
+    this.checkpointPlots = checkpointPlots
 
     return this.removeStaleData()
   }
@@ -105,8 +105,8 @@ export class PlotsModel {
     this.deferred.resolve()
   }
 
-  public getLivePlots() {
-    if (!this.livePlots) {
+  public getCheckpointPlots() {
+    if (!this.checkpointPlots) {
       return
     }
 
@@ -124,10 +124,10 @@ export class PlotsModel {
 
     return {
       colors,
-      plots: this.getPlots(this.livePlots, selectedExperiments),
-      sectionName: this.getSectionName(Section.LIVE_PLOTS),
+      plots: this.getPlots(this.checkpointPlots, selectedExperiments),
+      sectionName: this.getSectionName(Section.CHECKPOINT_PLOTS),
       selectedMetrics: this.getSelectedMetrics(),
-      size: this.getPlotSize(Section.LIVE_PLOTS)
+      size: this.getPlotSize(Section.CHECKPOINT_PLOTS)
     }
   }
 
@@ -301,8 +301,11 @@ export class PlotsModel {
     return this.experiments.getSelectedRevisions().map(({ label }) => label)
   }
 
-  private getPlots(livePlots: LivePlotData[], selectedExperiments: string[]) {
-    return livePlots.map(plot => {
+  private getPlots(
+    checkpointPlots: CheckpointPlotData[],
+    selectedExperiments: string[]
+  ) {
+    return checkpointPlots.map(plot => {
       const { title, values } = plot
       return {
         title,

--- a/extension/src/plots/webview/contract.ts
+++ b/extension/src/plots/webview/contract.ts
@@ -10,25 +10,25 @@ type PlotSizeKeys = keyof typeof PlotSize
 export type PlotSize = typeof PlotSize[PlotSizeKeys]
 
 export enum Section {
-  LIVE_PLOTS = 'live-plots',
+  CHECKPOINT_PLOTS = 'checkpoint-plots',
   TEMPLATE_PLOTS = 'template-plots',
   COMPARISON_TABLE = 'comparison-table'
 }
 
 export const DEFAULT_SECTION_NAMES = {
-  [Section.LIVE_PLOTS]: 'Experiment Checkpoints',
+  [Section.CHECKPOINT_PLOTS]: 'Experiment Checkpoints',
   [Section.TEMPLATE_PLOTS]: 'Plots',
   [Section.COMPARISON_TABLE]: 'Comparison'
 }
 
 export const DEFAULT_SECTION_SIZES = {
-  [Section.LIVE_PLOTS]: PlotSize.REGULAR,
+  [Section.CHECKPOINT_PLOTS]: PlotSize.REGULAR,
   [Section.TEMPLATE_PLOTS]: PlotSize.REGULAR,
   [Section.COMPARISON_TABLE]: PlotSize.REGULAR
 }
 
 export const DEFAULT_SECTION_COLLAPSED = {
-  [Section.LIVE_PLOTS]: false,
+  [Section.CHECKPOINT_PLOTS]: false,
   [Section.TEMPLATE_PLOTS]: false,
   [Section.COMPARISON_TABLE]: false
 }
@@ -51,18 +51,22 @@ export interface PlotsComparisonData {
   size: PlotSize
 }
 
-export type LivePlotValues = { group: string; iteration: number; y: number }[]
+export type CheckpointPlotValues = {
+  group: string
+  iteration: number
+  y: number
+}[]
 
-export type LivePlotsColors = { domain: string[]; range: string[] }
+export type CheckpointPlotsColors = { domain: string[]; range: string[] }
 
-export type LivePlotData = {
+export type CheckpointPlotData = {
   title: string
-  values: LivePlotValues
+  values: CheckpointPlotValues
 }
 
-export type LivePlotsData = {
-  plots: LivePlotData[]
-  colors: LivePlotsColors
+export type CheckpointPlotsData = {
+  plots: CheckpointPlotData[]
+  colors: CheckpointPlotsColors
   size: PlotSize
   sectionName: string
   selectedMetrics?: string[]
@@ -111,7 +115,7 @@ export type ComparisonPlot = {
 export type PlotsData =
   | {
       comparison?: PlotsComparisonData | null
-      live?: LivePlotsData | null
+      checkpoint?: CheckpointPlotsData | null
       template?: TemplatePlotsData | null
       sectionCollapsed?: SectionCollapsed
     }

--- a/extension/src/test/fixtures/expShow/checkpointPlots.ts
+++ b/extension/src/test/fixtures/expShow/checkpointPlots.ts
@@ -1,11 +1,11 @@
 import {
   DEFAULT_SECTION_NAMES,
-  LivePlotsData,
+  CheckpointPlotsData,
   PlotSize,
   Section
 } from '../../../plots/webview/contract'
 
-const data: LivePlotsData = {
+const data: CheckpointPlotsData = {
   colors: {
     domain: ['exp-e7a67', 'test-branch', 'exp-83425'],
     range: ['#f14c4c', '#3794ff', '#cca700']
@@ -82,7 +82,7 @@ const data: LivePlotsData = {
   ],
   selectedMetrics: undefined,
   size: PlotSize.REGULAR,
-  sectionName: DEFAULT_SECTION_NAMES[Section.LIVE_PLOTS]
+  sectionName: DEFAULT_SECTION_NAMES[Section.CHECKPOINT_PLOTS]
 }
 
 export default data

--- a/extension/src/test/suite/experiments/model/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/tree.test.ts
@@ -17,8 +17,8 @@ import { Status } from '../../../../experiments/model/status'
 import { experimentsUpdatedEvent, getFirstArgOfLastCall } from '../../util'
 import { dvcDemoPath } from '../../../util'
 import { RegisteredCommands } from '../../../../commands/external'
-import { buildPlots, getExpectedLivePlotsData } from '../../plots/util'
-import livePlotsFixture from '../../../fixtures/expShow/livePlots'
+import { buildPlots, getExpectedCheckpointPlotsData } from '../../plots/util'
+import checkpointPlotsFixture from '../../../fixtures/expShow/checkpointPlots'
 import plotsDiffFixture from '../../../fixtures/plotsDiff/output'
 import expShowFixture from '../../../fixtures/expShow/output'
 import { Operator } from '../../../../experiments/model/filterBy'
@@ -46,7 +46,7 @@ suite('Experiments Tree Test Suite', () => {
   })
 
   describe('ExperimentsTree', () => {
-    const { colors } = livePlotsFixture
+    const { colors } = checkpointPlotsFixture
     const { domain, range } = colors
 
     it('should appear in the UI', async () => {
@@ -61,18 +61,18 @@ suite('Experiments Tree Test Suite', () => {
       const expectedDomain = [...domain]
       const expectedRange = [...range]
 
-      const mockGetLivePlots = stub(plotsModel, 'getLivePlots')
-      const getLivePlotsEvent = new Promise(resolve =>
-        mockGetLivePlots.callsFake(() => {
+      const mockGetCheckpointPlots = stub(plotsModel, 'getCheckpointPlots')
+      const getCheckpointPlotsEvent = new Promise(resolve =>
+        mockGetCheckpointPlots.callsFake(() => {
           resolve(undefined)
-          return mockGetLivePlots.wrappedMethod.bind(plotsModel)()
+          return mockGetCheckpointPlots.wrappedMethod.bind(plotsModel)()
         })
       )
 
       await plots.showWebview()
-      await getLivePlotsEvent
+      await getCheckpointPlotsEvent
 
-      mockGetLivePlots.restore()
+      mockGetCheckpointPlots.restore()
 
       const setSelectionModeSpy = spy(
         ExperimentsModel.prototype,
@@ -80,15 +80,15 @@ suite('Experiments Tree Test Suite', () => {
       )
 
       while (expectedDomain.length) {
-        const expectedData = getExpectedLivePlotsData(
+        const expectedData = getExpectedCheckpointPlotsData(
           expectedDomain,
           expectedRange
         )
 
-        const { live } = getFirstArgOfLastCall(messageSpy)
+        const { checkpoint } = getFirstArgOfLastCall(messageSpy)
 
         expect(
-          { live },
+          { checkpoint },
           'a message is sent with colors for the currently selected experiments'
         ).to.deep.equal(expectedData)
         messageSpy.resetHistory()
@@ -116,7 +116,7 @@ suite('Experiments Tree Test Suite', () => {
         messageSpy,
         'when there are no experiments selected we send undefined (show empty state)'
       ).to.be.calledWith({
-        live: null
+        checkpoint: null
       })
       messageSpy.resetHistory()
 
@@ -136,7 +136,7 @@ suite('Experiments Tree Test Suite', () => {
       )
 
       expect(messageSpy, 'we no longer send undefined').to.be.calledWith(
-        getExpectedLivePlotsData(expectedDomain, expectedRange)
+        getExpectedCheckpointPlotsData(expectedDomain, expectedRange)
       )
       expect(
         setSelectionModeSpy,
@@ -198,7 +198,7 @@ suite('Experiments Tree Test Suite', () => {
         messageSpy,
         'a message is sent with colors for the currently selected experiments'
       ).to.be.calledWith(
-        getExpectedLivePlotsData([selectedDisplayName], [selectedColor])
+        getExpectedCheckpointPlotsData([selectedDisplayName], [selectedColor])
       )
       expect(
         setSelectionModeSpy,
@@ -240,7 +240,7 @@ suite('Experiments Tree Test Suite', () => {
         messageSpy,
         'the filter is applied and one experiment remains because of a single checkpoint'
       ).to.be.calledWith(
-        getExpectedLivePlotsData([selectedDisplayName], [selectedColor])
+        getExpectedCheckpointPlotsData([selectedDisplayName], [selectedColor])
       )
       expect(
         setSelectionModeSpy,
@@ -351,7 +351,11 @@ suite('Experiments Tree Test Suite', () => {
       expect(setSelectionModeSpy).to.be.calledOnceWith(true)
       setSelectionModeSpy.resetHistory()
 
-      const expectedMessage = { comparison: null, live: null, template: null }
+      const expectedMessage = {
+        checkpoint: null,
+        comparison: null,
+        template: null
+      }
 
       expect(
         messageSpy,

--- a/extension/src/test/suite/plots/index.test.ts
+++ b/extension/src/test/suite/plots/index.test.ts
@@ -7,7 +7,7 @@ import { restore, stub } from 'sinon'
 import { buildPlots } from '../plots/util'
 import { Disposable } from '../../../extension'
 import expShowFixture from '../../fixtures/expShow/output'
-import livePlotsFixture from '../../fixtures/expShow/livePlots'
+import checkpointPlotsFixture from '../../fixtures/expShow/checkpointPlots'
 import plotsDiffFixture from '../../fixtures/plotsDiff/output'
 import templatePlotsFixture from '../../fixtures/plotsDiff/template'
 import comparisonPlotsFixture from '../../fixtures/plotsDiff/comparison/vscode'
@@ -153,34 +153,34 @@ suite('Plots Test Suite', () => {
         plotsDiffFixture
       )
 
-      const mockGetLivePlots = stub(plotsModel, 'getLivePlots')
-      const getLivePlotsEvent = new Promise(resolve =>
-        mockGetLivePlots.callsFake(() => {
+      const mockGetCheckpointPlots = stub(plotsModel, 'getCheckpointPlots')
+      const getCheckpointPlotsEvent = new Promise(resolve =>
+        mockGetCheckpointPlots.callsFake(() => {
           resolve(undefined)
-          return mockGetLivePlots.wrappedMethod.bind(plotsModel)()
+          return mockGetCheckpointPlots.wrappedMethod.bind(plotsModel)()
         })
       )
 
       const webview = await plots.showWebview()
-      await getLivePlotsEvent
+      await getCheckpointPlotsEvent
 
       expect(mockPlotsDiff).to.be.called
 
       const {
+        checkpoint: checkpointData,
         comparison: comparisonData,
-        live: liveData,
         sectionCollapsed,
         template: templateData
       } = getFirstArgOfLastCall(messageSpy)
 
+      expect(checkpointData).to.deep.equal(checkpointPlotsFixture)
       expect(comparisonData).to.deep.equal(comparisonPlotsFixture)
-      expect(liveData).to.deep.equal(livePlotsFixture)
       expect(sectionCollapsed).to.deep.equal(DEFAULT_SECTION_COLLAPSED)
       expect(templateData).to.deep.equal(templatePlotsFixture)
 
       const expectedPlotsData: TPlotsData = {
+        checkpoint: checkpointPlotsFixture,
         comparison: comparisonPlotsFixture,
-        live: livePlotsFixture,
         sectionCollapsed: DEFAULT_SECTION_COLLAPSED,
         template: templatePlotsFixture
       }

--- a/extension/src/test/suite/plots/util.ts
+++ b/extension/src/test/suite/plots/util.ts
@@ -2,7 +2,7 @@ import { Disposer } from '@hediet/std/disposable'
 import { stub } from 'sinon'
 import * as FileSystem from '../../../fileSystem'
 import expShowFixture from '../../fixtures/expShow/output'
-import livePlotsFixture from '../../fixtures/expShow/livePlots'
+import checkpointPlotsFixture from '../../fixtures/expShow/checkpointPlots'
 import { Plots } from '../../../plots'
 import { buildMockMemento, dvcDemoPath } from '../../util'
 import { WorkspacePlots } from '../../../plots/workspace'
@@ -84,10 +84,13 @@ export const buildPlots = async (
   }
 }
 
-export const getExpectedLivePlotsData = (domain: string[], range: string[]) => {
-  const { plots, sectionName, selectedMetrics, size } = livePlotsFixture
+export const getExpectedCheckpointPlotsData = (
+  domain: string[],
+  range: string[]
+) => {
+  const { plots, sectionName, selectedMetrics, size } = checkpointPlotsFixture
   return {
-    live: {
+    checkpoint: {
       colors: {
         domain,
         range

--- a/webview/src/plots/components/App.test.tsx
+++ b/webview/src/plots/components/App.test.tsx
@@ -5,11 +5,11 @@ import React from 'react'
 import { render, cleanup, screen, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import comparisonTableFixture from 'dvc/src/test/fixtures/plotsDiff/comparison'
-import livePlotsFixture from 'dvc/src/test/fixtures/expShow/livePlots'
+import checkpointPlotsFixture from 'dvc/src/test/fixtures/expShow/checkpointPlots'
 import templatePlotsFixture from 'dvc/src/test/fixtures/plotsDiff/template/webview'
 import {
   DEFAULT_SECTION_COLLAPSED,
-  LivePlotsColors,
+  CheckpointPlotsColors,
   PlotsData,
   PlotSize,
   Section
@@ -27,7 +27,7 @@ jest.mock('../../shared/api')
 
 jest.mock('./constants', () => ({
   ...jest.requireActual('./constants'),
-  createSpec: (title: string, scale?: LivePlotsColors) => ({
+  createSpec: (title: string, scale?: CheckpointPlotsColors) => ({
     ...jest.requireActual('./constants').createSpec(title, scale),
     height: 100,
     width: 100
@@ -96,7 +96,7 @@ describe('App', () => {
 
   it('should render the loading state when not initially provided with collapsed sections', async () => {
     renderAppWithData({
-      live: null
+      checkpoint: null
     })
 
     const loadingState = await screen.findByText('Loading Plots...')
@@ -106,7 +106,7 @@ describe('App', () => {
 
   it('should render the empty state when given data with no plots', async () => {
     renderAppWithData({
-      live: null,
+      checkpoint: null,
       sectionCollapsed: DEFAULT_SECTION_COLLAPSED
     })
     const emptyState = await screen.findByText('No Plots to Display')
@@ -114,10 +114,10 @@ describe('App', () => {
     expect(emptyState).toBeInTheDocument()
   })
 
-  it('should render only live plots when given a message with only live plots data', () => {
+  it('should render only checkpoint plots when given a message with only checkpoint plots data', () => {
     jest.spyOn(console, 'warn').mockImplementation(() => {})
     renderAppWithData({
-      live: livePlotsFixture,
+      checkpoint: checkpointPlotsFixture,
       sectionCollapsed: DEFAULT_SECTION_COLLAPSED
     })
 
@@ -127,9 +127,9 @@ describe('App', () => {
     expect(screen.queryByText('Comparison')).not.toBeInTheDocument()
   })
 
-  it('should render live and template plots when given messages with both types of plots data', () => {
+  it('should render checkpoint and template plots when given messages with both types of plots data', () => {
     renderAppWithData({
-      live: livePlotsFixture,
+      checkpoint: checkpointPlotsFixture,
       sectionCollapsed: DEFAULT_SECTION_COLLAPSED
     })
 
@@ -150,7 +150,7 @@ describe('App', () => {
     const expectedSectionName = 'Comparison'
 
     renderAppWithData({
-      live: livePlotsFixture,
+      checkpoint: checkpointPlotsFixture,
       sectionCollapsed: DEFAULT_SECTION_COLLAPSED
     })
 
@@ -161,23 +161,23 @@ describe('App', () => {
     expect(screen.getByText(expectedSectionName)).toBeInTheDocument()
   })
 
-  it('should remove live plots given a message showing live plots as null', () => {
+  it('should remove checkpoint plots given a message showing checkpoint plots as null', () => {
     renderAppWithData({
-      live: livePlotsFixture,
+      checkpoint: checkpointPlotsFixture,
       sectionCollapsed: DEFAULT_SECTION_COLLAPSED
     })
 
     expect(screen.getByText('Experiment Checkpoints')).toBeInTheDocument()
 
     sendSetDataMessage({
-      live: null
+      checkpoint: null
     })
     expect(screen.queryByText('Experiment Checkpoints')).not.toBeInTheDocument()
   })
 
-  it('should toggle the live plots section in state when its header is clicked', async () => {
+  it('should toggle the checkpoint plots section in state when its header is clicked', async () => {
     renderAppWithData({
-      live: livePlotsFixture,
+      checkpoint: checkpointPlotsFixture,
       sectionCollapsed: DEFAULT_SECTION_COLLAPSED
     })
 
@@ -194,7 +194,7 @@ describe('App', () => {
       screen.queryByLabelText('Vega visualization')
     ).not.toBeInTheDocument()
     expect(mockPostMessage).toBeCalledWith({
-      payload: { [Section.LIVE_PLOTS]: true },
+      payload: { [Section.CHECKPOINT_PLOTS]: true },
       type: MessageFromWebviewType.PLOTS_SECTION_TOGGLED
     })
   })
@@ -204,7 +204,7 @@ describe('App', () => {
       <Plots
         state={{
           data: {
-            live: livePlotsFixture,
+            checkpoint: checkpointPlotsFixture,
             sectionCollapsed: DEFAULT_SECTION_COLLAPSED,
             template: null
           }
@@ -247,7 +247,7 @@ describe('App', () => {
 
   it('should send a message to the extension with the selected metrics when toggling the visibility of a plot', async () => {
     renderAppWithData({
-      live: livePlotsFixture,
+      checkpoint: checkpointPlotsFixture,
       sectionCollapsed: DEFAULT_SECTION_COLLAPSED
     })
 
@@ -280,7 +280,7 @@ describe('App', () => {
 
   it('should change the size of the plots according to the size picker', async () => {
     renderAppWithData({
-      live: livePlotsFixture,
+      checkpoint: checkpointPlotsFixture,
       sectionCollapsed: DEFAULT_SECTION_COLLAPSED
     })
 
@@ -307,7 +307,7 @@ describe('App', () => {
 
   it('should send a message to the extension with the selected size when changing the size of plots', () => {
     renderAppWithData({
-      live: livePlotsFixture,
+      checkpoint: checkpointPlotsFixture,
       sectionCollapsed: DEFAULT_SECTION_COLLAPSED
     })
 
@@ -319,7 +319,7 @@ describe('App', () => {
     fireEvent.click(largeButton)
 
     expect(mockPostMessage).toBeCalledWith({
-      payload: { section: Section.LIVE_PLOTS, size: PlotSize.LARGE },
+      payload: { section: Section.CHECKPOINT_PLOTS, size: PlotSize.LARGE },
       type: MessageFromWebviewType.PLOTS_RESIZED
     })
 
@@ -327,14 +327,14 @@ describe('App', () => {
     fireEvent.click(smallButton)
 
     expect(mockPostMessage).toBeCalledWith({
-      payload: { section: Section.LIVE_PLOTS, size: PlotSize.SMALL },
+      payload: { section: Section.CHECKPOINT_PLOTS, size: PlotSize.SMALL },
       type: MessageFromWebviewType.PLOTS_RESIZED
     })
   })
 
   it('should show an input to rename the section when clicking the rename icon button', () => {
     renderAppWithData({
-      live: livePlotsFixture,
+      checkpoint: checkpointPlotsFixture,
       sectionCollapsed: DEFAULT_SECTION_COLLAPSED
     })
 
@@ -349,7 +349,7 @@ describe('App', () => {
 
   it('should change the title of the section when hitting enter on the title input', () => {
     renderAppWithData({
-      live: livePlotsFixture,
+      checkpoint: checkpointPlotsFixture,
       sectionCollapsed: DEFAULT_SECTION_COLLAPSED
     })
     const originalText = 'Experiment Checkpoints'
@@ -370,7 +370,7 @@ describe('App', () => {
 
   it('should change the title of the section on the blur event of the input', () => {
     renderAppWithData({
-      live: livePlotsFixture,
+      checkpoint: checkpointPlotsFixture,
       sectionCollapsed: DEFAULT_SECTION_COLLAPSED
     })
     const originalText = 'Experiment Checkpoints'
@@ -391,7 +391,7 @@ describe('App', () => {
 
   it('should send a message to the extension with the new section name after a section rename', () => {
     renderAppWithData({
-      live: livePlotsFixture,
+      checkpoint: checkpointPlotsFixture,
       sectionCollapsed: DEFAULT_SECTION_COLLAPSED
     })
 
@@ -405,14 +405,14 @@ describe('App', () => {
     fireEvent.keyDown(titleInput, { key: 'Enter' })
 
     expect(mockPostMessage).toBeCalledWith({
-      payload: { name: newTitle, section: Section.LIVE_PLOTS },
+      payload: { name: newTitle, section: Section.CHECKPOINT_PLOTS },
       type: MessageFromWebviewType.SECTION_RENAMED
     })
   })
 
-  it('should display the live plots in the order stored', () => {
+  it('should display the checkpoint plots in the order stored', () => {
     renderAppWithData({
-      live: livePlotsFixture,
+      checkpoint: checkpointPlotsFixture,
       sectionCollapsed: DEFAULT_SECTION_COLLAPSED
     })
 
@@ -437,9 +437,9 @@ describe('App', () => {
     ])
   })
 
-  it('should remove the live plot from the order if it is removed from the plots', () => {
+  it('should remove the checkpoint plot from the order if it is removed from the plots', () => {
     renderAppWithData({
-      live: livePlotsFixture,
+      checkpoint: checkpointPlotsFixture,
       sectionCollapsed: DEFAULT_SECTION_COLLAPSED
     })
 
@@ -447,9 +447,9 @@ describe('App', () => {
     dragAndDrop(plots[1], plots[0])
 
     sendSetDataMessage({
-      live: {
-        ...livePlotsFixture,
-        plots: livePlotsFixture.plots.slice(1)
+      checkpoint: {
+        ...checkpointPlotsFixture,
+        plots: checkpointPlotsFixture.plots.slice(1)
       }
     })
     plots = screen.getAllByTestId(/summary\.json/)
@@ -462,7 +462,7 @@ describe('App', () => {
 
   it('should add the new plot at the end of the set order', () => {
     renderAppWithData({
-      live: livePlotsFixture,
+      checkpoint: checkpointPlotsFixture,
       sectionCollapsed: DEFAULT_SECTION_COLLAPSED
     })
 
@@ -470,14 +470,14 @@ describe('App', () => {
     dragAndDrop(plots[3], plots[0])
 
     sendSetDataMessage({
-      live: {
-        ...livePlotsFixture,
+      checkpoint: {
+        ...checkpointPlotsFixture,
         plots: [
           {
             title: 'summary.json:new-plot',
-            values: livePlotsFixture.plots[0].values
+            values: checkpointPlotsFixture.plots[0].values
           },
-          ...livePlotsFixture.plots
+          ...checkpointPlotsFixture.plots
         ]
       }
     })
@@ -493,17 +493,17 @@ describe('App', () => {
 
   it('should not be possible to drag a plot from a section to another', () => {
     renderAppWithData({
-      live: livePlotsFixture,
+      checkpoint: checkpointPlotsFixture,
       sectionCollapsed: DEFAULT_SECTION_COLLAPSED,
       template: templatePlotsFixture
     })
 
-    const livePlots = screen.getAllByTestId(/summary\.json/)
-    const staticPlots = screen.getAllByTestId(/^plot-/)
+    const checkpointPlots = screen.getAllByTestId(/summary\.json/)
+    const templatePlots = screen.getAllByTestId(/^plot-/)
 
-    dragAndDrop(staticPlots[0], livePlots[2])
+    dragAndDrop(templatePlots[0], checkpointPlots[2])
 
-    expect(livePlots.map(plot => plot.id)).toStrictEqual([
+    expect(checkpointPlots.map(plot => plot.id)).toStrictEqual([
       'summary.json:loss',
       'summary.json:accuracy',
       'summary.json:val_loss',

--- a/webview/src/plots/components/CheckpointPlots.tsx
+++ b/webview/src/plots/components/CheckpointPlots.tsx
@@ -1,4 +1,7 @@
-import { LivePlotData, LivePlotsColors } from 'dvc/src/plots/webview/contract'
+import {
+  CheckpointPlotData,
+  CheckpointPlotsColors
+} from 'dvc/src/plots/webview/contract'
 import React, { useEffect, useState } from 'react'
 import { EmptyState } from './EmptyState'
 import { Plot } from './Plot'
@@ -8,12 +11,15 @@ import { performOrderedUpdate } from '../../util/objects'
 import { withScale } from '../../util/styles'
 import { GripIcon } from '../../shared/components/dragDrop/GripIcon'
 
-interface LivePlotsProps {
-  plots: LivePlotData[]
-  colors: LivePlotsColors
+interface CheckpointPlotsProps {
+  plots: CheckpointPlotData[]
+  colors: CheckpointPlotsColors
 }
 
-export const LivePlots: React.FC<LivePlotsProps> = ({ plots, colors }) => {
+export const CheckpointPlots: React.FC<CheckpointPlotsProps> = ({
+  plots,
+  colors
+}) => {
   const [order, setOrder] = useState(plots.map(plot => plot.title))
 
   useEffect(() => {

--- a/webview/src/plots/components/Plot.tsx
+++ b/webview/src/plots/components/Plot.tsx
@@ -1,12 +1,15 @@
-import { LivePlotsColors, LivePlotValues } from 'dvc/src/plots/webview/contract'
+import {
+  CheckpointPlotsColors,
+  CheckpointPlotValues
+} from 'dvc/src/plots/webview/contract'
 import React from 'react'
 import { VegaLite } from 'react-vega'
 import { config, createSpec } from './constants'
 
 interface PlotProps {
-  values: LivePlotValues
+  values: CheckpointPlotValues
   title: string
-  scale?: LivePlotsColors
+  scale?: CheckpointPlotsColors
 }
 
 export const Plot: React.FC<PlotProps> = ({ values, title, scale }) => {

--- a/webview/src/plots/components/Plots.tsx
+++ b/webview/src/plots/components/Plots.tsx
@@ -1,17 +1,21 @@
 import React, { Dispatch, useState, useEffect } from 'react'
-import { LivePlotData, PlotSize, Section } from 'dvc/src/plots/webview/contract'
+import {
+  CheckpointPlotData,
+  PlotSize,
+  Section
+} from 'dvc/src/plots/webview/contract'
 import { MessageFromWebviewType } from 'dvc/src/webview/contract'
 import { EmptyState } from './EmptyState'
 import { PlotsContainer } from './PlotsContainer'
+import { CheckpointPlots } from './CheckpointPlots'
 import { ComparisonTable } from './ComparisonTable/ComparisonTable'
-import { LivePlots } from './LivePlots'
 import { TemplatePlots } from './TemplatePlots'
 import { PlotsReducerAction, PlotsWebviewState } from '../hooks/useAppReducer'
 import { getDisplayNameFromPath } from '../../util/paths'
 import { sendMessage } from '../../shared/vscode'
 import { Theme } from '../../shared/components/theme/Theme'
 
-const getMetricsFromPlots = (plots?: LivePlotData[]): string[] =>
+const getMetricsFromPlots = (plots?: CheckpointPlotData[]): string[] =>
   plots?.map(plot => getDisplayNameFromPath(plot.title)) || []
 
 export const Plots = ({
@@ -28,9 +32,9 @@ export const Plots = ({
   const [selectedPlots, setSelectedPlots] = useState<string[]>([])
 
   useEffect(() => {
-    const newMetrics = getMetricsFromPlots(data?.live?.plots)
+    const newMetrics = getMetricsFromPlots(data?.checkpoint?.plots)
     setMetrics(newMetrics)
-    setSelectedPlots(data?.live?.selectedMetrics || newMetrics)
+    setSelectedPlots(data?.checkpoint?.selectedMetrics || newMetrics)
   }, [data, setSelectedPlots, setMetrics])
 
   if (!data || !data.sectionCollapsed) {
@@ -38,13 +42,13 @@ export const Plots = ({
   }
 
   const {
+    checkpoint: checkpointPlots,
     sectionCollapsed,
-    live: livePlots,
     template: templatePlots,
     comparison: comparisonTable
   } = data
 
-  if (!livePlots && !templatePlots && !comparisonTable) {
+  if (!checkpointPlots && !templatePlots && !comparisonTable) {
     return EmptyState('No Plots to Display')
   }
 
@@ -102,23 +106,23 @@ export const Plots = ({
           />
         </PlotsContainer>
       )}
-      {livePlots && (
+      {checkpointPlots && (
         <PlotsContainer
-          title={livePlots.sectionName}
-          sectionKey={Section.LIVE_PLOTS}
+          title={checkpointPlots.sectionName}
+          sectionKey={Section.CHECKPOINT_PLOTS}
           menu={{
             metrics,
             selectedMetrics: selectedPlots,
             setSelectedPlots: setSelectedMetrics
           }}
-          currentSize={livePlots.size}
+          currentSize={checkpointPlots.size}
           {...basicContainerProps}
         >
-          <LivePlots
-            plots={livePlots.plots.filter(plot =>
+          <CheckpointPlots
+            plots={checkpointPlots.plots.filter(plot =>
               selectedPlots?.includes(getDisplayNameFromPath(plot.title))
             )}
-            colors={livePlots.colors}
+            colors={checkpointPlots.colors}
           />
         </PlotsContainer>
       )}

--- a/webview/src/plots/components/constants.ts
+++ b/webview/src/plots/components/constants.ts
@@ -1,10 +1,10 @@
-import { LivePlotsColors } from 'dvc/src/plots/webview/contract'
+import { CheckpointPlotsColors } from 'dvc/src/plots/webview/contract'
 import { Config, FontWeight } from 'vega'
 import { VisualizationSpec } from 'react-vega'
 
 export const createSpec = (
   title: string,
-  scale?: LivePlotsColors
+  scale?: CheckpointPlotsColors
 ): VisualizationSpec => {
   return {
     $schema: 'https://vega.github.io/schema/vega-lite/v5.json',

--- a/webview/src/stories/Plots.stories.tsx
+++ b/webview/src/stories/Plots.stories.tsx
@@ -4,7 +4,7 @@ import {
   PlotsData,
   DEFAULT_SECTION_COLLAPSED
 } from 'dvc/src/plots/webview/contract'
-import livePlotsFixture from 'dvc/src/test/fixtures/expShow/livePlots'
+import checkpointPlotsFixture from 'dvc/src/test/fixtures/expShow/checkpointPlots'
 import templatePlotsFixture from 'dvc/src/test/fixtures/plotsDiff/template'
 import comparisonPlotsFixture from 'dvc/src/test/fixtures/plotsDiff/comparison'
 import { Plots } from '../plots/components/Plots'
@@ -17,8 +17,8 @@ import '../plots/components/styles.module.scss'
 export default {
   args: {
     data: {
+      checkpoint: checkpointPlotsFixture,
       comparison: comparisonPlotsFixture,
-      live: livePlotsFixture,
       sectionCollapsed: DEFAULT_SECTION_COLLAPSED,
       template: templatePlotsFixture
     }
@@ -36,10 +36,10 @@ const Template: Story<{
 
 export const WithData = Template.bind({})
 
-export const WithLiveOnly = Template.bind({})
-WithLiveOnly.args = {
+export const WithCheckpointOnly = Template.bind({})
+WithCheckpointOnly.args = {
   data: {
-    live: livePlotsFixture,
+    checkpoint: checkpointPlotsFixture,
     sectionCollapsed: DEFAULT_SECTION_COLLAPSED
   }
 }


### PR DESCRIPTION
# 3/3 `main` <- #1397 <- #1398 <- this

This PR renames all instances of `Live` to `Checkpoint`. Makes sense to finish this job off now IMO. 

Let me know if you have any better suggestions for naming/names.
