### PR TITLE
Show DVC roots in tracked tree when there is more than one DVC project in the workspace

### DIFF
--- a/extension/src/fileSystem/tree.test.ts
+++ b/extension/src/fileSystem/tree.test.ts
@@ -82,23 +82,24 @@ describe('TrackedTreeView', () => {
       )
       trackedTreeView.initialize(mockedDvcRoots)
 
-      const getRootPathItem = (dvcRoot: string) => ({
-        dvcRoot,
-        isDirectory: true,
-        resourceUri: Uri.file(dvcRoot)
-      })
-
-      mockedGetChildren.mockImplementation(dvcRoot => [
-        getRootPathItem(dvcRoot)
-      ])
-
       const rootElements = await trackedTreeView.getChildren()
 
-      expect(rootElements).toStrictEqual(mockedDvcRoots.map(getRootPathItem))
-      expect(mockedGetRepository).toBeCalledTimes(2)
-      expect(mockedGetRepository).toBeCalledWith(dvcDemoPath)
-      expect(mockedGetRepository).toBeCalledWith(mockedOtherRoot)
-      expect(mockedGetChildren).toBeCalledTimes(2)
+      expect(rootElements).toStrictEqual([
+        {
+          dvcRoot: dvcDemoPath,
+          isDirectory: true,
+          isTracked: true,
+          resourceUri: Uri.file(dvcDemoPath)
+        },
+        {
+          dvcRoot: mockedOtherRoot,
+          isDirectory: true,
+          isTracked: true,
+          resourceUri: Uri.file(mockedOtherRoot)
+        }
+      ])
+      expect(mockedGetRepository).toBeCalledTimes(0)
+      expect(mockedGetChildren).toBeCalledTimes(0)
     })
 
     it('should return directories first in the list of root items', async () => {

--- a/extension/src/fileSystem/tree.ts
+++ b/extension/src/fileSystem/tree.ts
@@ -112,7 +112,7 @@ export class TrackedExplorerTree
     this.repositories.treeDataChanged.fire()
   }
 
-  private async getRootElements() {
+  private getRootElements() {
     if (!this.viewed) {
       sendViewOpenedTelemetryEvent(
         EventName.VIEWS_TRACKED_EXPLORER_TREE_OPENED,
@@ -126,11 +126,12 @@ export class TrackedExplorerTree
       return this.getRepoChildren(onlyRoot)
     }
 
-    const rootChildren = await Promise.all(
-      this.dvcRoots.map(dvcRoot => this.getRepoChildren(dvcRoot))
-    )
-
-    return rootChildren.flat()
+    return this.dvcRoots.map(dvcRoot => ({
+      dvcRoot,
+      isDirectory: true,
+      isTracked: true,
+      resourceUri: Uri.file(dvcRoot)
+    }))
   }
 
   private getDataPlaceholder({ fsPath }: { fsPath: string }): string {


### PR DESCRIPTION
# 1/2 `main` <- this <- #1952

Related to https://github.com/iterative/vscode-dvc/issues/1929

This fixes how the DVC-Tracked tree handles multiple DVC projects being in the workspace:

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/37993418/176059974-6cf39b0b-b31b-457d-a024-a1937e86073a.png">
