### PR TITLE
Increase timeout of scheduled CLI test

### DIFF
--- a/extension/src/test/cli/index.ts
+++ b/extension/src/test/cli/index.ts
@@ -28,7 +28,7 @@ async function main() {
       () => {
         removeDir(TEMP_DIR)
       },
-      20000
+      30000
     )
   } catch {
     process.exit(1)


### PR DESCRIPTION
In response to https://github.com/iterative/vscode-dvc/actions/workflows/dvc-cli-output-test.yml (tests pass locally).