### PR TITLE
Move experiment tree commands inline

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -347,12 +347,14 @@
       {
         "title": "%command.views.experimentsTree.applyExperiment%",
         "command": "dvc.views.experimentsTree.applyExperiment",
-        "category": "DVC"
+        "category": "DVC",
+        "icon": "$(merge)"
       },
       {
         "title": "%command.views.experimentsTree.branchExperiment%",
         "command": "dvc.views.experimentsTree.branchExperiment",
-        "category": "DVC"
+        "category": "DVC",
+        "icon": "$(source-control)"
       },
       {
         "title": "%command.views.experimentsTree.queueExperiment%",
@@ -367,7 +369,7 @@
         "title": "%command.views.experimentsTree.removeExperiment%",
         "command": "dvc.views.experimentsTree.removeExperiment",
         "category": "DVC",
-        "icon": "$(close)"
+        "icon": "$(trash)"
       },
       {
         "title": "%command.views.experimentsTree.selectExperiments%",
@@ -876,23 +878,23 @@
         },
         {
           "command": "dvc.views.experimentsTree.applyExperiment",
-          "group": "1_do@1",
+          "group": "inline@1",
           "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(checkpoint|experiment)$/ && !dvc.runner.running"
         },
         {
           "command": "dvc.views.experimentsTree.branchExperiment",
-          "group": "1_do@2",
+          "group": "inline@2",
           "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(checkpoint|experiment)$/ && !dvc.runner.running"
+        },
+        {
+          "command": "dvc.views.experimentsTree.removeExperiment",
+          "group": "inline@3",
+          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(experiment|queued)$/ && !dvc.runner.running"
         },
         {
           "command": "dvc.views.experimentsTree.queueExperiment",
           "group": "1_do@3",
           "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(workspace|branch|experiment|queued)$/ && !dvc.runner.running"
-        },
-        {
-          "command": "dvc.views.experimentsTree.removeExperiment",
-          "group": "7_modification@1",
-          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(experiment|queued)$/ && !dvc.runner.running"
         },
         {
           "command": "dvc.views.experimentsTree.selectExperiments",


### PR DESCRIPTION
# 3/4 `main` <- #1655 <- #1656 <- this <-#1659

Closes https://github.com/iterative/vscode-dvc/issues/1632.

This PR moves three of the commands from the experiments tree context menu inline. This should remove the expectation that highlighted rows can be deleted in bulk.

For the time being, I have gone with `Apply to Workspace`, `Create new Branch` & `Remove` but I will (very likely) replace `Apply to Workspace` with `Modify Experiment Param(s) and Run` and move `Apply to Workspace` back into the context menu when #1628 has been built.

### Demo

https://user-images.githubusercontent.com/37993418/166856023-21cd7c20-0698-4516-9656-02b860b6514a.mov

https://user-images.githubusercontent.com/37993418/166856578-d96bc927-559f-4c84-ad5c-fb5501ba1ce8.mov


