### PR TITLE
Watch all .dvc files for exp show updates

### DIFF
--- a/extension/src/experiments/data/index.ts
+++ b/extension/src/experiments/data/index.ts
@@ -40,7 +40,7 @@ export class ExperimentsData extends BaseData<ExperimentsOutput> {
         },
         { name: 'fullUpdate', process: () => this.update() }
       ],
-      ['dvc.lock', 'dvc.yaml', 'params.yaml']
+      ['dvc.lock', 'dvc.yaml', 'params.yaml', '*.dvc']
     )
 
     this.watchExpGitRefs()

--- a/extension/src/test/suite/experiments/data/index.test.ts
+++ b/extension/src/test/suite/experiments/data/index.test.ts
@@ -62,7 +62,7 @@ suite('Experiments Data Test Suite', () => {
         join(
           dvcDemoPath,
           '**',
-          `{dvc.lock,dvc.yaml,params.yaml,nested${sep}params.yaml,summary.json}`
+          `{dvc.lock,dvc.yaml,params.yaml,*.dvc,nested${sep}params.yaml,summary.json}`
         )
       )
     })
@@ -134,14 +134,14 @@ suite('Experiments Data Test Suite', () => {
         join(
           dvcDemoPath,
           '**',
-          `{dvc.lock,dvc.yaml,params.yaml,nested${sep}params.yaml,summary.json}`
+          `{dvc.lock,dvc.yaml,params.yaml,*.dvc,nested${sep}params.yaml,summary.json}`
         )
       )
       expect(getFirstArgOfCall(mockCreateFileSystemWatcher, 1)).to.equal(
         join(
           dvcDemoPath,
           '**',
-          `{dvc.lock,dvc.yaml,params.yaml,nested${sep}params.yaml,new_params.yml,new_summary.json,summary.json}`
+          `{dvc.lock,dvc.yaml,params.yaml,*.dvc,nested${sep}params.yaml,new_params.yml,new_summary.json,summary.json}`
         )
       )
     })


### PR DESCRIPTION
Starting to look at using the `exp show` data for knowing which directories can/should be pulled when a request is sent from the DVC Tracked tree.