### PR TITLE
Kill scheduled CLI output tests on fail

### DIFF
--- a/extension/src/test/cli/index.ts
+++ b/extension/src/test/cli/index.ts
@@ -46,6 +46,7 @@ runMocha(
   },
   () => {
     removeDir(TEMP_DIR)
+    process.exit()
   },
   6000
 )


### PR DESCRIPTION
We had some long-running actions over the weekend as the CLI retry kept the process alive:

https://github.com/iterative/vscode-dvc/actions/workflows/dvc-cli-output-test.yml

I've asked in the `dvc-eng` slack channel about this error message:

```
plots diff -o .dvc/tmp/plots --split --show-json failed with Command failed with exit code 1: /home/runner/work/vscode-dvc/vscode-dvc/extension/src/test/cli/temp/.env/bin/dvc plots diff -o .dvc/tmp/plots --split --show-json
Traceback (most recent call last):
  File "/home/runner/work/vscode-dvc/vscode-dvc/extension/src/test/cli/temp/.env/lib/python3.8/site-packages/dvc/cli/__init__.py", line 89, in main
  File "/home/runner/work/vscode-dvc/vscode-dvc/extension/src/test/cli/temp/.env/lib/python3.8/site-packages/dvc/cli/command.py", line 22, in do_run
  File "/home/runner/work/vscode-dvc/vscode-dvc/extension/src/test/cli/temp/.env/lib/python3.8/site-packages/dvc/commands/plots.py", line 83, in run
  File "/home/runner/work/vscode-dvc/vscode-dvc/extension/src/test/cli/temp/.env/lib/python3.8/site-packages/dvc/commands/plots.py", line 24, in _show_json
  File "/home/runner/work/vscode-dvc/vscode-dvc/extension/src/test/cli/temp/.env/lib/python3.8/site-packages/dvc/ui/__init__.py", line 105, in write_json
  File "/home/runner/work/vscode-dvc/vscode-dvc/extension/src/test/cli/temp/.env/lib/python3.8/site-packages/funcy/objects.py", line 28, in __get__
  File "/home/runner/work/vscode-dvc/vscode-dvc/extension/src/test/cli/temp/.env/lib/python3.8/site-packages/dvc/ui/__init__.py", line 211, in rich_console
ModuleNotFoundError: No module named 'rich'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/runner/work/vscode-dvc/vscode-dvc/extension/src/test/cli/temp/.env/bin/dvc", line 8, in <module>
  File "/home/runner/work/vscode-dvc/vscode-dvc/extension/src/test/cli/temp/.env/lib/python3.8/site-packages/dvc/cli/__init__.py", line 118, in main
ModuleNotFoundError: No module named 'dvc.info'
``` 