### PR TITLE
Remove meta cell color class

### DIFF
--- a/webview/src/experiments/components/table/Cell.tsx
+++ b/webview/src/experiments/components/table/Cell.tsx
@@ -68,7 +68,6 @@ export const CellWrapper: React.FC<
   <div
     {...cell.getCellProps({
       className: cx(styles.td, cell.isPlaceholder && styles.groupPlaceholder, {
-        [styles.metaCell]: !cell.column.group,
         [styles.workspaceChange]: changes?.includes(cell.column.id)
       })
     })}

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -379,11 +379,6 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
   .sortingHeaderCellDesc {
     border-bottom: 2px solid $fg-color;
   }
-
-  .metaCell {
-    color: $meta-cell-color;
-    font-size: 0.75rem;
-  }
 }
 
 .webviewHeader {


### PR DESCRIPTION
# #1697 <- this

old:
![image](https://user-images.githubusercontent.com/9111807/167984787-ae4a3298-0198-43eb-b2cb-0590a0578531.png)

new:
![image](https://user-images.githubusercontent.com/9111807/167984704-f143e8ab-bfb8-4fe6-b733-151ccd00ce94.png)

This tiny PR simplifies our colors a little by removing the `metaCell` color and class, which effectively just made our timestamp cells slightly smaller and have less contrast. Experiment cells carry the `metaCell` class but are unaffected because they set their own size and color.