### PR TITLE
Fix checkbox selection issues

### DIFF
--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -842,6 +842,35 @@ describe('App', () => {
       const itemLabels = menuitems.map(item => item.textContent)
       expect(itemLabels).toContain('Star Experiments')
     })
+
+    it('should clear the row selection when the Escape key is pressed', () => {
+      render(<App />)
+
+      fireEvent(
+        window,
+        new MessageEvent('message', {
+          data: {
+            data: tableDataFixture,
+            type: MessageToWebviewType.SET_DATA
+          }
+        })
+      )
+
+      const firstRowCheckbox = within(getRow('4fb124a')).getByRole('checkbox')
+      fireEvent.click(firstRowCheckbox)
+
+      const tailRow = within(getRow('42b8736')).getByRole('checkbox')
+      fireEvent.click(tailRow, { shiftKey: true })
+
+      const selectedRows = () =>
+        screen.queryAllByRole('row', { selected: true })
+      expect(selectedRows().length).toBe(4)
+
+      fireEvent.keyUp(tailRow, { bubbles: true, key: 'Escape' })
+
+      jest.advanceTimersByTime(100)
+      expect(selectedRows().length).toBe(0)
+    })
   })
 
   describe('Star Experiments', () => {

--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -843,6 +843,42 @@ describe('App', () => {
       expect(itemLabels).toContain('Star Experiments')
     })
 
+    it('should not include collapsed experiments in the bulk selection', () => {
+      render(<App />)
+
+      fireEvent(
+        window,
+        new MessageEvent('message', {
+          data: {
+            data: {
+              ...tableDataFixture,
+              hasRunningExperiment: false
+            },
+            type: MessageToWebviewType.SET_DATA
+          }
+        })
+      )
+
+      const testBranchContractButton = within(getRow('42b8736')).getByTitle(
+        'Contract Row'
+      )
+      fireEvent.click(testBranchContractButton)
+
+      jest.advanceTimersByTime(100)
+      const firstRowCheckbox = within(getRow('4fb124a')).getByRole('checkbox')
+      fireEvent.click(firstRowCheckbox)
+
+      const tailRow = within(getRow('22e40e1')).getByRole('checkbox')
+      fireEvent.click(tailRow, { shiftKey: true })
+
+      fireEvent.click(testBranchContractButton)
+
+      jest.advanceTimersByTime(100)
+      expect(getRow('42b8736')).toHaveAttribute('aria-selected', 'true')
+      expect(getRow('2173124')).not.toHaveAttribute('aria-selected', 'true')
+      expect(getRow('9523bde')).not.toHaveAttribute('aria-selected', 'true')
+    })
+
     it('should present the Clear selected rows option when multiple rows are selected', () => {
       render(<App />)
 

--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -746,8 +746,8 @@ describe('App', () => {
       const menuitems = screen.getAllByRole('menuitem')
       const itemLabels = menuitems.map(item => item.textContent)
       expect(itemLabels).toStrictEqual([
-        'Modify and Resume',
         'Modify, Reset and Run',
+        'Modify and Resume',
         'Modify and Queue',
         'Star Experiment'
       ])

--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -843,6 +843,35 @@ describe('App', () => {
       expect(itemLabels).toContain('Star Experiments')
     })
 
+    it('should allow batch selection from the bottom up too', () => {
+      render(<App />)
+
+      fireEvent(
+        window,
+        new MessageEvent('message', {
+          data: {
+            data: {
+              ...tableDataFixture,
+              hasRunningExperiment: false
+            },
+            type: MessageToWebviewType.SET_DATA
+          }
+        })
+      )
+
+      const firstRowCheckbox = within(getRow('4fb124a')).getByRole('checkbox')
+      const tailRow = within(getRow('42b8736')).getByRole('checkbox')
+      fireEvent.click(tailRow)
+      fireEvent.click(firstRowCheckbox, { shiftKey: true })
+
+      const selectedRows = () => screen.getAllByRole('row', { selected: true })
+      expect(selectedRows()).toHaveLength(4)
+
+      const anotherRow = within(getRow('2173124')).getByRole('checkbox')
+      fireEvent.click(anotherRow, { shiftKey: true })
+      expect(selectedRows()).toHaveLength(5)
+    })
+
     it('should not include collapsed experiments in the bulk selection', () => {
       render(<App />)
 

--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -843,6 +843,43 @@ describe('App', () => {
       expect(itemLabels).toContain('Star Experiments')
     })
 
+    it('should present the Clear selected rows option when multiple rows are selected', () => {
+      render(<App />)
+
+      fireEvent(
+        window,
+        new MessageEvent('message', {
+          data: {
+            data: {
+              ...tableDataFixture,
+              hasRunningExperiment: false
+            },
+            type: MessageToWebviewType.SET_DATA
+          }
+        })
+      )
+
+      const firstRowCheckbox = within(getRow('4fb124a')).getByRole('checkbox')
+      fireEvent.click(firstRowCheckbox)
+
+      const tailRow = within(getRow('42b8736')).getByRole('checkbox')
+      fireEvent.click(tailRow, { shiftKey: true })
+
+      const selectedRows = () =>
+        screen.queryAllByRole('row', { selected: true })
+      expect(selectedRows().length).toBe(4)
+
+      const target = screen.getByText('4fb124a')
+      fireEvent.contextMenu(target, { bubbles: true })
+
+      jest.advanceTimersByTime(100)
+      const clearOption = screen.getByText('Clear row selection')
+      fireEvent.click(clearOption)
+
+      jest.advanceTimersByTime(100)
+      expect(selectedRows().length).toBe(0)
+    })
+
     it('should clear the row selection when the Escape key is pressed', () => {
       render(<App />)
 

--- a/webview/src/experiments/components/table/Row.tsx
+++ b/webview/src/experiments/components/table/Row.tsx
@@ -106,7 +106,7 @@ const getMultiSelectMenuOptions = (
   ]
 }
 
-const getWorkspaceOptions = (
+const getRunResumeOptions = (
   withId: (
     label: string,
     type: MessageFromWebviewType,
@@ -176,7 +176,7 @@ const getSingleSelectMenuOptions = (
       MessageFromWebviewType.CREATE_BRANCH_FROM_EXPERIMENT,
       hideApplyAndCreateBranch
     ),
-    ...getWorkspaceOptions(
+    ...getRunResumeOptions(
       withId,
       isWorkspace,
       projectHasCheckpoints,

--- a/webview/src/experiments/components/table/Row.tsx
+++ b/webview/src/experiments/components/table/Row.tsx
@@ -92,7 +92,13 @@ const getMultiSelectMenuOptions = (selectedRowsList: RowProp[]) => {
       MessageFromWebviewType.REMOVE_EXPERIMENT,
       hideRemoveOption,
       true
-    )
+    ),
+    {
+      divider: true,
+      id: 'clear-selection',
+      keyboardShortcut: 'Esc',
+      label: 'Clear row selection'
+    }
   ]
 }
 

--- a/webview/src/experiments/components/table/Row.tsx
+++ b/webview/src/experiments/components/table/Row.tsx
@@ -122,15 +122,15 @@ const getRunResumeOptions = (
 
   return [
     withId(
+      'Modify, Reset and Run',
+      MessageFromWebviewType.VARY_EXPERIMENT_PARAMS_RESET_AND_RUN,
+      !isNotCheckpoint || !projectHasCheckpoints
+    ),
+    withId(
       projectHasCheckpoints ? 'Modify and Resume' : 'Modify and Run',
       MessageFromWebviewType.VARY_EXPERIMENT_PARAMS_AND_RUN,
       !isNotCheckpoint,
       !hideVaryAndRun
-    ),
-    withId(
-      'Modify, Reset and Run',
-      MessageFromWebviewType.VARY_EXPERIMENT_PARAMS_RESET_AND_RUN,
-      !isNotCheckpoint || !projectHasCheckpoints
     ),
     withId(
       'Modify and Queue',

--- a/webview/src/experiments/components/table/Table.tsx
+++ b/webview/src/experiments/components/table/Table.tsx
@@ -161,7 +161,17 @@ export const Table: React.FC<TableProps & WithChanges> = ({
 
   return (
     <div className={styles.tableContainer}>
-      <div {...getTableProps({ className: styles.table })} ref={tableRef}>
+      <div
+        {...getTableProps({ className: styles.table })}
+        ref={tableRef}
+        tabIndex={0}
+        role="tree"
+        onKeyUp={e => {
+          if (e.key === 'Escape') {
+            clearSelectedRows?.()
+          }
+        }}
+      >
         <TableHead
           instance={instance}
           sorts={sorts}

--- a/webview/src/experiments/components/table/Table.tsx
+++ b/webview/src/experiments/components/table/Table.tsx
@@ -127,7 +127,7 @@ export const Table: React.FC<TableProps & WithChanges> = ({
     filteredCounts
   } = tableData
 
-  const { clearSelectedRows, batchSelection, selectedRows } =
+  const { clearSelectedRows, batchSelection, lastSelectedRow } =
     React.useContext(RowSelectionContext)
 
   const tableRef = useRef<HTMLDivElement>(null)
@@ -139,24 +139,22 @@ export const Table: React.FC<TableProps & WithChanges> = ({
   useClickOutside(tableRef, clickOutsideHandler)
 
   const batchRowSelection = React.useCallback(
-    ({ row: { flatIndex } }: RowProp) => {
-      const firstSelection = flatRows.find(
-        ({ values: { id } }) => selectedRows[id]
-      )
+    ({ row: { id } }: RowProp) => {
+      const lastSelectedRowId = lastSelectedRow?.row.id ?? ''
+      const lastIndex =
+        flatRows.findIndex(flatRow => flatRow.id === lastSelectedRowId) || 1
+      const selectedIndex =
+        flatRows.findIndex(flatRow => flatRow.id === id) || 1
+      const rangeStart = Math.min(lastIndex, selectedIndex)
+      const rangeEnd = Math.max(lastIndex, selectedIndex)
 
-      const firstIndex = firstSelection?.flatIndex || 1
+      const batch = flatRows
+        .slice(rangeStart, rangeEnd + 1)
+        .map(row => ({ row }))
 
-      if (flatIndex >= firstIndex) {
-        const batch = flatRows
-          .filter(
-            row => row.flatIndex > firstIndex && row.flatIndex <= flatIndex
-          )
-          .map(row => ({ row }))
-
-        batchSelection?.(batch)
-      }
+      batchSelection?.(batch)
     },
-    [selectedRows, flatRows, batchSelection]
+    [flatRows, batchSelection, lastSelectedRow]
   )
 
   return (

--- a/webview/src/experiments/components/table/Table.tsx
+++ b/webview/src/experiments/components/table/Table.tsx
@@ -14,6 +14,7 @@ export const NestedRow: React.FC<
   instance,
   contextMenuDisabled,
   projectHasCheckpoints,
+  hasRunningExperiment,
   batchRowSelection
 }) => {
   instance.prepareRow(row)
@@ -23,6 +24,7 @@ export const NestedRow: React.FC<
       className={styles.nestedRow}
       contextMenuDisabled={contextMenuDisabled}
       projectHasCheckpoints={projectHasCheckpoints}
+      hasRunningExperiment={hasRunningExperiment}
       batchRowSelection={batchRowSelection}
     />
   )
@@ -35,6 +37,7 @@ export const ExperimentGroup: React.FC<
   instance,
   contextMenuDisabled,
   projectHasCheckpoints,
+  hasRunningExperiment,
   batchRowSelection
 }) => {
   instance.prepareRow(row)
@@ -50,6 +53,7 @@ export const ExperimentGroup: React.FC<
         instance={instance}
         contextMenuDisabled={contextMenuDisabled}
         projectHasCheckpoints={projectHasCheckpoints}
+        hasRunningExperiment={hasRunningExperiment}
         batchRowSelection={batchRowSelection}
       />
       {row.isExpanded &&
@@ -60,6 +64,7 @@ export const ExperimentGroup: React.FC<
             key={row.id}
             contextMenuDisabled={contextMenuDisabled}
             projectHasCheckpoints={projectHasCheckpoints}
+            hasRunningExperiment={hasRunningExperiment}
             batchRowSelection={batchRowSelection}
           />
         ))}
@@ -75,6 +80,7 @@ export const TableBody: React.FC<
   changes,
   contextMenuDisabled,
   projectHasCheckpoints,
+  hasRunningExperiment,
   batchRowSelection
 }) => {
   instance.prepareRow(row)
@@ -93,6 +99,7 @@ export const TableBody: React.FC<
       <RowContent
         row={row}
         projectHasCheckpoints={projectHasCheckpoints}
+        hasRunningExperiment={hasRunningExperiment}
         changes={changes}
         contextMenuDisabled={contextMenuDisabled}
         batchRowSelection={batchRowSelection}
@@ -105,6 +112,7 @@ export const TableBody: React.FC<
             key={subRow.values.id}
             contextMenuDisabled={contextMenuDisabled}
             projectHasCheckpoints={projectHasCheckpoints}
+            hasRunningExperiment={hasRunningExperiment}
             batchRowSelection={batchRowSelection}
           />
         ))}
@@ -183,7 +191,7 @@ export const Table: React.FC<TableProps & WithChanges> = ({
             instance={instance}
             key={row.id}
             changes={changes}
-            contextMenuDisabled={hasRunningExperiment}
+            hasRunningExperiment={hasRunningExperiment}
             projectHasCheckpoints={hasCheckpoints}
             batchRowSelection={batchRowSelection}
           />

--- a/webview/src/experiments/components/table/Table.tsx
+++ b/webview/src/experiments/components/table/Table.tsx
@@ -156,8 +156,18 @@ export const Table: React.FC<TableProps & WithChanges> = ({
       const rangeStart = Math.min(lastIndex, selectedIndex)
       const rangeEnd = Math.max(lastIndex, selectedIndex)
 
+      const collapsedIds = flatRows
+        .filter(flatRow => !flatRow.isExpanded)
+        .map(flatRow => flatRow.id)
+
       const batch = flatRows
         .slice(rangeStart, rangeEnd + 1)
+        .filter(
+          flatRow =>
+            !collapsedIds.some(collapsedId =>
+              flatRow.id.startsWith(`${collapsedId}.`)
+            )
+        )
         .map(row => ({ row }))
 
       batchSelection?.(batch)

--- a/webview/src/experiments/components/table/interfaces.ts
+++ b/webview/src/experiments/components/table/interfaces.ts
@@ -16,6 +16,7 @@ export interface WithChanges {
 export interface RowProp {
   row: Row<Experiment>
   contextMenuDisabled?: boolean
+  hasRunningExperiment?: boolean
   projectHasCheckpoints?: boolean
 }
 

--- a/webview/src/shared/components/messagesMenu/MessagesMenuOption.tsx
+++ b/webview/src/shared/components/messagesMenu/MessagesMenuOption.tsx
@@ -7,16 +7,17 @@ import { sendMessage } from '../../vscode'
 export interface MessagesMenuOptionProps {
   id: string
   label: string
-  message: MessageFromWebview
+  message?: MessageFromWebview
   hidden?: boolean
   divider?: boolean
+  keyboardShortcut?: string
 }
 
 export const MessagesMenuOption: React.FC<
   MessagesMenuOptionProps & { onOptionSelected?: () => void }
-> = ({ label, message, divider, onOptionSelected }) => {
+> = ({ label, message, divider, onOptionSelected, keyboardShortcut }) => {
   const sendTheMessage = () => {
-    sendMessage(message)
+    !!message && sendMessage(message)
     onOptionSelected?.()
   }
 
@@ -44,6 +45,7 @@ export const MessagesMenuOption: React.FC<
         >
           {label}
         </div>
+        {keyboardShortcut && <div>{keyboardShortcut}</div>}
       </div>
     </>
   )


### PR DESCRIPTION
This PR will fix some issues with the current checkbox selection of rows in the experiments table.

It will also be possible to clear the selection with the Esc key.

https://user-images.githubusercontent.com/1231848/177400574-f2e60c2e-9ea4-4188-bb84-79024f489119.mov




### TODO

- [x] Remove the context-menu suppression when an experiment is running (apply rule per-option)
- [x] Only select the parent row if all of its children are selected