### PR TITLE
Only pull selected files if they include the invoked path

### DIFF
--- a/extension/src/fileSystem/tree.ts
+++ b/extension/src/fileSystem/tree.ts
@@ -258,10 +258,7 @@ export class TrackedExplorerTree
 
   private tryThenForce(commandId: CommandId) {
     return async (pathItem: PathItem) => {
-      const selected = collectSelected([
-        ...this.getSelectedPathItems(),
-        pathItem
-      ])
+      const selected = collectSelected(pathItem, this.getSelectedPathItems())
 
       for (const [dvcRoot, pathItems] of Object.entries(selected)) {
         const tracked = []

--- a/extension/src/repository/model/collect.ts
+++ b/extension/src/repository/model/collect.ts
@@ -227,12 +227,26 @@ const collectRootOrPathItem = (
 }
 
 export const collectSelected = (
-  pathItems: (string | PathItem)[]
+  invokedPathItem: PathItem,
+  selectedPathItems: (string | PathItem)[]
 ): SelectedPathAccumulator => {
-  const selectedPaths = collectSelectedPaths(pathItems)
+  const invokedPath = invokedPathItem.resourceUri.fsPath
+
+  if (
+    !selectedPathItems.some(pathItem => {
+      if (typeof pathItem === 'string') {
+        return pathItem === invokedPath
+      }
+      return pathItem.resourceUri.fsPath === invokedPath
+    })
+  ) {
+    return { [invokedPathItem.dvcRoot]: [invokedPathItem] }
+  }
+
+  const selectedPaths = collectSelectedPaths(selectedPathItems)
   const acc: SelectedPathAccumulator = {}
   const addedPaths = new Set<string>()
-  for (const pathItem of pathItems) {
+  for (const pathItem of selectedPathItems) {
     collectRootOrPathItem(acc, addedPaths, selectedPaths, pathItem)
   }
   return acc


### PR DESCRIPTION
Closes #1939.

This PR addresses #1939 by using the same rules that the Explorer tree uses to invoke context menu actions when right-clicking with multiple items selected.

Details of the logic implemented are [here](https://github.com/iterative/vscode-dvc/issues/1939#issuecomment-1171794783).

### Demo

https://user-images.githubusercontent.com/37993418/176802682-c812d9d3-4f12-4183-b0be-8b5f24ba96d2.mov


