### PR TITLE
Add "Modify Experiment Params" to workspace/branches in tree

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -879,7 +879,7 @@
         {
           "command": "dvc.views.experimentsTree.queueExperiment",
           "group": "1_do@3",
-          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(experiment|queued)$/ && !dvc.runner.running"
+          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(workspace|branch|experiment|queued)$/ && !dvc.runner.running"
         },
         {
           "command": "dvc.views.experimentsTree.removeExperiment",


### PR DESCRIPTION
Originally from https://github.com/iterative/vscode-dvc/pull/1590#issuecomment-1103441607

> Other notes:
> 
> The Command Palette version of modify and queue can target branches and workspace, while context menus disable it

To fix update the package.json entry to:

```
        {
          "command": "dvc.views.experimentsTree.queueExperiment",
          "group": "1_do@3",
          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(workspace|branch|experiment|queued)$/ && !dvc.runner.running"        },
```

![image](https://user-images.githubusercontent.com/9111807/164303253-d2bf0237-80c3-4f41-a58d-774301836893.png)

https://user-images.githubusercontent.com/9111807/164303565-ec223e63-e5f4-4723-a5c9-1be6d7d9afe0.mp4