### PR TITLE
Add maxWorkers option to Jest configs

### DIFF
--- a/extension/jest.config.js
+++ b/extension/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   coverageDirectory: 'coverage/jest',
   coveragePathIgnorePatterns: ['<rootDir>/src/test/'],
   coverageReporters: ['json'],
+  maxWorkers: '50%',
   preset: 'ts-jest',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/src/test/', '<rootDir>/dist/']

--- a/webview/jest.config.js
+++ b/webview/jest.config.js
@@ -14,6 +14,7 @@ module.exports = {
   globals: {
     __webpack_public_path__: true
   },
+  maxWorkers: '50%',
   moduleNameMapper: {
     '\\.(scss|css|less)$': 'identity-obj-proxy'
   },


### PR DESCRIPTION
Follow up from #1846. 

Setting this option cuts the test run times again.