### PR TITLE
Extension: add more tags and categories

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -20,9 +20,11 @@
   "homepage": "https://github.com/iterative/vscode-dvc/README.md",
   "keywords": [
     "iterative",
-    "data",
-    "version",
-    "control",
+    "data version control",
+    "plots",
+    "experiment tracking",
+    "hyperparameters",
+    "dataset",
     "dvc"
   ],
   "categories": [


### PR DESCRIPTION
Add ML and SCM as categories to the extension.

<img width="1119" alt="Screen Shot 2022-06-04 at 6 58 12 PM" src="https://user-images.githubusercontent.com/3659196/172031666-bd156e4b-200a-435d-a2bf-16596e409b9b.png">

+ add more Tags also