### PR TITLE
Fix deeply nested fixture on storybook

### DIFF
--- a/extension/src/test/fixtures/expShow/deeplyNested.ts
+++ b/extension/src/test/fixtures/expShow/deeplyNested.ts
@@ -34,6 +34,38 @@ export const deeplyNestedOutput: ExperimentsOutput = {
         executor: null
       }
     }
+  },
+  '53c3851f46955fa3e2b8f6e1c52999acc8c9ea77': {
+    baseline: {
+      data: {
+        timestamp: '2020-11-21T19:58:22',
+        params: {
+          'params.yaml': {
+            data: {
+              nested1: {
+                doubled: 'first instance!',
+                nested2: {
+                  nested3: {
+                    nested4: {
+                      nested5: { nested6: { nested7: 'Lucky!' } },
+                      nested5b: {
+                        nested6: 'Wow!!!!!!!!!!!!!!!!!!!!',
+                        doubled: 'second instance!'
+                      }
+                    }
+                  }
+                }
+              },
+              outlier: 1
+            }
+          }
+        },
+        queued: false,
+        running: false,
+        executor: null,
+        name: 'main'
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This PR adds a dummy row to our deeply nested fixture so that it isn't recognized as an empty state by the changes from #1529

We can probably craft a better one that exhibits more edge cases, but this opts to start off with as simple an addition as possible.

Fixes #1553 