### PR TITLE
Show table header context menu on left click (as well as right)

### DIFF
--- a/webview/src/experiments/components/table/TableHeader.tsx
+++ b/webview/src/experiments/components/table/TableHeader.tsx
@@ -174,6 +174,7 @@ const TableHeaderCell: React.FC<{
     <ContextMenu
       content={menuContent}
       disabled={menuDisabled || menuSuppressed}
+      trigger={'contextmenu click'}
     >
       <div
         {...column.getHeaderProps(

--- a/webview/src/shared/components/contextMenu/ContextMenu.tsx
+++ b/webview/src/shared/components/contextMenu/ContextMenu.tsx
@@ -41,17 +41,19 @@ export interface ContextMenuProps {
   content?: React.ReactNode
   disabled?: boolean
   onShow?: () => void
+  trigger?: string
 }
 
 export const ContextMenu: React.FC<ContextMenuProps> = ({
   children,
   content,
   disabled,
-  onShow
+  onShow,
+  trigger = 'contextmenu'
 }) => (
   <Tooltip
     arrow
-    trigger={'contextmenu'}
+    trigger={trigger}
     delay={[100, 200]}
     placement={'bottom'}
     interactive


### PR DESCRIPTION
This PR adds left-click to the triggers for showing the table header context menu.