### PR TITLE
Fix DVC cwd for Windows

### DIFF
--- a/extension/src/cli/cwd.ts
+++ b/extension/src/cli/cwd.ts
@@ -1,6 +1,6 @@
 import { realpathSync } from 'fs'
 
-export const getCwd = (path: string): string => {
+export const getCaseSensitiveCwd = (path: string): string => {
   try {
     const cwd = realpathSync.native(path)
     if (cwd) {

--- a/extension/src/cli/cwd.ts
+++ b/extension/src/cli/cwd.ts
@@ -1,0 +1,11 @@
+import { realpathSync } from 'fs'
+
+export const getCwd = (path: string): string => {
+  try {
+    const cwd = realpathSync.native(path)
+    if (cwd) {
+      return cwd
+    }
+  } catch {}
+  return path
+}

--- a/extension/src/cli/options.ts
+++ b/extension/src/cli/options.ts
@@ -1,6 +1,6 @@
 import { dirname } from 'path'
 import { Args } from './constants'
-import { getCwd } from './cwd'
+import { getCaseSensitiveCwd } from './cwd'
 import { getProcessEnv } from '../env'
 import { joinEnvPath } from '../util/env'
 
@@ -49,7 +49,7 @@ export const getOptions = (
   return {
     args,
     command: [executable, ...args].join(' '),
-    cwd: getCwd(cwd),
+    cwd: getCaseSensitiveCwd(cwd),
     env: getEnv(pythonBinPath),
     executable
   }

--- a/extension/src/cli/options.ts
+++ b/extension/src/cli/options.ts
@@ -1,5 +1,6 @@
 import { dirname } from 'path'
 import { Args } from './constants'
+import { getCwd } from './cwd'
 import { getProcessEnv } from '../env'
 import { joinEnvPath } from '../util/env'
 
@@ -45,13 +46,11 @@ export const getOptions = (
 ): ExecutionDetails => {
   const executable = getExecutable(pythonBinPath, cliPath)
   const args = getArgs(pythonBinPath, cliPath, ...originalArgs)
-  const command = [executable, ...args].join(' ')
-  const env = getEnv(pythonBinPath)
   return {
     args,
-    command,
-    cwd,
-    env,
+    command: [executable, ...args].join(' '),
+    cwd: getCwd(cwd),
+    env: getEnv(pythonBinPath),
     executable
   }
 }

--- a/extension/src/test/suite/cli/cwd.test.ts
+++ b/extension/src/test/suite/cli/cwd.test.ts
@@ -1,0 +1,26 @@
+import { sep } from 'path'
+import { describe, it, suite } from 'mocha'
+import { expect } from 'chai'
+import { dvcDemoPath } from '../../util'
+import { getCaseSensitiveCwd } from '../../../cli/cwd'
+
+suite('Cwd Test Suite', () => {
+  describe('getCaseSensitiveCwd', () => {
+    it('should return a case sensitive path for case sensitive systems which matches os.getcwd() in the CLI', () => {
+      const caseInsensitiveCwd = dvcDemoPath.toUpperCase()
+      const realpathCwd = getCaseSensitiveCwd(caseInsensitiveCwd)
+
+      expect(realpathCwd).to.have.length(dvcDemoPath.length)
+
+      const caseInsensitiveArray = caseInsensitiveCwd.split(sep)
+      const realPathArray = realpathCwd.split(sep)
+
+      expect(caseInsensitiveArray).to.have.length(realPathArray.length)
+      for (let i = 0; i <= caseInsensitiveArray.length; i++) {
+        expect(caseInsensitiveArray[i]).to.match(
+          new RegExp(realPathArray[i], 'i')
+        )
+      }
+    })
+  })
+})

--- a/extension/src/test/suite/cli/cwd.test.ts
+++ b/extension/src/test/suite/cli/cwd.test.ts
@@ -11,6 +11,12 @@ suite('Cwd Test Suite', () => {
       const realpathCwd = getCaseSensitiveCwd(caseInsensitiveCwd)
 
       expect(realpathCwd).to.have.length(dvcDemoPath.length)
+      expect(realpathCwd).not.to.equal(
+        ['win32', 'darwin'].includes(process.platform)
+          ? caseInsensitiveCwd
+          : caseInsensitiveCwd.toLowerCase(),
+        'should behave differently on different systems'
+      )
 
       const caseInsensitiveArray = caseInsensitiveCwd.split(sep)
       const realPathArray = realpathCwd.split(sep)


### PR DESCRIPTION
Attempt to fix https://github.com/iterative/dvc/issues/7909 on our side.

The issue is that when we call the CLI it uses Python's `os.getcwd()` to get the directory that the command is being run in. This returns a case-sensitive path. It seems that by default Node (and VS Code) will always return a lower-case letter for a drive on Windows. As Windows is a case-sensitive file system this causes bizarre behaviour (see issue above). 

The fix is to use `fs.realpath.native` on the cwd before we send it to the CLI. I have tested it manually on both Mac and Windows and it seems to behave as expected. I would call this a patch and not a long-term solution.