### PR TITLE
Fix tooltip casting

### DIFF
--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -663,3 +663,7 @@ $badge-size: 0.85rem;
   vertical-align: middle;
   font-size: 0.5rem;
 }
+
+.cellTooltip {
+  padding: 2px 6px;
+}

--- a/webview/src/experiments/util/buildDynamicColumns.tsx
+++ b/webview/src/experiments/util/buildDynamicColumns.tsx
@@ -13,7 +13,6 @@ import Tooltip, {
   CELL_TOOLTIP_DELAY
 } from '../../shared/components/tooltip/Tooltip'
 import styles from '../components/table/styles.module.scss'
-import tooltipStyles from '../../shared/components/tooltip/styles.module.scss'
 import { CopyButton } from '../../shared/components/copyButton/CopyButton'
 import { OverflowHoverTooltip } from '../components/overflowHoverTooltip/OverflowHoverTooltip'
 const UndefinedCell = (
@@ -23,11 +22,11 @@ const UndefinedCell = (
 )
 
 const CellTooltip: React.FC<{
-  cell: Cell<Experiment, string | number>
-}> = ({ cell }) => {
-  const { value } = cell
+  stringValue: string
+}> = ({ stringValue }) => {
   return (
     <div
+      className={styles.cellTooltip}
       role="textbox"
       tabIndex={0}
       onClick={e => {
@@ -37,7 +36,7 @@ const CellTooltip: React.FC<{
         e.stopPropagation()
       }}
     >
-      {value}
+      {stringValue}
     </div>
   )
 }
@@ -57,8 +56,7 @@ const Cell: React.FC<Cell<Experiment, string | number>> = cell => {
 
   return (
     <Tooltip
-      className={tooltipStyles.padded}
-      content={<CellTooltip cell={cell} />}
+      content={<CellTooltip stringValue={stringValue} />}
       placement="bottom"
       arrow={true}
       delay={[CELL_TOOLTIP_DELAY, 0]}


### PR DESCRIPTION
Had a regression while adding `stopPropagation` to the tooltips where I forgot to re-add the `String` conversion.

I suppose this really emphasizes the need for regression tests. Also refactored things to be slightly more efficient.

https://user-images.githubusercontent.com/9111807/177436373-9a3ae893-d9fb-454b-a138-9848531c7ee2.mp4
