### PR TITLE
Add queue experiment to experiment tree item context menu

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -348,6 +348,15 @@
         "category": "DVC"
       },
       {
+        "title": "%command.views.experimentsTree.queueExperiment%",
+        "command": "dvc.views.experimentsTree.queueExperiment",
+        "category": "DVC",
+        "icon": {
+          "dark": "resources/dark/queue-experiment.svg",
+          "light": "resources/light/queue-experiment.svg"
+        }
+      },
+      {
         "title": "%command.views.experimentsTree.removeExperiment%",
         "command": "dvc.views.experimentsTree.removeExperiment",
         "category": "DVC",
@@ -588,6 +597,10 @@
         },
         {
           "command": "dvc.views.experimentsTree.branchExperiment",
+          "when": "false"
+        },
+        {
+          "command": "dvc.views.experimentsTree.queueExperiment",
           "when": "false"
         },
         {
@@ -847,6 +860,11 @@
           "command": "dvc.views.experimentsTree.branchExperiment",
           "group": "1_do@2",
           "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(checkpoint|experiment)$/"
+        },
+        {
+          "command": "dvc.views.experimentsTree.queueExperiment",
+          "group": "1_do@3",
+          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(experiment|queued)$/"
         },
         {
           "command": "dvc.views.experimentsTree.removeExperiment",

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -55,6 +55,7 @@
   "command.views.experimentsTree.disableAutoApplyFilters": "Disable Auto Apply Filters To Experiment Selection",
   "command.views.experimentsTree.applyExperiment": "Apply to Workspace",
   "command.views.experimentsTree.branchExperiment": "Create new Branch",
+  "command.views.experimentsTree.queueExperiment": "Vary Param(s) and Queue",
   "command.views.experimentsTree.removeExperiment": "Remove",
   "command.views.experimentsTree.selectExperiments": "Select Experiments",
   "config.doNotRecommendRedHatExtension.description": "Do not prompt to install the Red Hat YAML extension to assist with DVC YAML schema validation.",

--- a/extension/src/commands/external.ts
+++ b/extension/src/commands/external.ts
@@ -34,6 +34,7 @@ export enum RegisteredCommands {
   EXPERIMENT_METRICS_AND_PARAMS_TOGGLE = 'dvc.views.experimentsMetricsAndParamsTree.toggleStatus',
   EXPERIMENT_TREE_APPLY = 'dvc.views.experimentsTree.applyExperiment',
   EXPERIMENT_TREE_BRANCH = 'dvc.views.experimentsTree.branchExperiment',
+  EXPERIMENT_TREE_QUEUE = 'dvc.views.experimentsTree.queueExperiment',
   EXPERIMENT_TREE_REMOVE = 'dvc.views.experimentsTree.removeExperiment',
   EXPERIMENT_SELECT = 'dvc.views.experimentsTree.selectExperiments',
   EXPERIMENT_SHOW = 'dvc.showExperiments',

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -255,17 +255,13 @@ export class Experiments extends BaseRepository<TableData> {
     return pickExperiment(this.experiments.getQueuedExperiments())
   }
 
-  public async pickParamsToQueue() {
-    const base = await pickExperiment(
-      this.experiments.getExperiments(),
-      Title.SELECT_BASE_EXPERIMENT
-    )
-
-    if (!base) {
+  public async pickParamsToQueue(overrideId?: string) {
+    const id = await this.getExperimentId(overrideId)
+    if (!id) {
       return
     }
 
-    const params = this.experiments.getExperimentParams(base.id)
+    const params = this.experiments.getExperimentParams(id)
 
     if (!params) {
       return
@@ -385,5 +381,18 @@ export class Experiments extends BaseRepository<TableData> {
     if (response === Response.SELECT_MOST_RECENT) {
       this.experiments.setSelected(filteredExperiments)
     }
+  }
+
+  private async getExperimentId(overrideId?: string) {
+    if (overrideId) {
+      return overrideId
+    }
+
+    const experiment = await pickExperiment(
+      this.experiments.getExperiments(),
+      Title.SELECT_BASE_EXPERIMENT
+    )
+
+    return experiment?.id
   }
 }

--- a/extension/src/experiments/model/tree.ts
+++ b/extension/src/experiments/model/tree.ts
@@ -144,6 +144,12 @@ export class ExperimentsTree
     )
 
     internalCommands.registerExternalCommand<ExperimentItem>(
+      RegisteredCommands.EXPERIMENT_TREE_QUEUE,
+      ({ dvcRoot, id }: ExperimentItem) =>
+        this.experiments.queueExperimentFromExisting(dvcRoot, id)
+    )
+
+    internalCommands.registerExternalCommand<ExperimentItem>(
       RegisteredCommands.EXPERIMENT_TREE_REMOVE,
       ({ dvcRoot, id }: ExperimentItem) =>
         this.experiments.runCommand(

--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -102,8 +102,11 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
     return this.getRepository(dvcRoot).autoApplyFilters(enable)
   }
 
-  public async queueExperimentFromExisting() {
-    const cwd = await this.getFocusedOrOnlyOrPickProject()
+  public async queueExperimentFromExisting(
+    overrideRoot?: string,
+    overrideId?: string
+  ) {
+    const cwd = await this.getDvcRoot(overrideRoot)
     if (!cwd) {
       return
     }
@@ -113,7 +116,7 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
       return
     }
 
-    const paramsToQueue = await repository.pickParamsToQueue()
+    const paramsToQueue = await repository.pickParamsToQueue(overrideId)
     if (!paramsToQueue) {
       return
     }

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -94,6 +94,7 @@ export interface IEventNamePropertyMapping {
   [EventName.EXPERIMENT_SORTS_REMOVE_ALL]: undefined
   [EventName.EXPERIMENT_TREE_APPLY]: undefined
   [EventName.EXPERIMENT_TREE_BRANCH]: undefined
+  [EventName.EXPERIMENT_TREE_QUEUE]: undefined
   [EventName.EXPERIMENT_TREE_REMOVE]: undefined
   [EventName.EXPERIMENT_TOGGLE]: undefined
   [EventName.QUEUE_EXPERIMENT]: undefined

--- a/extension/src/test/suite/experiments/util.ts
+++ b/extension/src/test/suite/experiments/util.ts
@@ -69,6 +69,8 @@ export const buildExperiments = (
   return {
     cliReader,
     experiments,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    experimentsModel: (experiments as any).experiments,
     internalCommands,
     messageSpy,
     mockExperimentShow,

--- a/extension/src/test/suite/experiments/workspace.test.ts
+++ b/extension/src/test/suite/experiments/workspace.test.ts
@@ -112,11 +112,15 @@ suite('Workspace Experiments Test Suite', () => {
 
       const mockShowQuickPick = stub(window, 'showQuickPick') as SinonStub<
         [items: readonly QuickPickItem[], options: QuickPickOptionsWithTitle],
-        Thenable<QuickPickItem[] | QuickPickItemWithValue<string> | undefined>
+        Thenable<
+          QuickPickItem[] | QuickPickItemWithValue<{ id: string }> | undefined
+        >
       >
       mockShowQuickPick
         .onFirstCall()
-        .resolves({ value: 'workspace' } as QuickPickItemWithValue)
+        .resolves({ value: { id: 'workspace' } } as QuickPickItemWithValue<{
+          id: string
+        }>)
         .onSecondCall()
         .resolves([
           {


### PR DESCRIPTION
# 4/4 `main` <- #1458 <- #1459 <- #1460 <- this

This PR adds a new command (`dvc.views.experimentsTree.queueExperiment`) which lets users vary params and queue using both experiments and queued experiments as a base from a right-click context menu in the experiments tree.

### Demo

https://user-images.githubusercontent.com/37993418/158933882-9ec8bca7-2b52-402c-9ff5-509c28485382.mov


