### PR TITLE
Handle empty string being returned in --show-json output

### DIFF
--- a/extension/src/cli/reader.test.ts
+++ b/extension/src/cli/reader.test.ts
@@ -204,6 +204,14 @@ describe('CliReader', () => {
   })
 
   describe('plotsDiff', () => {
+    it('should handle empty output being returned', async () => {
+      const cwd = __dirname
+      mockedCreateProcess.mockReturnValueOnce(getMockedProcess(''))
+
+      const plots = await cliReader.plotsDiff(cwd, 'HEAD')
+      expect(plots).toStrictEqual({})
+    })
+
     it('should match the expected output', async () => {
       const cwd = __dirname
 

--- a/extension/src/cli/reader.ts
+++ b/extension/src/cli/reader.ts
@@ -152,18 +152,18 @@ export class CliReader extends Cli {
   }
 
   public version(cwd: string): Promise<string> {
-    return this.readProcess(cwd, trim, Flag.VERSION)
+    return this.readProcess(cwd, trim, '', Flag.VERSION)
   }
 
   private async readProcess<T = string>(
     cwd: string,
     formatter: typeof trimAndSplit | typeof JSON.parse | typeof trim,
+    defaultValue: string,
     ...args: Args
   ): Promise<T> {
-    const output = await retry(
-      () => this.executeProcess(cwd, ...args),
-      args.join(' ')
-    )
+    const output =
+      (await retry(() => this.executeProcess(cwd, ...args), args.join(' '))) ||
+      defaultValue
     if (!formatter) {
       return output as unknown as T
     }
@@ -174,6 +174,7 @@ export class CliReader extends Cli {
     return this.readProcess<T>(
       cwd,
       JSON.parse,
+      '{}',
       command,
       ...args,
       Flag.SHOW_JSON


### PR DESCRIPTION
Discovered whilst testing against a `dvcgen` project. When there are no plots in the DVC repository `plots diff --show-json` returns an empty string. Generally `'{}'` is returned when a `--show-json` command has no output but we cannot rely on this.