### PR TITLE
Simplify import of icons

### DIFF
--- a/webview/src/experiments/components/table/TableHeader.tsx
+++ b/webview/src/experiments/components/table/TableHeader.tsx
@@ -21,7 +21,7 @@ import {
 import { MessagesMenu } from '../../../shared/components/messagesMenu/MessagesMenu'
 import { MessagesMenuOptionProps } from '../../../shared/components/messagesMenu/MessagesMenuOption'
 import { IconMenu } from '../../../shared/components/iconMenu/IconMenu'
-import { AllIcons } from '../../../shared/components/Icon'
+import { DownArrow, Lines, UpArrow } from '../../../shared/components/icons'
 
 export enum SortOrder {
   ASCENDING = 'Sort Ascending',
@@ -119,14 +119,12 @@ const getIconMenuItems = (
 ) => [
   {
     hidden: !sortEnabled || sortOrder === SortOrder.NONE,
-    icon:
-      (sortOrder === SortOrder.DESCENDING && AllIcons.DOWN_ARROW) ||
-      AllIcons.UP_ARROW,
+    icon: (sortOrder === SortOrder.DESCENDING && DownArrow) || UpArrow,
     tooltip: 'Table Sorted By'
   },
   {
     hidden: !hasFilter,
-    icon: AllIcons.LINES,
+    icon: Lines,
     tooltip: 'Table Filtered By'
   }
 ]

--- a/webview/src/plots/components/DropTarget.tsx
+++ b/webview/src/plots/components/DropTarget.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import cx from 'classnames'
 import styles from './styles.module.scss'
-import { AllIcons, Icon } from '../../shared/components/Icon'
+import { Icon } from '../../shared/components/Icon'
+import { GraphLine } from '../../shared/components/icons'
 
 export const DropTarget: React.FC = () => (
   <div
@@ -9,11 +10,6 @@ export const DropTarget: React.FC = () => (
     id="plot-drop-target"
     className={cx(styles.plot, styles.dropTarget)}
   >
-    <Icon
-      icon={AllIcons.GRAPH_LINE}
-      className={styles.dropIcon}
-      width={50}
-      height={50}
-    />
+    <Icon icon={GraphLine} className={styles.dropIcon} width={50} height={50} />
   </div>
 )

--- a/webview/src/plots/components/PlotsContainer.tsx
+++ b/webview/src/plots/components/PlotsContainer.tsx
@@ -10,11 +10,18 @@ import { PlotsSizeContext } from './PlotsSizeContext'
 import { PlotsPicker, PlotsPickerProps } from './PlotsPicker'
 import { SizePicker } from './SizePicker'
 import styles from './styles.module.scss'
-import { AllIcons, Icon } from '../../shared/components/Icon'
+import { Icon } from '../../shared/components/Icon'
 import { IconMenu } from '../../shared/components/iconMenu/IconMenu'
 import { IconMenuItemProps } from '../../shared/components/iconMenu/IconMenuItem'
 import { sendMessage } from '../../shared/vscode'
 import Tooltip from '../../shared/components/tooltip/Tooltip'
+import {
+  ChevronDown,
+  ChevronRight,
+  Dots,
+  Info,
+  Lines
+} from '../../shared/components/icons'
 
 export interface PlotsContainerProps {
   sectionCollapsed: SectionCollapsed
@@ -40,12 +47,7 @@ export const SectionDescription = {
 }
 
 const InfoIcon = () => (
-  <Icon
-    icon={AllIcons.INFO}
-    width={16}
-    height={16}
-    className={styles.infoIcon}
-  />
+  <Icon icon={Info} width={16} height={16} className={styles.infoIcon} />
 )
 
 export const PlotsContainer: React.FC<PlotsContainerProps> = ({
@@ -83,7 +85,7 @@ export const PlotsContainer: React.FC<PlotsContainerProps> = ({
   }
   const menuItems: IconMenuItemProps[] = [
     {
-      icon: AllIcons.DOTS,
+      icon: Dots,
       onClickNode: (
         <SizePicker currentSize={size} setSelectedSize={changeSize} />
       ),
@@ -93,7 +95,7 @@ export const PlotsContainer: React.FC<PlotsContainerProps> = ({
 
   if (menu) {
     menuItems.unshift({
-      icon: AllIcons.LINES,
+      icon: Lines,
       onClickNode: <PlotsPicker {...menu} />,
       tooltip: 'Select Plots'
     })
@@ -121,7 +123,7 @@ export const PlotsContainer: React.FC<PlotsContainerProps> = ({
           }}
         >
           <Icon
-            icon={open ? AllIcons.CHEVRON_DOWN : AllIcons.CHEVRON_RIGHT}
+            icon={open ? ChevronDown : ChevronRight}
             data-testid="plots-container-details-chevron"
             width={20}
             height={20}

--- a/webview/src/plots/components/comparisonTable/ComparisonTableRow.tsx
+++ b/webview/src/plots/components/comparisonTable/ComparisonTableRow.tsx
@@ -3,9 +3,10 @@ import { MessageFromWebviewType } from 'dvc/src/webview/contract'
 import React, { useState } from 'react'
 import cx from 'classnames'
 import styles from './styles.module.scss'
-import { AllIcons, Icon } from '../../../shared/components/Icon'
+import { Icon } from '../../../shared/components/Icon'
 import { RefreshButton } from '../../../shared/components/button/RefreshButton'
 import { sendMessage } from '../../../shared/vscode'
+import { ChevronDown, ChevronRight } from '../../../shared/components/icons'
 
 export interface ComparisonTableRowProps {
   path: string
@@ -29,9 +30,7 @@ export const ComparisonTableRow: React.FC<ComparisonTableRowProps> = ({
       <tr>
         <td className={cx({ [styles.pinnedColumnCell]: pinnedColumn })}>
           <button className={styles.rowToggler} onClick={toggleIsShownState}>
-            <Icon
-              icon={isShown ? AllIcons.CHEVRON_DOWN : AllIcons.CHEVRON_RIGHT}
-            />
+            <Icon icon={isShown ? ChevronDown : ChevronRight} />
             {path}
           </button>
         </td>

--- a/webview/src/plots/components/comparisonTable/DropTarget.tsx
+++ b/webview/src/plots/components/comparisonTable/DropTarget.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
-import { AllIcons, Icon } from '../../../shared/components/Icon'
+import { Icon } from '../../../shared/components/Icon'
+import { Ellipsis } from '../../../shared/components/icons'
 import styles from '../styles.module.scss'
 
 export const DropTarget: React.FC = () => (
   <div className={styles.dropTarget} data-testid="comparison-drop-target">
     <Icon
-      icon={AllIcons.ELLIPSIS}
+      icon={Ellipsis}
       className={styles.smallDropIcon}
       width={15}
       height={15}

--- a/webview/src/plots/components/ribbon/Ribbon.tsx
+++ b/webview/src/plots/components/ribbon/Ribbon.tsx
@@ -5,9 +5,9 @@ import { reorderObjectList } from 'dvc/src/util/array'
 import styles from './styles.module.scss'
 import { RibbonBlock } from './RibbonBlock'
 import { sendMessage } from '../../../shared/vscode'
-import { AllIcons } from '../../../shared/components/Icon'
 import { IconButton } from '../../../shared/components/button/IconButton'
 import { performOrderedUpdate } from '../../../util/objects'
+import { Lines, Refresh } from '../../../shared/components/icons'
 
 interface RibbonProps {
   revisions: Revision[]
@@ -47,14 +47,14 @@ export const Ribbon: React.FC<RibbonProps> = ({ revisions }) => {
       <li className={styles.buttonWrapper}>
         <IconButton
           onClick={selectRevisions}
-          icon={AllIcons.LINES}
+          icon={Lines}
           text={`${revisions.length} of ${MAX_NB_EXP}`}
         />
       </li>
       <li className={styles.buttonWrapper}>
         <IconButton
           onClick={refreshRevisions}
-          icon={AllIcons.REFRESH}
+          icon={Refresh}
           text="Refresh All"
           appearance="secondary"
         />

--- a/webview/src/plots/components/ribbon/RibbonBlock.tsx
+++ b/webview/src/plots/components/ribbon/RibbonBlock.tsx
@@ -1,9 +1,10 @@
 import { Revision } from 'dvc/src/plots/webview/contract'
 import React from 'react'
 import styles from './styles.module.scss'
-import { AllIcons, Icon } from '../../../shared/components/Icon'
+import { Icon } from '../../../shared/components/Icon'
 import Tooltip from '../../../shared/components/tooltip/Tooltip'
 import { CopyButton } from '../../../shared/components/copyButton/CopyButton'
+import { Close } from '../../../shared/components/icons'
 
 interface RibbonBlockProps {
   revision: Revision
@@ -38,7 +39,7 @@ export const RibbonBlock: React.FC<RibbonBlockProps> = ({
       </div>
       <Tooltip content="Clear" placement="bottom" delay={500}>
         <button className={styles.clearButton} onClick={onClear}>
-          <Icon icon={AllIcons.CLOSE} width={12} height={12} />
+          <Icon icon={Close} width={12} height={12} />
         </button>
       </Tooltip>
     </li>

--- a/webview/src/plots/components/templatePlots/AddedSection.tsx
+++ b/webview/src/plots/components/templatePlots/AddedSection.tsx
@@ -3,8 +3,9 @@ import cx from 'classnames'
 import { TemplatePlotSection } from 'dvc/src/plots/webview/contract'
 import styles from '../styles.module.scss'
 import { getIDWithoutIndex } from '../../../util/ids'
-import { AllIcons, Icon } from '../../../shared/components/Icon'
+import { Icon } from '../../../shared/components/Icon'
 import { DragDropContext } from '../../../shared/components/dragDrop/DragDropContext'
+import { GraphLine } from '../../../shared/components/icons'
 
 interface AddedSectionProps {
   id: string
@@ -57,7 +58,7 @@ export const AddedSection: React.FC<AddedSectionProps> = ({
         {isHovered && (
           <Icon
             data-testid={`${id}_drop-icon`}
-            icon={AllIcons.GRAPH_LINE}
+            icon={GraphLine}
             className={styles.dropIcon}
             width={50}
             height={50}

--- a/webview/src/shared/components/Icon.tsx
+++ b/webview/src/shared/components/Icon.tsx
@@ -1,43 +1,8 @@
-import React from 'react'
-import {
-  Add,
-  Check,
-  ChevronDown,
-  ChevronRight,
-  Close,
-  Dots,
-  DownArrow,
-  Ellipsis,
-  GraphLine,
-  Gripper,
-  Info,
-  Lines,
-  Refresh,
-  UpArrow
-} from './icons'
+import React, { SVGProps } from 'react'
 
-export const AllIcons = {
-  ADD: Add,
-  CHECK: Check,
-  CHEVRON_DOWN: ChevronDown,
-  CHEVRON_RIGHT: ChevronRight,
-  CLOSE: Close,
-  DOTS: Dots,
-  DOWN_ARROW: DownArrow,
-  ELLIPSIS: Ellipsis,
-  GRAPH_LINE: GraphLine,
-  GRIPPER: Gripper,
-  INFO: Info,
-  LINES: Lines,
-  REFRESH: Refresh,
-  UP_ARROW: UpArrow
-}
-
-type IconKeys = keyof typeof AllIcons
-export type IconValues = typeof AllIcons[IconKeys]
-
+export type IconValue = (props: SVGProps<SVGSVGElement>) => JSX.Element
 interface IconProps {
-  icon: IconValues
+  icon: IconValue
   className?: string
   width?: number
   height?: number

--- a/webview/src/shared/components/button/IconButton.tsx
+++ b/webview/src/shared/components/button/IconButton.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import { Button, ButtonProps } from './Button'
-import { Icon, IconValues } from '../Icon'
+import { Icon, IconValue } from '../Icon'
 
-export type IconButtonProps = ButtonProps & { icon: IconValues }
+export type IconButtonProps = ButtonProps & { icon: IconValue }
 
 export const IconButton: React.FC<IconButtonProps> = ({
   appearance,

--- a/webview/src/shared/components/button/RefreshButton.tsx
+++ b/webview/src/shared/components/button/RefreshButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { ButtonProps } from './Button'
 import { IconButton } from './IconButton'
-import { AllIcons } from '../Icon'
+import { Refresh } from '../icons'
 
 type RefreshButtonProps = Omit<ButtonProps, 'text'>
 
@@ -14,7 +14,7 @@ export const RefreshButton: React.FC<RefreshButtonProps> = ({
     <IconButton
       appearance={appearance}
       isNested={isNested}
-      icon={AllIcons.REFRESH}
+      icon={Refresh}
       onClick={onClick}
       text={'Refresh'}
     />

--- a/webview/src/shared/components/button/StartButton.tsx
+++ b/webview/src/shared/components/button/StartButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { ButtonProps } from './Button'
 import { IconButton } from './IconButton'
-import { AllIcons } from '../Icon'
+import { Add } from '../icons'
 
 export const StartButton: React.FC<ButtonProps> = ({
   appearance,
@@ -13,7 +13,7 @@ export const StartButton: React.FC<ButtonProps> = ({
     <IconButton
       appearance={appearance}
       isNested={isNested}
-      icon={AllIcons.ADD}
+      icon={Add}
       onClick={onClick}
       text={text}
     />

--- a/webview/src/shared/components/dragDrop/GripIcon.tsx
+++ b/webview/src/shared/components/dragDrop/GripIcon.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
-import { AllIcons, Icon } from '../Icon'
+import { Icon } from '../Icon'
+import { Gripper } from '../icons'
 
 interface GripIconProps {
   className: string
 }
 
 export const GripIcon: React.FC<GripIconProps> = ({ className }) => (
-  <Icon icon={AllIcons.GRIPPER} width={30} height={30} className={className} />
+  <Icon icon={Gripper} width={30} height={30} className={className} />
 )

--- a/webview/src/shared/components/iconMenu/IconMenu.test.tsx
+++ b/webview/src/shared/components/iconMenu/IconMenu.test.tsx
@@ -12,16 +12,16 @@ import {
 } from '@testing-library/react'
 import { IconMenu } from './IconMenu'
 import { IconMenuItemProps } from './IconMenuItem'
-import { AllIcons } from '../Icon'
+import { Add, Lines, UpArrow } from '../icons'
 
 const items: IconMenuItemProps[] = [
   {
-    icon: AllIcons.UP_ARROW,
+    icon: UpArrow,
     onClick: jest.fn,
     tooltip: 'Move Up'
   },
   {
-    icon: AllIcons.LINES,
+    icon: Lines,
     onClickNode: 'On Click Node',
     tooltip: 'Choose metrics'
   }
@@ -34,7 +34,7 @@ const basicProps = {
 const renderMenu = (props = basicProps) => render(<IconMenu {...props} />)
 
 const item = {
-  icon: AllIcons.ADD,
+  icon: Add,
   onClickNode: 'Menu',
   tooltip: 'Tooltip'
 }

--- a/webview/src/shared/components/iconMenu/IconMenuItem.tsx
+++ b/webview/src/shared/components/iconMenu/IconMenuItem.tsx
@@ -2,11 +2,11 @@ import React from 'react'
 import cx from 'classnames'
 import { TippyProps } from '@tippyjs/react'
 import styles from './styles.module.scss'
-import { Icon, IconValues } from '../Icon'
+import { Icon, IconValue } from '../Icon'
 import Tooltip from '../tooltip/Tooltip'
 
 export interface IconMenuItemProps {
-  icon: IconValues
+  icon: IconValue
   onClick?: () => void
   onClickNode?: React.ReactNode
   tooltip: string

--- a/webview/src/shared/components/modal/Modal.tsx
+++ b/webview/src/shared/components/modal/Modal.tsx
@@ -1,6 +1,7 @@
 import React, { MouseEvent, useEffect } from 'react'
 import styles from './styles.module.scss'
-import { AllIcons, Icon } from '../Icon'
+import { Icon } from '../Icon'
+import { Close } from '../icons'
 
 interface ModalProps {
   onClose: () => void
@@ -32,7 +33,7 @@ export const Modal: React.FC<ModalProps> = ({ onClose, children }) => {
           onClick={onClose}
           data-testid="modal-close"
         >
-          <Icon icon={AllIcons.CLOSE} width={30} height={30} />
+          <Icon icon={Close} width={30} height={30} />
         </button>
         <div
           className={styles.modalContent}

--- a/webview/src/shared/components/selectMenu/SelectMenuOption.tsx
+++ b/webview/src/shared/components/selectMenu/SelectMenuOption.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react'
 import styles from './styles.module.scss'
-import { AllIcons, Icon } from '../Icon'
+import { Icon } from '../Icon'
+import { Check } from '../icons'
 
 export interface SelectMenuOptionProps {
   id: string
@@ -41,7 +42,7 @@ export const SelectMenuOption: React.FC<SelectMenuOptionAllProps> = ({
       <div className={styles.itemIcon}>
         {isSelected && (
           <Icon
-            icon={AllIcons.CHECK}
+            icon={Check}
             width={13}
             data-testid="select-menu-option-check"
           />

--- a/webview/src/stories/ContextMenu.stories.tsx
+++ b/webview/src/stories/ContextMenu.stories.tsx
@@ -8,8 +8,9 @@ import {
   ContextMenu,
   ContextMenuProps
 } from '../shared/components/contextMenu/ContextMenu'
-import { AllIcons, Icon } from '../shared/components/Icon'
+import { Icon } from '../shared/components/Icon'
 import { MessagesMenu } from '../shared/components/messagesMenu/MessagesMenu'
+import { Lines } from '../shared/components/icons'
 
 export default {
   args: {},
@@ -37,7 +38,7 @@ const Template: Story<ContextMenuProps> = () => {
         }
       >
         <div>
-          <Icon width={15} icon={AllIcons.LINES} />
+          <Icon width={15} icon={Lines} />
         </div>
       </ContextMenu>
     </WebviewWrapper>

--- a/webview/src/stories/IconMenu.stories.tsx
+++ b/webview/src/stories/IconMenu.stories.tsx
@@ -6,22 +6,22 @@ import { SelectMenu } from '../shared/components/selectMenu/SelectMenu'
 
 import { IconMenu } from '../shared/components/iconMenu/IconMenu'
 import { IconMenuItemProps } from '../shared/components/iconMenu/IconMenuItem'
-import { AllIcons } from '../shared/components/Icon'
 import { WebviewWrapper } from '../shared/components/webviewWrapper/WebviewWrapper'
+import { Dots, DownArrow, Lines, UpArrow } from '../shared/components/icons'
 
 const items: IconMenuItemProps[] = [
   {
-    icon: AllIcons.DOWN_ARROW,
+    icon: DownArrow,
     onClick: () => alert('Move down'),
     tooltip: 'Move Down'
   },
   {
-    icon: AllIcons.UP_ARROW,
+    icon: UpArrow,
     onClick: () => alert('Move up'),
     tooltip: 'Move Up'
   },
   {
-    icon: AllIcons.LINES,
+    icon: Lines,
     onClickNode: (
       <SelectMenu
         options={[
@@ -47,7 +47,7 @@ const items: IconMenuItemProps[] = [
     tooltip: 'Choose metrics'
   },
   {
-    icon: AllIcons.DOTS,
+    icon: Dots,
     onClickNode: (
       <SelectMenu
         options={[


### PR DESCRIPTION
Initially, `AllIcons` was use for autocompletion of available icons. Not only it adds an extra step when creating a new icon, it simply duplicates `shared/components/icons/index.ts`
