### PR TITLE
requirement: Remove explicit dvclive

### DIFF
--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,5 +1,4 @@
 dvc[s3]>=2.10.0
-dvclive
 torch
 torchvision
 ruamel.yaml


### PR DESCRIPTION
Remove `dvclive` as it is now included and pinned as part of DVC:

https://github.com/iterative/dvc/blob/03f553c54bf0e6b91626a87309d817edce61282a/setup.cfg#L151

This ensures a version compatible with DVC.