### PR TITLE
Remove auto increment version from publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ github.ref }}
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v2


### PR DESCRIPTION
# 1/2 `main` <- this <- #1684 

This PR adds the version bump added in #1679. After talking to @shcheklein I am going to add a separate action to create a release PR instead of auto-committing to `main`.