### PR TITLE
Show middle state badges for running, starred and checked sub-rows

### DIFF
--- a/webview/src/experiments/components/Experiments.tsx
+++ b/webview/src/experiments/components/Experiments.tsx
@@ -94,7 +94,8 @@ const getColumns = (columns: Column[]): TableColumn<Row>[] =>
       Header: ExperimentHeader,
       accessor: 'id',
       id: 'id',
-      width: 150
+      minWidth: 250,
+      width: 250
     },
     {
       Cell: ({ value }: { value: string }) => {

--- a/webview/src/experiments/components/table/Cell.tsx
+++ b/webview/src/experiments/components/table/Cell.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
 import cx from 'classnames'
 import { VSCodeCheckbox } from '@vscode/webview-ui-toolkit/react'
+import { Indicator, IndicatorWithJustTheCounter } from './Indicators'
 import styles from './styles.module.scss'
 import { CellProp, RowProp } from './interfaces'
 import ClockIcon from '../../../shared/components/icons/Clock'
 import { clickAndEnterProps } from '../../../util/props'
 import { StarFull, StarEmpty } from '../../../shared/components/icons'
+import { pluralize } from '../../../util/strings'
 
 const RowExpansionButton: React.FC<RowProp> = ({ row }) =>
   row.canExpand ? (
@@ -31,26 +33,114 @@ const RowExpansionButton: React.FC<RowProp> = ({ row }) =>
     <span className={styles.rowArrowContainer} />
   )
 
-export const FirstCell: React.FC<
-  CellProp & {
-    bulletColor?: string
-    isRowSelected: boolean
-    toggleExperiment: () => void
-    toggleRowSelection: () => void
-    toggleStarred: () => void
+export type RowActionsProps = {
+  isRowSelected: boolean
+  showSubRowStates: boolean
+  starred?: boolean
+  subRowStates: {
+    selections: number
+    stars: number
+    plotSelections: number
   }
-> = ({
-  cell,
-  bulletColor,
+  toggleRowSelection: () => void
+  toggleStarred: () => void
+}
+
+export type RowActionProps = {
+  showSubRowStates: boolean
+  subRowsAffected: number
+  actionAppliedLabel: string
+  children: React.ReactElement
+  hidden?: boolean
+  testId?: string
+}
+
+export const RowAction: React.FC<RowActionProps> = ({
+  showSubRowStates,
+  subRowsAffected,
+  actionAppliedLabel,
+  children,
+  hidden,
+  testId
+}) => {
+  const count = (showSubRowStates && subRowsAffected) || 0
+
+  return (
+    <div
+      className={cx(styles.rowActions, hidden && styles.hidden)}
+      data-testid={testId}
+    >
+      <Indicator
+        count={count}
+        tooltipContent={
+          count &&
+          `${count} ${pluralize('sub-row', count)} ${actionAppliedLabel}.`
+        }
+      >
+        {children}
+      </Indicator>
+    </div>
+  )
+}
+
+export const RowActions: React.FC<RowActionsProps> = ({
   isRowSelected,
-  toggleExperiment,
+  showSubRowStates,
+  starred,
+  subRowStates: { selections, stars },
   toggleRowSelection,
   toggleStarred
 }) => {
+  return (
+    <>
+      <RowAction
+        showSubRowStates={showSubRowStates}
+        subRowsAffected={selections}
+        actionAppliedLabel={'selected'}
+        testId={'row-action-checkbox'}
+      >
+        <VSCodeCheckbox
+          {...clickAndEnterProps(toggleRowSelection)}
+          checked={isRowSelected}
+        />
+      </RowAction>
+      <RowAction
+        showSubRowStates={showSubRowStates}
+        subRowsAffected={stars}
+        actionAppliedLabel={'starred'}
+        testId={'row-action-star'}
+      >
+        <div
+          className={styles.starSwitch}
+          role="switch"
+          aria-checked={starred}
+          tabIndex={0}
+          {...clickAndEnterProps(toggleStarred)}
+          data-testid="star-icon"
+        >
+          {starred && <StarFull />}
+          {!starred && <StarEmpty />}
+        </div>
+      </RowAction>
+    </>
+  )
+}
+
+export const FirstCell: React.FC<
+  CellProp &
+    RowActionsProps & {
+      bulletColor?: string
+      toggleExperiment: () => void
+    }
+> = ({ cell, bulletColor, toggleExperiment, ...rowActionsProps }) => {
   const { row, isPlaceholder } = cell
   const {
-    original: { starred, queued }
+    original: { queued }
   } = row
+
+  const {
+    subRowStates: { plotSelections }
+  } = rowActionsProps
 
   return (
     <div
@@ -63,29 +153,21 @@ export const FirstCell: React.FC<
       })}
     >
       <div className={styles.innerCell}>
-        <div className={styles.rowActions}>
-          <VSCodeCheckbox
-            {...clickAndEnterProps(toggleRowSelection)}
-            checked={isRowSelected}
-          />
-          <div
-            className={styles.starSwitch}
-            role="switch"
-            aria-checked={starred}
-            tabIndex={0}
-            {...clickAndEnterProps(toggleStarred)}
-            data-testid="star-icon"
-          >
-            {starred && <StarFull />}
-            {!starred && <StarEmpty />}
-          </div>
-        </div>
+        <RowActions {...rowActionsProps} />
         <RowExpansionButton row={row} />
         <span
           className={styles.bullet}
           style={{ color: bulletColor }}
           {...clickAndEnterProps(toggleExperiment)}
         >
+          <IndicatorWithJustTheCounter
+            aria-label={'Sub-rows selected for plots'}
+            count={plotSelections}
+            tooltipContent={`${plotSelections} ${pluralize(
+              'sub-row',
+              plotSelections
+            )} selected for plots.`}
+          />
           {queued && <ClockIcon />}
         </span>
         {isPlaceholder ? null : (

--- a/webview/src/experiments/components/table/Indicators.tsx
+++ b/webview/src/experiments/components/table/Indicators.tsx
@@ -44,9 +44,9 @@ export const CounterBadge: React.FC<CounterBadgeProps> = ({ count }) => {
     <span
       className={styles.indicatorCount}
       role={'marquee'}
-      aria-label={`${count ?? 0}`}
+      aria-label={`${count}`}
     >
-      {count ?? 0}
+      {count}
     </span>
   ) : null
 }

--- a/webview/src/experiments/components/table/Indicators.tsx
+++ b/webview/src/experiments/components/table/Indicators.tsx
@@ -3,6 +3,7 @@ import { SortDefinition } from 'dvc/src/experiments/model/sortBy'
 import cx from 'classnames'
 import { MessageFromWebviewType } from 'dvc/src/webview/contract'
 import { FilteredCounts } from 'dvc/src/experiments/model/filterBy/collect'
+import { TippyProps } from '@tippyjs/react'
 import styles from './styles.module.scss'
 import { Icon } from '../../../shared/components/Icon'
 import SvgSortPrecedence from '../../../shared/components/icons/SortPrecedence'
@@ -10,43 +11,88 @@ import SvgFilter from '../../../shared/components/icons/Filter'
 import { sendMessage } from '../../../shared/vscode'
 import Tooltip from '../../../shared/components/tooltip/Tooltip'
 import tooltipStyles from '../../../shared/components/tooltip/styles.module.scss'
+import { pluralize } from '../../../util/strings'
 
-const Indicator = ({
+export type IndicatorTooltipProps = Pick<TippyProps, 'children'> & {
+  tooltipContent: ReactNode
+}
+
+export const IndicatorTooltip: React.FC<IndicatorTooltipProps> = ({
+  children,
+  tooltipContent
+}) => {
+  const wrapperRef = React.useRef<HTMLDivElement>(null)
+  return (
+    <Tooltip
+      placement="bottom-start"
+      disabled={!tooltipContent}
+      content={tooltipContent}
+      className={tooltipStyles.padded}
+      ref={wrapperRef}
+    >
+      {children}
+    </Tooltip>
+  )
+}
+
+export type CounterBadgeProps = {
+  count?: number
+}
+
+export const CounterBadge: React.FC<CounterBadgeProps> = ({ count }) => {
+  return count ? (
+    <span
+      className={styles.indicatorCount}
+      role={'marquee'}
+      aria-label={`${count ?? 0}`}
+    >
+      {count ?? 0}
+    </span>
+  ) : null
+}
+
+export const Indicator = ({
   children,
   count,
   'aria-label': ariaLabel,
   tooltipContent,
   onClick
-}: {
-  children: ReactNode
-  count?: number
-  'aria-label'?: string
-  onClick?: MouseEventHandler
-  tooltipContent: ReactNode
-}) => (
-  <Tooltip
-    placement="bottom-start"
-    content={tooltipContent}
-    className={tooltipStyles.padded}
-  >
+}: IndicatorTooltipProps &
+  CounterBadgeProps & {
+    'aria-label'?: string
+    onClick?: MouseEventHandler
+  }) => (
+  <IndicatorTooltip tooltipContent={tooltipContent}>
     <button
       className={cx(styles.indicatorIcon, count && styles.indicatorWithCount)}
       aria-label={ariaLabel}
       onClick={onClick}
     >
       {children}
-      {count ? <span className={styles.indicatorCount}>{count}</span> : null}
+      <CounterBadge count={count} />
     </button>
-  </Tooltip>
+  </IndicatorTooltip>
+)
+
+export const IndicatorWithJustTheCounter = ({
+  count,
+  'aria-label': ariaLabel,
+  tooltipContent
+}: CounterBadgeProps &
+  IndicatorTooltipProps & {
+    'aria-label'?: string
+  }) => (
+  <IndicatorTooltip tooltipContent={tooltipContent}>
+    <span aria-label={ariaLabel}>
+      <CounterBadge count={count} />
+    </span>
+  </IndicatorTooltip>
 )
 
 const focusFiltersTree = () =>
   sendMessage({ type: MessageFromWebviewType.FOCUS_FILTERS_TREE })
 const focusSortsTree = () =>
   sendMessage({ type: MessageFromWebviewType.FOCUS_SORTS_TREE })
-
-const pluralize = (word: string, number: number | undefined) =>
-  number === 1 ? word : `${word}s`
 
 const formatCountMessage = (item: string, count: number | undefined) =>
   `${count || 'No'} ${pluralize(item, count)} Applied`

--- a/webview/src/experiments/components/table/Row.tsx
+++ b/webview/src/experiments/components/table/Row.tsx
@@ -322,9 +322,12 @@ export const RowContent: React.FC<
     cells: [firstCell, ...cells],
     original,
     flatIndex,
+    isExpanded,
+    subRows,
+    depth,
     values: { id }
   } = row
-  const { displayColor } = original
+  const { displayColor, starred } = original
   const isWorkspace = id === 'workspace'
   const changesIfWorkspace = isWorkspace ? changes : undefined
   const toggleExperiment = () => {
@@ -360,6 +363,21 @@ export const RowContent: React.FC<
     [row, toggleRowSelected, isWorkspace, batchRowSelection]
   )
 
+  const subRowStates = React.useMemo(() => {
+    const stars = subRows?.filter(subRow => subRow.original.starred).length ?? 0
+    const plotSelections =
+      subRows?.filter(subRow => subRow.original.selected).length ?? 0
+
+    const selections =
+      subRows?.filter(subRow => selectedRows[subRow.values.id]).length ?? 0
+
+    return {
+      plotSelections,
+      selections,
+      stars
+    }
+  }, [subRows, selectedRows])
+
   return (
     <ContextMenu
       disabled={contextMenuDisabled}
@@ -390,7 +408,10 @@ export const RowContent: React.FC<
         <FirstCell
           cell={firstCell}
           bulletColor={displayColor}
+          starred={starred}
           isRowSelected={isRowSelected}
+          showSubRowStates={!isExpanded && depth > 0}
+          subRowStates={subRowStates}
           toggleExperiment={toggleExperiment}
           toggleRowSelection={toggleRowSelection}
           toggleStarred={toggleStarred}

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -54,6 +54,10 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
   }
 }
 
+.hidden {
+  visibility: hidden;
+}
+
 .iconMenu {
   position: absolute;
   left: 0;
@@ -450,17 +454,55 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
         align-items: center;
         position: relative;
         left: -$cell-padding;
+        height: 100%;
 
         .starSwitch {
           display: inline-flex;
           align-items: center;
+          justify-content: center;
           width: 14px;
-          margin-left: 8px;
           opacity: 0.4;
           cursor: pointer;
 
           &[aria-checked='true'] {
             opacity: 1;
+          }
+        }
+
+        .indicatorIcon {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: 1.3rem;
+          height: 100%;
+          padding: 0;
+          margin: 0;
+        }
+
+        .indicatorCount {
+          z-index: 2;
+          &[title='0'] {
+            display: none;
+          }
+        }
+
+        .bullet {
+          flex: 0 0 14px;
+          width: 14px;
+          &.subRunsCount {
+            &::after {
+              border: none;
+            }
+            &::before {
+              margin: 0;
+              vertical-align: middle;
+              border: 1.5px solid $row-bg-color;
+              border-radius: 100%;
+              border-right: 1.5px solid currentColor;
+              border-top: 1.5px solid currentColor;
+              animation: spin 1s cubic-bezier(0.53, 0.21, 0.29, 0.67) infinite;
+              background-color: transparent;
+            }
           }
         }
       }
@@ -671,4 +713,27 @@ $badge-size: 0.85rem;
 
 .cellTooltip {
   padding: 2px 6px;
+}
+
+.indicatorCount {
+  &[aria-label='0'] {
+    display: none;
+  }
+}
+
+.experimentCell {
+  .innerCell {
+    .indicatorCount {
+      display: none;
+      .experimentGroup & {
+        display: block;
+        &[aria-label='0'] {
+          display: none;
+        }
+      }
+      .experimentGroup.expandedGroup & {
+        display: none;
+      }
+    }
+  }
 }

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -485,26 +485,6 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
             display: none;
           }
         }
-
-        .bullet {
-          flex: 0 0 14px;
-          width: 14px;
-          &.subRunsCount {
-            &::after {
-              border: none;
-            }
-            &::before {
-              margin: 0;
-              vertical-align: middle;
-              border: 1.5px solid $row-bg-color;
-              border-radius: 100%;
-              border-right: 1.5px solid currentColor;
-              border-top: 1.5px solid currentColor;
-              animation: spin 1s cubic-bezier(0.53, 0.21, 0.29, 0.67) infinite;
-              background-color: transparent;
-            }
-          }
-        }
       }
     }
   }

