### PR TITLE
Fix experiment names overflowing from plots ribbon

### DIFF
--- a/webview/src/plots/components/ribbon/styles.module.scss
+++ b/webview/src/plots/components/ribbon/styles.module.scss
@@ -24,6 +24,7 @@
   border: none;
   text-align: left;
   color: $fg-color;
+  min-width: max-content;
 
   span {
     display: block;
@@ -56,6 +57,7 @@
   border-bottom: 1px solid $border-color;
   padding: 10px 15px;
   margin: 0;
+  flex-wrap: wrap;
 }
 
 .addButtonWrapper {


### PR DESCRIPTION
<img width="1632" alt="Screen Shot 2022-06-02 at 1 44 09 PM" src="https://user-images.githubusercontent.com/3683420/171693455-b9a7debc-e9dc-4cd7-b33d-e5ed8671f62f.png">

This is what was actually planned in the Figma spec.