### PR TITLE
Fix plot colors

### DIFF
--- a/webview/src/plots/components/constants.ts
+++ b/webview/src/plots/components/constants.ts
@@ -15,10 +15,10 @@ const title = {
 export const config: Config = {
   axis: {
     domain: false,
-    domainColor: foregroundColor,
     gridColor: foregroundColor,
     gridOpacity: 0.25,
     tickColor: foregroundColor,
+    titleColor: foregroundColor,
     titlePadding: 15
   },
   background: backgroundColor,

--- a/webview/src/plots/components/constants.ts
+++ b/webview/src/plots/components/constants.ts
@@ -25,6 +25,9 @@ export const config: Config = {
 
   padding: 20,
   style: {
+    cell: {
+      stroke: foregroundColor
+    },
     'group-title': title,
     'guide-label': {
       fill: foregroundColor,

--- a/webview/src/plots/components/constants.ts
+++ b/webview/src/plots/components/constants.ts
@@ -1,12 +1,12 @@
 import { Config, FontWeight } from 'vega'
-import { getThemeValue, ThemeProperty } from '../../util/styles'
 
-const foregroundColor = getThemeValue(ThemeProperty.FOREGROUND_COLOR)
+const foregroundColor = 'var(--vscode-editor-foreground)'
 const backgroundColor = 'var(--vscode-editor-foreground-transparency-1)'
 const font = 'var(--vscode-editor-font-family)'
 const fontWeight = 'normal' as FontWeight
 
 const title = {
+  fill: foregroundColor,
   font,
   fontSize: 12,
   fontWeight
@@ -15,44 +15,26 @@ const title = {
 export const config: Config = {
   axis: {
     domain: false,
+    domainColor: foregroundColor,
     gridColor: foregroundColor,
     gridOpacity: 0.25,
-    labelAngle: 0,
     tickColor: foregroundColor,
-    titleColor: foregroundColor,
     titlePadding: 15
   },
   background: backgroundColor,
-  mark: {
-    stroke: foregroundColor
-  },
+
   padding: 20,
-  rule: {
-    stroke: foregroundColor
-  },
   style: {
-    cell: {
-      stroke: foregroundColor
-    },
-    'group-title': {
-      fill: foregroundColor,
-      stroke: foregroundColor,
-      ...title
-    },
+    'group-title': title,
     'guide-label': {
       fill: foregroundColor,
       font,
-      fontWeight,
-      stroke: foregroundColor
+      fontWeight
     },
-    'guide-title': {
-      fill: foregroundColor,
-      stroke: foregroundColor,
-      ...title
-    },
-    rule: {
-      fill: foregroundColor,
-      stroke: foregroundColor
-    }
+    'guide-title': title
+  },
+  title: {
+    color: foregroundColor,
+    subtitleColor: foregroundColor
   }
 }


### PR DESCRIPTION
Fixes #1957 

This PR changes our Vega embed config to be less aggressive. The general goal is allowing for the plot's original color to show through on internal parts, like the cells of a confusion matrix, while changing the color of labels that are laid over the transparent background to adapt to light/dark mode via CSS variables.

The new config was adapted from [vega's built in dark theme](https://github.com/vega/vega-themes/blob/next/src/theme-dark.ts), but with colors replaced with CSS variables and some of our old settings added back in.

![image](https://user-images.githubusercontent.com/9111807/177426220-9a632e9a-18a3-4fea-b0a2-1980b47b6c76.png)
![image](https://user-images.githubusercontent.com/9111807/177426281-e0385cb4-b258-4bc8-9c0c-b8e063385156.png)

Videos:

https://user-images.githubusercontent.com/9111807/177435467-8f7a1e1b-26cc-4772-bf17-0204c53e8532.mp4

https://user-images.githubusercontent.com/9111807/177435470-3bcd2953-957e-4534-b7c6-e03c36d0366e.mp4