--- a/webview/src/shared/components/contextMenu/ContextMenu.tsx
+++ b/webview/src/shared/components/contextMenu/ContextMenu.tsx
@@ -61,6 +61,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
     content={content}
     onShow={onShow}
     disabled={!content || disabled}
+    appendTo={'parent'}
   >
     {children}
   </Tooltip>

--- a/webview/src/shared/components/tooltip/Tooltip.tsx
+++ b/webview/src/shared/components/tooltip/Tooltip.tsx
@@ -26,6 +26,7 @@ const TooltipRenderFunction: React.ForwardRefRenderFunction<
     onClickOutside,
     hideOnClick,
     onTrigger,
+    appendTo,
     animation = false,
     className = typeof content === 'string' ? styles.padded : undefined,
     arrow = false
@@ -34,7 +35,7 @@ const TooltipRenderFunction: React.ForwardRefRenderFunction<
 ) => (
   <Tippy
     animation={animation}
-    appendTo={'parent'}
+    appendTo={appendTo}
     content={content}
     className={className}
     placement={placement}

--- a/webview/src/stories/Table.stories.tsx
+++ b/webview/src/stories/Table.stories.tsx
@@ -18,6 +18,10 @@ import Experiments from '../experiments/components/Experiments'
 import './test-vscode-styles.scss'
 import '../shared/style.scss'
 import { CELL_TOOLTIP_DELAY } from '../shared/components/tooltip/Tooltip'
+import {
+  setExperimentsAsSelected,
+  setExperimentsAsStarred
+} from '../test/tableDataFixture'
 
 const tableData: TableData = {
   changes: workspaceChangesFixture,
@@ -35,9 +39,11 @@ const tableData: TableData = {
     ...row,
     subRows: row.subRows?.map(experiment => ({
       ...experiment,
+      starred: experiment.starred || experiment.label === '42b8736',
       subRows: experiment.subRows?.map(checkpoint => ({
         ...checkpoint,
-        running: checkpoint.running || checkpoint.label === '23250b3'
+        running: checkpoint.running || checkpoint.label === '23250b3',
+        starred: checkpoint.starred || checkpoint.label === '22e40e1'
       }))
     }))
   })),
