### PR TITLE
Only send size update events when the size is changed

### DIFF
--- a/webview/src/plots/components/App.test.tsx
+++ b/webview/src/plots/components/App.test.tsx
@@ -376,6 +376,34 @@ describe('App', () => {
     })
   })
 
+  it('should not send a message to the extension with the selected size when the size has not changed', () => {
+    renderAppWithData({
+      checkpoint: checkpointPlotsFixture,
+      sectionCollapsed: DEFAULT_SECTION_COLLAPSED
+    })
+
+    const sizeButton = screen.getAllByTestId('icon-menu-item')[2]
+    fireEvent.mouseEnter(sizeButton)
+    fireEvent.click(sizeButton)
+
+    const largeButton = screen.getByText('Large')
+    fireEvent.click(largeButton)
+
+    expect(mockPostMessage).toBeCalledWith({
+      payload: { section: Section.CHECKPOINT_PLOTS, size: PlotSize.LARGE },
+      type: MessageFromWebviewType.PLOTS_RESIZED
+    })
+
+    mockPostMessage.mockClear()
+
+    sendSetDataMessage({
+      checkpoint: checkpointPlotsFixture,
+      sectionCollapsed: DEFAULT_SECTION_COLLAPSED
+    })
+
+    expect(mockPostMessage).not.toBeCalled()
+  })
+
   it('should show an input to rename the section when clicking the rename icon button', () => {
     renderAppWithData({
       checkpoint: checkpointPlotsFixture,

--- a/webview/src/plots/components/PlotsContainer.tsx
+++ b/webview/src/plots/components/PlotsContainer.tsx
@@ -66,9 +66,12 @@ export const PlotsContainer: React.FC<PlotsContainerProps> = ({
     }
   ]
 
-  const changeSize = (size: PlotSize) => {
-    onResize(size, sectionKey)
-    setSize(size)
+  const changeSize = (newSize: PlotSize) => {
+    if (size === newSize) {
+      return
+    }
+    onResize(newSize, sectionKey)
+    setSize(newSize)
   }
 
   if (menu) {


### PR DESCRIPTION
Luckily I built the extension and tested the capturing of the new webview analytics events before shipping today.

There was a bug in the `PlotsContainer` that led to many (many) size update events being sent whenever new data was sent to the webview. Given the way that the message passing now works this led to some weird analytics numbers

<img width="1372" alt="image" src="https://user-images.githubusercontent.com/37993418/161159013-72d8f35f-dded-4fb6-91be-e673db5e91ea.png">

For reference that number of events were generated in < 1 minute.

## Cannot ship 0.2.5 without this