### PR TITLE
Show DVC root in tracked tree if there is only a single project nested inside of the workspace

### DIFF
--- a/extension/src/fileSystem/tree.ts
+++ b/extension/src/fileSystem/tree.ts
@@ -9,9 +9,10 @@ import {
   Uri
 } from 'vscode'
 import { exists, relativeWithUri } from '.'
+import { standardizePath } from './path'
 import { fireWatcher } from './watcher'
 import { deleteTarget, moveTargets } from './workspace'
-import { definedAndNonEmpty, uniqueValues } from '../util/array'
+import { definedAndNonEmpty, sameContents, uniqueValues } from '../util/array'
 import {
   AvailableCommands,
   CommandId,
@@ -35,6 +36,7 @@ import {
 import { Title } from '../vscode/title'
 import { Disposable } from '../class/dispose'
 import { createTreeView } from '../vscode/tree'
+import { getWorkspaceFolders } from '../vscode/workspaceFolders'
 
 export class TrackedExplorerTree
   extends Disposable
@@ -121,7 +123,13 @@ export class TrackedExplorerTree
       this.viewed = true
     }
 
-    if (this.dvcRoots.length === 1) {
+    if (
+      this.dvcRoots.length === 1 &&
+      sameContents(
+        getWorkspaceFolders(),
+        this.dvcRoots.map(dvcRoot => standardizePath(dvcRoot))
+      )
+    ) {
       const [onlyRoot] = this.dvcRoots
       return this.getRepoChildren(onlyRoot)
     }


### PR DESCRIPTION
# 2/2 `main` <- #1951 <- this

Closes https://github.com/iterative/vscode-dvc/issues/1929.

This PR changes the way that we show single nested DVC projects within the tracked tree. We will now show the root folder under these circumstances to more closely match the explorer tree:

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/37993418/176061650-e6e4986c-abe2-425e-a53c-a9151b26693a.png">
