### PR TITLE
Add end to end test for SCM and file decorations

### DIFF
--- a/extension/src/repository/decorationProvider.ts
+++ b/extension/src/repository/decorationProvider.ts
@@ -63,7 +63,7 @@ export class DecorationProvider
   private static DecorationGitModified: FileDecoration = {
     badge: 'M',
     color: new ThemeColor('gitDecoration.stageModifiedResourceForeground'),
-    tooltip: 'DVC tracked'
+    tooltip: 'DVC modified'
   }
 
   private static DecorationTracked: FileDecoration = {

--- a/extension/src/test/e2e/extension.test.ts
+++ b/extension/src/test/e2e/extension.test.ts
@@ -125,8 +125,6 @@ suite('DVC Extension For Visual Studio Code', () => {
   // eslint-disable-next-line sonarjs/cognitive-complexity
   describe('Source Control View', () => {
     it('should show the expected changes after running an experiment', async () => {
-      const treeItems = await findScmTreeItems()
-
       const expectedScmItemLabels = [
         'demo DVC',
         'training_metrics',
@@ -140,6 +138,7 @@ suite('DVC Extension For Visual Studio Code', () => {
       await browser.waitUntil(
         async () => {
           dvcTreeItemLabels = []
+          const treeItems = await findScmTreeItems()
           for (const treeItem of treeItems) {
             const treeItemLabel = await getLabel(treeItem)
             if (!expectedScmSet.has(treeItemLabel)) {

--- a/extension/src/test/e2e/extension.test.ts
+++ b/extension/src/test/e2e/extension.test.ts
@@ -163,6 +163,6 @@ suite('DVC Extension For Visual Studio Code', () => {
       expect(expectedScmItemLabels.sort()).toStrictEqual(
         dvcTreeItemLabels.sort()
       )
-    }).timeout(60000)
+    })
   })
 })

--- a/extension/src/test/e2e/extension.test.ts
+++ b/extension/src/test/e2e/extension.test.ts
@@ -1,8 +1,12 @@
+import { join } from 'path'
 import { suite, before, describe, it } from 'mocha'
 import {
   closeAllEditors,
   dismissAllNotifications,
+  findDecorationTooltip,
+  findScmTreeItems,
   getDVCActivityBarIcon,
+  getLabel,
   waitForDvcToFinish,
   waitForViewContainerToLoad
 } from './util'
@@ -116,5 +120,50 @@ suite('DVC Extension For Visual Studio Code', () => {
 
       await webview.unfocus()
     })
+  })
+
+  // eslint-disable-next-line sonarjs/cognitive-complexity
+  describe('Source Control View', () => {
+    it('should show the expected changes after running an experiment', async () => {
+      const treeItems = await findScmTreeItems()
+
+      const expectedScmItemLabels = [
+        'demo DVC',
+        'training_metrics',
+        'scalars, training_metrics',
+        `acc.tsv, ${join('training_metrics', 'scalars')}`,
+        `loss.tsv, ${join('training_metrics', 'scalars')}`
+      ]
+      const expectedScmSet = new Set(expectedScmItemLabels)
+      let dvcTreeItemLabels: string[] = []
+
+      await browser.waitUntil(
+        async () => {
+          dvcTreeItemLabels = []
+          for (const treeItem of treeItems) {
+            const treeItemLabel = await getLabel(treeItem)
+            if (!expectedScmSet.has(treeItemLabel)) {
+              continue
+            }
+            dvcTreeItemLabels.push(treeItemLabel)
+            if (treeItemLabel === 'demo DVC') {
+              continue
+            }
+
+            const tooltip = await findDecorationTooltip(treeItem)
+            expect(tooltip).toBeTruthy()
+          }
+          return expectedScmItemLabels.length === dvcTreeItemLabels.length
+        },
+        {
+          interval: 5000,
+          timeout: 60000
+        }
+      )
+
+      expect(expectedScmItemLabels.sort()).toStrictEqual(
+        dvcTreeItemLabels.sort()
+      )
+    }).timeout(60000)
   })
 })

--- a/extension/src/test/e2e/util.ts
+++ b/extension/src/test/e2e/util.ts
@@ -1,8 +1,23 @@
-import { ChainablePromiseArray, ElementArray } from 'webdriverio'
+import {
+  ChainablePromiseArray,
+  ChainablePromiseElement,
+  ElementArray
+} from 'webdriverio'
 import { ViewControl } from 'wdio-vscode-service'
 
 const findProgressBars = (): ChainablePromiseArray<ElementArray> =>
   $$('.monaco-progress-container')
+
+const findCurrentTreeItems = (): ChainablePromiseArray<ElementArray> =>
+  $$('div[role="treeitem"]')
+
+export const getLabel = (element: WebdriverIO.Element): Promise<string> =>
+  element.getAttribute('aria-label')
+
+export const findDecorationTooltip = (
+  element: WebdriverIO.Element
+): ChainablePromiseElement<WebdriverIO.Element> =>
+  element.$('div[title*="• DVC modified"]')
 
 export const dismissAllNotifications = async (): Promise<void> => {
   await browser.waitUntil(async () => {
@@ -95,4 +110,14 @@ export const closeAllEditors = async (): Promise<void> => {
   const workbench = await browser.getWorkbench()
   const editorView = workbench.getEditorView()
   return editorView.closeAllEditors()
+}
+
+export const findScmTreeItems = async () => {
+  const workspace = await browser.getWorkbench()
+  const activityBar = workspace.getActivityBar()
+  const sourceControlIcon = await activityBar.getViewControl('Source Control')
+
+  await sourceControlIcon?.openView()
+
+  return findCurrentTreeItems()
 }


### PR DESCRIPTION
# 2/2 `main` <- #2002 <- this

This PR adds an end to end test for the SCM view and our custom file decorations.
