### PR TITLE
Switch list-selection icon to list-filter

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -434,13 +434,13 @@
         "title": "%command.views.experimentsTree.selectExperiments%",
         "command": "dvc.views.experimentsTree.selectExperiments",
         "category": "DVC",
-        "icon": "$(list-selection)"
+        "icon": "$(list-filter)"
       },
       {
         "title": "%command.views.experimentsColumnsTree.selectColumns%",
         "command": "dvc.views.experimentsColumnsTree.selectColumns",
         "category": "DVC",
-        "icon": "$(list-selection)"
+        "icon": "$(list-filter)"
       },
       {
         "title": "%command.views.experimentsTree.autoApplyFilters%",
@@ -458,7 +458,7 @@
         "title": "%command.views.plotsPathsTree.selectPlots%",
         "command": "dvc.views.plotsPathsTree.selectPlots",
         "category": "DVC",
-        "icon": "$(list-selection)"
+        "icon": "$(list-filter)"
       }
     ],
     "configuration": {


### PR DESCRIPTION
This PR replaces our use of the `list-selection` icon in the view container trees with the `list-filter` icon which will be used in the plots ribbon (#1798).

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/37993418/171068081-b29ec773-2f04-4d94-8b37-f855ddc35248.png">
