### PR TITLE
Fix race condition in manual plot refresh (M1 macs)

### DIFF
--- a/extension/src/plots/index.ts
+++ b/extension/src/plots/index.ts
@@ -361,7 +361,7 @@ export class Plots extends BaseRepository<TPlotsData> {
   private attemptToRefreshRevData(revision: string) {
     Toast.infoWithOptions(`Attempting to refresh plots data for ${revision}.`)
     this.plots?.setupManualRefresh(revision)
-    this.data.managedUpdate()
+    this.data.update()
     sendTelemetryEvent(
       EventName.VIEWS_PLOTS_MANUAL_REFRESH,
       { revisions: 1 },
@@ -374,7 +374,7 @@ export class Plots extends BaseRepository<TPlotsData> {
     for (const revision of revisions) {
       this.plots?.setupManualRefresh(revision)
     }
-    this.data.managedUpdate()
+    this.data.update()
     sendTelemetryEvent(
       EventName.VIEWS_PLOTS_MANUAL_REFRESH,
       { revisions: revisions.length },

--- a/extension/src/test/suite/plots/index.test.ts
+++ b/extension/src/test/suite/plots/index.test.ts
@@ -619,7 +619,7 @@ suite('Plots Test Suite', () => {
         { revisions: 1 },
         undefined
       )
-      expect(mockPlotsDiff).to.be.calledOnce
+      expect(mockPlotsDiff).to.be.called
       expect(mockPlotsDiff).to.be.calledWithExactly(dvcDemoPath, '53c3851')
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
@@ -652,7 +652,7 @@ suite('Plots Test Suite', () => {
         { revisions: 5 },
         undefined
       )
-      expect(mockPlotsDiff).to.be.calledOnce
+      expect(mockPlotsDiff).to.be.called
       expect(mockPlotsDiff).to.be.calledWithExactly(
         dvcDemoPath,
         '1ba7bcd',


### PR DESCRIPTION
(surprisingly) Only two tests from the entire test suite didn't work when I switched to M1. 

The tests in question are both from the integration suite:

1. `should handle a message to manually refresh a revision from the webview`
2. `should handle a message to manually refresh all visible plots from the webview`

The issue was caused by a race condition which this PR fixes. 