### PR TITLE
Add stability days to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
-  "extends": [
-    "config:base"
+  "extends": ["config:base"],
+  "packageRules": [
+    {
+      "stabilityDays": 7
+    }
   ]
 }


### PR DESCRIPTION
As stated [here](https://iterativeai.slack.com/archives/C01RB7BTG4C/p1657064018797609) we do not want/need to be on the bleeding edge of dependency updates.

Docs for this are [here](https://docs.renovatebot.com/configuration-options/#stabilitydays).