@@ -67,6 +73,31 @@ const Template: ComponentStory<typeof Experiments> = ({ tableData }) => {
 }
 
 export const WithData = Template.bind({})
+
+export const WithMiddleStates = Template.bind({})
+const tableDataWithSomeSelectedExperiments = setExperimentsAsSelected(
+  tableData,
+  ['d1343a8', '91116c1', 'e821416']
+)
+WithMiddleStates.args = {
+  tableData: setExperimentsAsStarred(tableDataWithSomeSelectedExperiments, [
+    'd1343a8',
+    '9523bde',
+    'e821416'
+  ])
+}
+WithMiddleStates.play = async ({ canvasElement }) => {
+  await within(canvasElement).findByText('1ba7bcd')
+  let checkboxes = await within(canvasElement).findAllByRole('checkbox')
+  userEvent.click(checkboxes[10], { bubbles: true })
+  checkboxes = await within(canvasElement).findAllByRole('checkbox')
+  userEvent.click(checkboxes[11], { bubbles: true })
+  const collapseButtons = () =>
+    within(canvasElement).getAllByTitle('Contract Row')
+  userEvent.click(collapseButtons()[1])
+  userEvent.click(collapseButtons()[2])
+  userEvent.click(collapseButtons()[3])
+}
 
 export const WithNoRunningExperiments = Template.bind({})
 WithNoRunningExperiments.args = {

--- a/webview/src/test/tableDataFixture.ts
+++ b/webview/src/test/tableDataFixture.ts
@@ -1,0 +1,69 @@
+import { copyOriginalColors } from 'dvc/src/experiments/model/status/colors'
+import { Row, TableData } from 'dvc/src/experiments/webview/contract'
+
+const matchAndTransform = (
+  rows: Row[],
+  labelOrIds: string[],
+  transform: (source: Row) => Row
+): Row[] => {
+  return rows.map(parent => {
+    let newParent = parent
+
+    if (labelOrIds.includes(parent.id) || labelOrIds.includes(parent.label)) {
+      newParent = transform(parent)
+    }
+
+    return {
+      ...newParent,
+      subRows: matchAndTransform(newParent.subRows || [], labelOrIds, transform)
+    }
+  })
+}
+
+export const transformRows = (
+  fixture: TableData,
+  labelOrIds: string[],
+  transform: (source: Row) => Row
+) => {
+  const [workspace, main] = fixture.rows
+
+  const starredRows = [
+    workspace,
+    {
+      ...main,
+      subRows: matchAndTransform(main.subRows || [], labelOrIds, transform)
+    }
+  ]
+
+  return {
+    ...fixture,
+    rows: starredRows
+  } as TableData
+}
+
+export const setRowPropertyAsTrue =
+  (prop: keyof Row) => (fixture: TableData, labelOrIds: string[]) => {
+    return transformRows(fixture, labelOrIds, row => ({ ...row, [prop]: true }))
+  }
+
+export const setExperimentsAsStarred = setRowPropertyAsTrue('starred')
+
+export const setExperimentsAsSelected = (
+  fixture: TableData,
+  labelOrIds: string[]
+) => {
+  let colors = copyOriginalColors().reverse()
+  const nextColor = () => {
+    if (colors.length === 0) {
+      colors = copyOriginalColors().reverse()
+    }
+    return colors.pop()
+  }
+
+  return transformRows(fixture, labelOrIds, row => ({
+    ...row,
+    displayColor: nextColor(),
+    selected: true
+  }))
+}
+export const setExperimentsAsRunning = setRowPropertyAsTrue('running')

--- a/webview/src/util/strings.ts
+++ b/webview/src/util/strings.ts
@@ -1,2 +1,5 @@
 export const capitalize = (s: string) =>
   s[0].toUpperCase() + s.slice(1).toLowerCase()
+
+export const pluralize = (word: string, number: number | undefined) =>
+  number === 1 ? word : `${word}s`


### PR DESCRIPTION
This PR will introduce indicators for the state of sub-rows in the experiments table.

There will an indicator for selected, starred and running sub-rows.

See https://github.com/iterative/vscode-dvc/issues/1714 for context on the issue.

https://user-images.githubusercontent.com/1231848/179523374-1acbe6c8-d3e4-43c0-8c5e-6e82aecb8334.mov


