### PR TITLE
Rearrange internals of base workspace webviews

### DIFF
--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -21,8 +21,6 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
 
   public readonly updatesPaused: EventEmitter<boolean>
 
-  private focusedWebviewDvcRoot: string | undefined
-
   constructor(
     internalCommands: InternalCommands,
     updatesPaused: EventEmitter<boolean>,
@@ -38,13 +36,6 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
     for (const [dvcRoot, repository] of Object.entries(this.repositories)) {
       workspacePlots.getRepository(dvcRoot).setExperiments(repository)
     }
-  }
-
-  public getFocusedWebview(): Experiments | undefined {
-    if (!this.focusedWebviewDvcRoot) {
-      return undefined
-    }
-    return this.getRepository(this.focusedWebviewDvcRoot)
   }
 
   public async addFilter(overrideRoot?: string) {
@@ -253,14 +244,6 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
       return
     }
     return this.runCommand(commandId, cwd, experiment.name)
-  }
-
-  private async getDvcRoot(overrideRoot?: string) {
-    return overrideRoot || (await this.getFocusedOrOnlyOrPickProject())
-  }
-
-  private getFocusedOrOnlyOrPickProject() {
-    return this.focusedWebviewDvcRoot || this.getOnlyOrPickProject()
   }
 
   private pickCurrentExperiment(cwd: string) {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -221,7 +221,7 @@ export class Extension extends Disposable implements IExtension {
     )
 
     registerExperimentCommands(this.experiments, this.internalCommands)
-    registerPlotsCommands(this.plots)
+    registerPlotsCommands(this.plots, this.internalCommands)
 
     this.dispose.track(
       commands.registerCommand(RegisteredCommands.STOP_EXPERIMENT, async () => {

--- a/extension/src/plots/commands/register.ts
+++ b/extension/src/plots/commands/register.ts
@@ -1,9 +1,15 @@
-import { commands } from 'vscode'
 import { RegisteredCommands } from '../../commands/external'
+import { InternalCommands } from '../../commands/internal'
 import { WorkspacePlots } from '../workspace'
 
-export const registerPlotsCommands = (plots: WorkspacePlots) => {
-  commands.registerCommand(RegisteredCommands.PLOTS_SHOW, () => {
-    plots.showWebview()
-  })
+export const registerPlotsCommands = (
+  plots: WorkspacePlots,
+  internalCommands: InternalCommands
+) => {
+  internalCommands.registerExternalCommand(
+    RegisteredCommands.PLOTS_SHOW,
+    () => {
+      plots.showWebview()
+    }
+  )
 }

--- a/extension/src/plots/workspace.ts
+++ b/extension/src/plots/workspace.ts
@@ -30,6 +30,12 @@ export class WorkspacePlots extends BaseWorkspaceWebviews<Plots, PlotsData> {
       })
     )
 
+    plots.dispose.track(
+      plots.onDidChangeIsWebviewFocused(
+        dvcRoot => (this.focusedWebviewDvcRoot = dvcRoot)
+      )
+    )
+
     return plots
   }
 }

--- a/extension/src/test/suite/plots/util.ts
+++ b/extension/src/test/suite/plots/util.ts
@@ -17,6 +17,7 @@ import { mockHasCheckpoints } from '../experiments/util'
 import { MOCK_IMAGE_MTIME } from '../../fixtures/plotsDiff'
 import { PathsModel } from '../../../plots/paths/model'
 import { Color } from '../../../experiments/model/status/colors'
+import { BaseWorkspaceWebviews } from '../../../webview/workspace'
 
 export const buildPlots = async (
   disposer: Disposer,
@@ -67,7 +68,7 @@ export const buildPlots = async (
 
   await plots.isReady()
 
-  stub(WorkspaceExperiments.prototype, 'getDvcRoots').returns([dvcDemoPath])
+  stub(BaseWorkspaceWebviews.prototype, 'getDvcRoots').returns([dvcDemoPath])
   stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
   stub(WorkspacePlots.prototype, 'getRepository').returns(plots)
 

--- a/extension/src/webview/workspace.ts
+++ b/extension/src/webview/workspace.ts
@@ -11,6 +11,8 @@ export abstract class BaseWorkspaceWebviews<
 > extends BaseWorkspace<T, ResourceLocator> {
   protected readonly workspaceState: Memento
 
+  protected focusedWebviewDvcRoot: string | undefined
+
   constructor(
     internalCommands: InternalCommands,
     workspaceState: Memento,
@@ -34,5 +36,20 @@ export abstract class BaseWorkspaceWebviews<
     const repository = this.getRepository(dvcRoot)
     await repository.showWebview()
     return repository
+  }
+
+  public getFocusedWebview(): T | undefined {
+    if (!this.focusedWebviewDvcRoot) {
+      return undefined
+    }
+    return this.getRepository(this.focusedWebviewDvcRoot)
+  }
+
+  protected async getDvcRoot(overrideRoot?: string) {
+    return overrideRoot || (await this.getFocusedOrOnlyOrPickProject())
+  }
+
+  protected getFocusedOrOnlyOrPickProject() {
+    return this.focusedWebviewDvcRoot || this.getOnlyOrPickProject()
   }
 }


### PR DESCRIPTION
# 1/2 `main` <- this <- #1701 

Noticed this misalignment whilst working on #1701. Pulled it out to make it easier to review.