### PR TITLE
Remove preview tag from marketplace listing

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dvc",
   "private": true,
-  "preview": true,
+  "preview": false,
   "displayName": "%displayName%",
   "description": "%description%",
   "publisher": "iterative",


### PR DESCRIPTION
This is an item from the release checklist. Should remove the preview tag from here:

![image](https://user-images.githubusercontent.com/37993418/172530695-a55fd9b6-eb6c-487f-b0b2-325ae7d23cbb.png)
