### PR TITLE
Add dep prefix to experiments table tooltip

### DIFF
--- a/webview/src/experiments/util/buildDynamicColumns.tsx
+++ b/webview/src/experiments/util/buildDynamicColumns.tsx
@@ -23,6 +23,7 @@ const UndefinedCell = (
 )
 
 const groupLabels: Record<string, string> = {
+  deps: 'Dep',
   metrics: 'Metric',
   params: 'Parameter'
 }


### PR DESCRIPTION
`Dep: ` was missing from the experiments table tooltip.