### PR TITLE
Use vertical line as drop target indicator for plots

### DIFF
--- a/webview/src/plots/components/comparisonTable/ComparisonTableHead.tsx
+++ b/webview/src/plots/components/comparisonTable/ComparisonTableHead.tsx
@@ -5,6 +5,7 @@ import styles from './styles.module.scss'
 import { DropTarget } from './DropTarget'
 import { ComparisonTableHeader } from './ComparisonTableHeader'
 import { DragDropContainer } from '../../../shared/components/dragDrop/DragDropContainer'
+import { DragEnterDirection } from '../../../shared/components/dragDrop/util'
 
 export type ComparisonTableColumn = Revision
 
@@ -53,8 +54,8 @@ export const ComparisonTableHead: React.FC<ComparisonTableHeadProps> = ({
           items={items}
           group="comparison"
           dropTarget={{
-            element: <DropTarget />,
-            wrapperTag: 'th'
+            element: <DropTarget direction={DragEnterDirection.AUTO} />,
+            wrapperTag: 'div'
           }}
         />
       </tr>

--- a/webview/src/plots/components/comparisonTable/ComparisonTableRow.tsx
+++ b/webview/src/plots/components/comparisonTable/ComparisonTableRow.tsx
@@ -1,11 +1,12 @@
 import { ComparisonPlot } from 'dvc/src/plots/webview/contract'
 import { MessageFromWebviewType } from 'dvc/src/webview/contract'
-import React, { useState } from 'react'
+import React, { useContext, useState } from 'react'
 import cx from 'classnames'
 import styles from './styles.module.scss'
 import { AllIcons, Icon } from '../../../shared/components/Icon'
 import { RefreshButton } from '../../../shared/components/button/RefreshButton'
 import { sendMessage } from '../../../shared/vscode'
+import { DragDropContext, DragDropContextValue } from '../../../shared/components/dragDrop/DragDropContext'
 
 export interface ComparisonTableRowProps {
   path: string
@@ -21,6 +22,7 @@ export const ComparisonTableRow: React.FC<ComparisonTableRowProps> = ({
   pinnedColumn
 }) => {
   const [isShown, setIsShown] = useState(true)
+  const { draggedRef } = useContext<DragDropContextValue>(DragDropContext)
 
   const toggleIsShownState = () => setIsShown(!isShown)
 
@@ -41,13 +43,15 @@ export const ComparisonTableRow: React.FC<ComparisonTableRowProps> = ({
         {plots.map((plot: ComparisonPlot) => {
           const isPinned = pinnedColumn === plot.revision
           const missing = !plot?.url
+          const isBeingDragged = draggedRef?.itemId === plot.revision;
 
           return (
             <td
               key={path + plot.revision}
               className={cx({
                 [styles.pinnedColumnCell]: isPinned,
-                [styles.missing]: isShown && missing
+                [styles.missing]: isShown && missing,
+                [styles.draggedColumnCell]: isBeingDragged
               })}
             >
               <div

--- a/webview/src/plots/components/comparisonTable/DropTarget.tsx
+++ b/webview/src/plots/components/comparisonTable/DropTarget.tsx
@@ -1,14 +1,20 @@
 import React from 'react'
-import { AllIcons, Icon } from '../../../shared/components/Icon'
+import { DragEnterDirection } from '../../../shared/components/dragDrop/util'
 import styles from '../styles.module.scss'
+import { DropTargetIndicator } from './DropTargetIndicator'
 
-export const DropTarget: React.FC = () => (
+export const DropTarget: React.FC<Props> = ({ children, direction }) => (
   <div className={styles.dropTarget} data-testid="comparison-drop-target">
-    <Icon
-      icon={AllIcons.ELLIPSIS}
-      className={styles.smallDropIcon}
-      width={15}
-      height={15}
-    />
+    {direction === DragEnterDirection.LEFT && (
+      <DropTargetIndicator direction={direction} />
+    )}
+    {children}
+    {direction === DragEnterDirection.RIGHT && (
+      <DropTargetIndicator direction={direction} />
+    )}
   </div>
 )
+
+interface Props {
+  direction: DragEnterDirection
+}

--- a/webview/src/plots/components/comparisonTable/DropTargetIndicator.tsx
+++ b/webview/src/plots/components/comparisonTable/DropTargetIndicator.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { DragEnterDirection } from '../../../shared/components/dragDrop/util'
+import styles from '../styles.module.scss'
+
+export const DropTargetIndicator: React.FC<Props> = ({ direction }) => (
+  <span
+    className={styles.dropTargetIndicator}
+    data-testid="comparison-drop-target-indicator"
+    style={{
+      [direction.toLowerCase()]: -4
+    }}
+  />
+)
+
+interface Props {
+  direction: DragEnterDirection
+}

--- a/webview/src/plots/components/comparisonTable/styles.module.scss
+++ b/webview/src/plots/components/comparisonTable/styles.module.scss
@@ -134,6 +134,21 @@ $gap: 4px;
   z-index: 3;
 }
 
+.draggedColumnCell {
+  position: relative;
+
+  &::after {
+    content: '';
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    background:rgba(0,0,0,0.6);
+    opacity: 1;
+  }
+}
+
 .cell {
   max-height: 100vh;
   width: 100%;

--- a/webview/src/plots/components/styles.module.scss
+++ b/webview/src/plots/components/styles.module.scss
@@ -268,12 +268,24 @@ $gap: 20px;
 
 .dropSectionMaximized,
 .dropTarget {
+  position: relative;
   height: auto;
-  opacity: 0.5;
-  border: 3px dashed $accent-color;
+  width: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
+
+  & > th {
+    display: block;
+    width: 100%;
+  }
+}
+
+.dropTargetIndicator {
+  position: absolute;
+  top: 2px;
+  min-height: 32px;
+  border: 2px dotted $accent-color;
 }
 
 .dropIcon {

--- a/webview/src/shared/components/dragDrop/DragDropContainer.tsx
+++ b/webview/src/shared/components/dragDrop/DragDropContainer.tsx
@@ -42,7 +42,8 @@ export const makeTarget = (
   dropTarget: DropTargetInfo,
   handleDragOver: DragEventHandler<HTMLElement>,
   handleOnDrop: DragEventHandler<HTMLElement>,
-  id: string
+  id: string,
+  props?: Partial<{ children: JSX.Element; direction: DragEnterDirection }>
 ) => (
   <dropTarget.wrapperTag
     data-testid="drop-target"
@@ -51,7 +52,7 @@ export const makeTarget = (
     onDrop={handleOnDrop}
     id={`${id}__drop`}
   >
-    {dropTarget.element}
+    {React.cloneElement(dropTarget.element, props)}
   </dropTarget.wrapperTag>
 )
 interface DragDropContainerProps {
@@ -126,7 +127,6 @@ export const DragDropContainer: React.FC<DragDropContainerProps> = ({
     })
     draggedOverIdTimeout.current = window.setTimeout(() => {
       setDraggedId(id)
-      setDraggedOverId(order[toIdx])
     }, 0)
   }
 
@@ -204,7 +204,7 @@ export const DragDropContainer: React.FC<DragDropContainerProps> = ({
       onDragEnter={handleDragEnter}
       onDrop={handleOnDrop}
       draggable={!disabledDropIds.includes(id)}
-      style={(id === draggedId && { display: 'none' }) || draggable.props.style}
+      style={draggable.props.style}
     />
   )
 
@@ -213,11 +213,12 @@ export const DragDropContainer: React.FC<DragDropContainerProps> = ({
     const item = id && buildItem(id, draggable)
 
     if (id === draggedOverId) {
-      const target = makeTarget(dropTarget, handleDragOver, handleOnDrop, id)
+      const target = makeTarget(dropTarget, handleDragOver, handleOnDrop, id, {
+        children: draggable,
+        direction
+      })
 
-      return direction === DragEnterDirection.RIGHT
-        ? [item, target]
-        : [target, item]
+      return target
     }
 
     return item


### PR DESCRIPTION
Fixes #1604

This was a tricky one to do initially. My first idea was to simply change the DropTarget to a vertical line and change the dragged column to not be hidden, but that didn't work because the vertical line was still part of the table flow, meaning it would consume the entire width of a header.

My current approach passes the header element itself to DropTarget so it can render the header as well as the drop indicators.

TODO:

- [ ] Fix not being able to drag a column to the first or last spot
- [ ] Fix tests