### PR TITLE
Mitigate Python extension rejecting ready promise

### DIFF
--- a/extension/src/extensions/python.test.ts
+++ b/extension/src/extensions/python.test.ts
@@ -1,0 +1,82 @@
+import { extensions } from 'vscode'
+import {
+  getPythonBinPath,
+  getOnDidChangePythonExecutionDetails,
+  VscodePython
+} from './python'
+import { executeProcess } from '../processExecution'
+
+jest.mock('vscode')
+jest.mock('../processExecution')
+
+const mockedExecuteProcess = jest.mocked(executeProcess)
+
+const mockedExtensions = jest.mocked(extensions)
+const mockedGetExtension = jest.fn()
+mockedExtensions.getExtension = mockedGetExtension
+
+const mockedReady = jest.fn()
+const mockedOnDidChangeExecutionDetails = jest.fn()
+let mockedExecCommand: string[] | undefined
+
+const mockedSettings = {
+  getExecutionDetails: () => ({
+    execCommand: mockedExecCommand
+  }),
+  onDidChangeExecutionDetails: mockedOnDidChangeExecutionDetails
+}
+
+const mockedVscodePythonAPI = {
+  ready: mockedReady,
+  settings: mockedSettings
+} as unknown as VscodePython
+
+const mockedVscodePython = {
+  activate: () => Promise.resolve(mockedVscodePythonAPI)
+}
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  mockedGetExtension.mockReturnValueOnce(mockedVscodePython)
+})
+
+describe('getPythonBinPath', () => {
+  const mockedPythonBinPath = '/some/path/to/python'
+  mockedExecCommand = [mockedPythonBinPath]
+
+  it('should return the python path even if the python ready promise rejects', async () => {
+    mockedReady.mockRejectedValueOnce(undefined)
+    mockedExecuteProcess.mockResolvedValueOnce(mockedPythonBinPath)
+
+    const pythonBinPath = await getPythonBinPath()
+
+    expect(pythonBinPath).toStrictEqual(mockedPythonBinPath)
+  })
+
+  it('should return the python path if the python extension initializes as expected', async () => {
+    mockedReady.mockResolvedValueOnce(undefined)
+    mockedExecuteProcess.mockResolvedValueOnce(mockedPythonBinPath)
+
+    const pythonBinPath = await getPythonBinPath()
+
+    expect(pythonBinPath).toStrictEqual(mockedPythonBinPath)
+  })
+})
+
+describe('getOnDidChangePythonExecutionDetails', () => {
+  it('should return the listener if the python ready promise rejects', async () => {
+    mockedReady.mockRejectedValueOnce(undefined)
+
+    const listener = await getOnDidChangePythonExecutionDetails()
+
+    expect(listener).toBe(mockedOnDidChangeExecutionDetails)
+  })
+
+  it('should return the listener if the python extension initializes as expected', async () => {
+    mockedReady.mockResolvedValueOnce(undefined)
+
+    const listener = await getOnDidChangePythonExecutionDetails()
+
+    expect(listener).toBe(mockedOnDidChangeExecutionDetails)
+  })
+})

--- a/extension/src/extensions/python.ts
+++ b/extension/src/extensions/python.ts
@@ -11,19 +11,19 @@ interface Settings {
   }
 }
 
-interface VscodePython {
+export interface VscodePython {
   ready: Thenable<void>
   settings: Settings
 }
 
-export const getPythonExtensionSettings = async (): Promise<
-  Settings | undefined
-> => {
+const getPythonExtensionSettings = async (): Promise<Settings | undefined> => {
   const api = await getExtensionAPI<VscodePython>(PYTHON_EXTENSION_ID)
   if (!api) {
     return
   }
-  await api.ready
+  try {
+    await api.ready
+  } catch {}
   return api.settings
 }
 

--- a/extension/src/vscode/extensions.ts
+++ b/extension/src/vscode/extensions.ts
@@ -13,13 +13,17 @@ type PackageJSON = {
 const getExtension = <T>(id: string): Extension<T & PackageJSON> | undefined =>
   extensions.getExtension<T & PackageJSON>(id)
 
-export const getExtensionAPI = <T>(name: string): Thenable<T> | undefined => {
+export const getExtensionAPI = async <T>(
+  name: string
+): Promise<T | undefined> => {
   const extension = getExtension<T>(name)
   if (!extension) {
     return
   }
 
-  return extension.activate()
+  try {
+    return await extension.activate()
+  } catch {}
 }
 
 export const getExtensionVersion = <T>(id: string): string | undefined => {


### PR DESCRIPTION
This issue was first surfaced by @rogermparent in https://github.com/iterative/vscode-dvc/issues/1318.

I've raised this PR due to the behaviour demonstrated by @dacbd in [this video](https://iterativeai.slack.com/archives/C01APS0FHDM/p1653425478470219). 

My working theory is that some part of the Python extension fails to load correctly in a SSH session and the ready promise gets rejected. Hopefully, this will be mitigated by the solution Roger proposed above.