### PR TITLE
Fix timing of comparison table renders

### DIFF
--- a/webview/src/plots/components/comparisonTable/ComparisonTable.tsx
+++ b/webview/src/plots/components/comparisonTable/ComparisonTable.tsx
@@ -1,4 +1,5 @@
 import {
+  ComparisonPlots,
   ComparisonRevision,
   PlotsComparisonData
 } from 'dvc/src/plots/webview/contract'
@@ -26,6 +27,7 @@ export const ComparisonTable: React.FC<ComparisonTableProps> = ({
 }) => {
   const pinnedColumn = useRef(currentPinnedColumn || '')
   const [columns, setColumns] = useState<ComparisonTableColumn[]>([])
+  const [comparisonPlots, setComparisonPlots] = useState<ComparisonPlots>([])
 
   const isPinned = (column: ComparisonTableColumn): boolean =>
     column.revision === pinnedColumn.current
@@ -53,6 +55,8 @@ export const ComparisonTable: React.FC<ComparisonTableProps> = ({
       }),
     [revisions, getPinnedColumnRevision]
   )
+
+  useEffect(() => setComparisonPlots(plots), [plots])
 
   const setColumnsOrder = (order: string[]) => {
     const newOrder = reorderObjectList<ComparisonRevision>(
@@ -91,7 +95,7 @@ export const ComparisonTable: React.FC<ComparisonTableProps> = ({
         setColumnsOrder={setColumnsOrder}
         setPinnedColumn={changePinnedColumn}
       />
-      {plots.map(({ path, revisions: revs }) => (
+      {comparisonPlots.map(({ path, revisions: revs }) => (
         <ComparisonTableRow
           key={path}
           path={path}


### PR DESCRIPTION
This PR fixes an issue with the way that the comparison table rendered. We were incorrectly rendering the "missing plot" whenever a plot was added/removed from the table. More details inline.

### Before

https://user-images.githubusercontent.com/37993418/169956799-17e1705e-a785-4ed1-829f-a2769626c86c.mov

**(I only had to see this a few times before I had to fix it 🤯 )**

### After

https://user-images.githubusercontent.com/37993418/169956668-3c34b7c4-a1d6-425c-ac52-7f71a450045d.mov
