### PR TITLE
Remove reduce from experiment model tree

### DIFF
--- a/extension/src/experiments/model/tree.ts
+++ b/extension/src/experiments/model/tree.ts
@@ -250,11 +250,12 @@ export class ExperimentsTree
       return
     }
 
-    const selected = dvcRoots.reduce(
-      (acc, dvcRoot) =>
-        acc +
-        this.experiments.getRepository(dvcRoot).getSelectedRevisions().length,
-      0
+    let selected = 0
+    dvcRoots.forEach(
+      dvcRoot =>
+        (selected += this.experiments
+          .getRepository(dvcRoot)
+          .getSelectedRevisions().length)
     )
 
     return `${selected} of ${dvcRoots.length * MAX_SELECTED_EXPERIMENTS}`


### PR DESCRIPTION
This PR removes the use of `.reduce` from `extension/src/experiments/model/tree.ts`.