### PR TITLE
Re-enable Tooltip flipping

### DIFF
--- a/webview/src/shared/components/iconMenu/IconMenu.tsx
+++ b/webview/src/shared/components/iconMenu/IconMenu.tsx
@@ -8,6 +8,17 @@ interface IconMenuProps {
   items: IconMenuItemProps[]
 }
 
+const popperOptions = {
+  modifiers: [
+    {
+      name: 'computeStyles',
+      options: {
+        adaptive: false
+      }
+    }
+  ]
+}
+
 export const IconMenu: React.FC<IconMenuProps> = ({ items }) => {
   const [tooltipDisabled, setTooltipDisabled] = useState<boolean>(false)
   const [menuSource, menuTarget] = useSingleton()
@@ -19,6 +30,7 @@ export const IconMenu: React.FC<IconMenuProps> = ({ items }) => {
     <Tooltip
       singleton={tooltipSource}
       placement="bottom-end"
+      popperOptions={popperOptions}
       disabled={tooltipDisabled}
     >
       <Tooltip
@@ -26,6 +38,7 @@ export const IconMenu: React.FC<IconMenuProps> = ({ items }) => {
         interactive
         singleton={menuSource}
         placement="bottom"
+        popperOptions={popperOptions}
         onShow={() => {
           setTooltipDisabled(true)
         }}

--- a/webview/src/shared/components/tooltip/Tooltip.tsx
+++ b/webview/src/shared/components/tooltip/Tooltip.tsx
@@ -6,21 +6,6 @@ import 'tippy.js/dist/tippy.css'
 export const HEADER_TOOLTIP_DELAY = 100
 export const CELL_TOOLTIP_DELAY = 1000
 
-const defaultModifiers = {
-  modifiers: [
-    {
-      enabled: false,
-      name: 'flip'
-    },
-    {
-      name: 'computeStyles',
-      options: {
-        adaptive: false
-      }
-    }
-  ]
-}
-
 const TooltipRenderFunction: React.ForwardRefRenderFunction<
   unknown,
   TippyProps
@@ -36,10 +21,10 @@ const TooltipRenderFunction: React.ForwardRefRenderFunction<
     onShow,
     onHide,
     placement,
+    popperOptions,
     animation = false,
     className = styles.menu,
-    arrow = false,
-    popperOptions = defaultModifiers
+    arrow = false
   },
   ref
 ) => (


### PR DESCRIPTION
Fixes #1492 

Super simple PR, re-enables the Tippy positioning defaults that make tooltips "flip" their position when they would otherwise go offscreen.

https://user-images.githubusercontent.com/9111807/160922018-cc361715-3807-4cd3-9d0b-c8e273ecf7d5.mp4

The initial reason I had this disabled was me suspecting it as the cause of a positioning bug with the singleton tooltips in the IconMenu component, and then I kept it because the horizontal repositioning without it looked better to me than flipping in the Storybook; that case which looked better without flipping doesn't really occur in the extension, so not only does disabling flipping cause vertical issues but the horizontal flipping I originally disabled it for isn't even a real issue.