### PR TITLE
Link experiments tree to webviews in UI

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -946,13 +946,33 @@
       "view/title": [
         {
           "command": "dvc.showExperiments",
-          "when": "view =~ /^(dvc.views.experimentsColumnsTree|dvc.views.experimentsTree)$/",
+          "when": "view == dvc.views.experimentsColumnsTree",
+          "group": "navigation@1"
+        },
+        {
+          "command": "dvc.showExperiments",
+          "when": "view == dvc.views.experimentsTree && !dvc.experiments.webviewActive",
           "group": "navigation@1"
         },
         {
           "command": "dvc.runExperiment",
-          "when": "view == dvc.views.experimentsTree && !dvc.runner.running",
+          "when": "view == dvc.views.experimentsTree && !dvc.experiments.webviewActive",
           "group": "1_run@1"
+        },
+        {
+          "command": "dvc.runExperiment",
+          "when": "view == dvc.views.experimentsTree && dvc.experiments.webviewActive",
+          "group": "navigation@1"
+        },
+        {
+          "command": "dvc.showPlots",
+          "when": "view == dvc.views.experimentsTree && !dvc.plots.webviewActive",
+          "group": "navigation@2"
+        },
+        {
+          "command": "dvc.views.experimentsTree.selectExperiments",
+          "when": "view == dvc.views.experimentsTree && dvc.plots.webviewActive",
+          "group": "navigation@2"
         },
         {
           "command": "dvc.runQueuedExperiments",
@@ -968,11 +988,6 @@
           "command": "dvc.modifyExperimentParamsAndQueue",
           "when": "view == dvc.views.experimentsTree && !dvc.runner.running",
           "group": "2_queue@2"
-        },
-        {
-          "command": "dvc.views.experimentsTree.selectExperiments",
-          "when": "view == dvc.views.experimentsTree",
-          "group": "navigation@3"
         },
         {
           "command": "dvc.views.experimentsTree.autoApplyFilters",
@@ -1006,8 +1021,8 @@
         },
         {
           "command": "dvc.showPlots",
-          "when": "view =~ /^(dvc.views.experimentsTree|dvc.views.plotsPathsTree)$/",
-          "group": "navigation@2"
+          "when": "view == dvc.views.plotsPathsTree",
+          "group": "navigation@1"
         }
       ]
     },

--- a/extension/src/vscode/title.ts
+++ b/extension/src/vscode/title.ts
@@ -6,7 +6,7 @@ export enum Title {
   GARBAGE_COLLECT_EXPERIMENTS = 'Garbage Collect Experiments',
   SELECT_BASE_EXPERIMENT = 'Select an Experiment to Use as a Base',
   SELECT_EXPERIMENT = 'Select an Experiment',
-  SELECT_EXPERIMENTS = 'Select up to 7 Experiments',
+  SELECT_EXPERIMENTS = 'Select up to 7 Experiments to Display in Plots',
   SELECT_FILTERS_TO_REMOVE = 'Select Filter(s) to Remove',
   SELECT_OPERATOR = 'Select an Operator',
   SELECT_PARAM_OR_METRIC_FILTER = 'Select a Param or Metric to Filter by',


### PR DESCRIPTION
# 4/4 `main` <- #1655 <- #1656 <- #1658 <- this

This is me trying to solve the problem of linking the toggle action in the experiments tree to the plots webview. I have 

1. ~changed the title of the tree to "EXPERIMENTS / REVISIONS"~ -> seems like this is out
2. Added show plots as a title/menu navigation action
3. Added show experiments as title/menu navigation action
4. Moved the old title/menu commands into the context menu

### Demo

https://user-images.githubusercontent.com/37993418/166858456-98c69e6e-561a-4aac-8c7c-f818170b32cc.mov

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/37993418/166858812-f68922d2-61ae-4d4d-92c5-56e0551d99b8.png">

What does everyone think? Does this help? cc @maxagin @yalozhkin 

Pros:

- Drives the user towards the webviews
- Shows the user that the tree is connected to both webviews

Cons:

- Name is long
- Have to open context menu to perform the old actions