### PR TITLE
Watch all dvc.yamls for changes to plots

### DIFF
--- a/extension/src/plots/data/index.ts
+++ b/extension/src/plots/data/index.ts
@@ -17,12 +17,18 @@ export class PlotsData extends BaseData<{ data: PlotsOutput; revs: string[] }> {
     internalCommands: InternalCommands,
     updatesPaused: EventEmitter<boolean>
   ) {
-    super(dvcRoot, internalCommands, updatesPaused, [
-      {
-        name: 'update',
-        process: () => this.update()
-      }
-    ])
+    super(
+      dvcRoot,
+      internalCommands,
+      updatesPaused,
+      [
+        {
+          name: 'update',
+          process: () => this.update()
+        }
+      ],
+      ['dvc.yaml']
+    )
   }
 
   public async update(): Promise<void> {


### PR DESCRIPTION
Relates to #1797.

I did not setup the scenario correctly when I previously tried to fix this issue. If there are actually no plots on the checked-out branch then no paths are being watched. This meant that the watcher did not fire when moving back to `main`/a branch that has plots. Watching all `dvc.yaml`s for changes will actually fix the issue and will fix another issue for new projects without plots as well.

### Demo

https://user-images.githubusercontent.com/37993418/171723054-5a09f9d3-80af-46f7-ba04-48ab3fb8106e.mov


