### PR TITLE
Remove webview message handling from plots

### DIFF
--- a/extension/src/plots/index.ts
+++ b/extension/src/plots/index.ts
@@ -243,13 +243,13 @@ export class Plots extends BaseRepository<TPlotsData> {
     const webviewMessages = new WebviewMessages(
       paths,
       plots,
-      this.data,
       experiments,
       () => this.sendSectionCollapsed(),
       () => this.sendTemplatePlots(),
       () => this.sendComparisonPlots(),
       () => this.sendCheckpointPlotsData(),
-      () => this.selectPlots()
+      () => this.selectPlots(),
+      () => this.data.update()
     )
     this.dispose.track(
       this.onDidReceivedWebviewMessage(message =>

--- a/extension/src/plots/index.ts
+++ b/extension/src/plots/index.ts
@@ -5,10 +5,9 @@ import {
   ComparisonPlot,
   ComparisonRevisionData,
   PlotsData as TPlotsData,
-  PlotSize,
-  Section,
-  SectionCollapsed
+  Section
 } from './webview/contract'
+import { WebviewMessages } from './webview/messages'
 import { PlotsData } from './data'
 import { PlotsModel } from './model'
 import { collectScale } from './paths/collect'
@@ -19,16 +18,9 @@ import { BaseRepository } from '../webview/repository'
 import { Experiments } from '../experiments'
 import { Resource } from '../resourceLocator'
 import { InternalCommands } from '../commands/internal'
-import {
-  MessageFromWebviewType,
-  PlotsTemplatesReordered
-} from '../webview/contract'
-import { Logger } from '../common/logger'
 import { definedAndNonEmpty } from '../util/array'
 import { ExperimentsOutput, TEMP_PLOTS_DIR } from '../cli/reader'
 import { getModifiedTime, removeDir } from '../fileSystem'
-import { sendTelemetryEvent } from '../telemetry'
-import { EventName } from '../telemetry/constants'
 import { Toast } from '../vscode/toast'
 import { pickPaths } from '../path/selection/quickPick'
 
@@ -75,8 +67,6 @@ export class Plots extends BaseRepository<TPlotsData> {
 
     this.ensureTempDirRemoved()
 
-    this.handleMessageFromWebview()
-
     this.workspaceState = workspaceState
 
     this.onDidChangePaths = this.pathsChanged.event
@@ -91,6 +81,8 @@ export class Plots extends BaseRepository<TPlotsData> {
     this.paths = this.dispose.track(
       new PathsModel(this.dvcRoot, this.workspaceState)
     )
+
+    this.handleMessageFromWebview(this.paths, this.plots, this.experiments)
 
     this.data.setModel(this.plots)
 
@@ -243,152 +235,46 @@ export class Plots extends BaseRepository<TPlotsData> {
     }
   }
 
-  private handleMessageFromWebview() {
+  private handleMessageFromWebview(
+    paths: PathsModel,
+    plots: PlotsModel,
+    experiments: Experiments
+  ) {
+    const webviewMessages = new WebviewMessages(
+      paths,
+      plots,
+      this.data,
+      experiments,
+      () => this.sendSectionCollapsed(),
+      () => this.sendTemplatePlots(),
+      () => this.sendComparisonPlots(),
+      () => this.sendCheckpointPlotsData(),
+      () => this.selectPlots()
+    )
     this.dispose.track(
-      this.onDidReceivedWebviewMessage(message => {
-        switch (message.type) {
-          case MessageFromWebviewType.TOGGLE_METRIC:
-            return this.setSelectedMetrics(message.payload)
-          case MessageFromWebviewType.RESIZE_PLOTS:
-            return this.setPlotSize(
-              message.payload.section,
-              message.payload.size
-            )
-          case MessageFromWebviewType.TOGGLE_PLOTS_SECTION:
-            return this.setSectionCollapsed(message.payload)
-          case MessageFromWebviewType.REORDER_PLOTS_COMPARISON:
-            return this.setComparisonOrder(message.payload)
-          case MessageFromWebviewType.REORDER_PLOTS_TEMPLATES:
-            return this.setTemplateOrder(message.payload)
-          case MessageFromWebviewType.REORDER_PLOTS_METRICS:
-            return this.setMetricOrder(message.payload)
-          case MessageFromWebviewType.SELECT_PLOTS:
-            return this.selectPlotsFromWebview()
-          case MessageFromWebviewType.SELECT_EXPERIMENTS:
-            return this.selectExperimentsFromWebview()
-          case MessageFromWebviewType.REFRESH_REVISION:
-            return this.attemptToRefreshRevData(message.payload)
-          case MessageFromWebviewType.REFRESH_REVISIONS:
-            return this.attemptToRefreshSelectedData(message.payload)
-          case MessageFromWebviewType.TOGGLE_EXPERIMENT:
-            return this.setExperimentStatus(message.payload)
-          default:
-            Logger.error(`Unexpected message: ${JSON.stringify(message)}`)
-        }
-      })
+      this.onDidReceivedWebviewMessage(message =>
+        webviewMessages.handleMessageFromWebview(message)
+      )
     )
   }
 
-  private setSelectedMetrics(metrics: string[]) {
-    this.plots?.setSelectedMetrics(metrics)
-    this.sendCheckpointPlotsAndEvent(EventName.VIEWS_PLOTS_METRICS_SELECTED)
-  }
-
-  private setPlotSize(section: Section, size: PlotSize) {
-    this.plots?.setPlotSize(section, size)
-    sendTelemetryEvent(
-      EventName.VIEWS_PLOTS_SECTION_RESIZED,
-      { section, size },
-      undefined
-    )
-  }
-
-  private setSectionCollapsed(collapsed: Partial<SectionCollapsed>) {
-    this.plots?.setSectionCollapsed(collapsed)
+  private sendSectionCollapsed() {
     this.webview?.show({
       sectionCollapsed: this.plots?.getSectionCollapsed()
     })
-    sendTelemetryEvent(
-      EventName.VIEWS_PLOTS_SECTION_TOGGLE,
-      collapsed,
-      undefined
-    )
   }
 
-  private setComparisonOrder(order: string[]) {
-    this.plots?.setComparisonOrder(order)
+  private sendComparisonPlots() {
     this.webview?.show({
       comparison: this.getComparisonPlots(),
       selectedRevisions: this.plots?.getSelectedRevisionDetails()
     })
-    sendTelemetryEvent(
-      EventName.VIEWS_PLOTS_REVISIONS_REORDERED,
-      undefined,
-      undefined
-    )
   }
 
-  private setTemplateOrder(order: PlotsTemplatesReordered) {
-    this.paths?.setTemplateOrder(order)
+  private sendTemplatePlots() {
     this.webview?.show({
       template: this.getTemplatePlots()
     })
-    sendTelemetryEvent(
-      EventName.VIEWS_REORDER_PLOTS_TEMPLATES,
-      undefined,
-      undefined
-    )
-  }
-
-  private setMetricOrder(order: string[]) {
-    this.plots?.setMetricOrder(order)
-    this.sendCheckpointPlotsAndEvent(EventName.VIEWS_REORDER_PLOTS_METRICS)
-  }
-
-  private selectPlotsFromWebview() {
-    this.selectPlots()
-    sendTelemetryEvent(EventName.VIEWS_PLOTS_SELECT_PLOTS, undefined, undefined)
-  }
-
-  private selectExperimentsFromWebview() {
-    this.experiments?.selectExperiments()
-    sendTelemetryEvent(
-      EventName.VIEWS_PLOTS_SELECT_EXPERIMENTS,
-      undefined,
-      undefined
-    )
-  }
-
-  private setExperimentStatus(id: string) {
-    this.experiments?.toggleExperimentStatus(id)
-    sendTelemetryEvent(
-      EventName.VIEWS_PLOTS_EXPERIMENT_TOGGLE,
-      undefined,
-      undefined
-    )
-  }
-
-  private attemptToRefreshRevData(revision: string) {
-    Toast.infoWithOptions(`Attempting to refresh plots data for ${revision}.`)
-    this.plots?.setupManualRefresh(revision)
-    this.data.update()
-    sendTelemetryEvent(
-      EventName.VIEWS_PLOTS_MANUAL_REFRESH,
-      { revisions: 1 },
-      undefined
-    )
-  }
-
-  private attemptToRefreshSelectedData(revisions: string[]) {
-    Toast.infoWithOptions('Attempting to refresh visible plots data.')
-    for (const revision of revisions) {
-      this.plots?.setupManualRefresh(revision)
-    }
-    this.data.update()
-    sendTelemetryEvent(
-      EventName.VIEWS_PLOTS_MANUAL_REFRESH,
-      { revisions: revisions.length },
-      undefined
-    )
-  }
-
-  private sendCheckpointPlotsAndEvent(
-    event:
-      | typeof EventName.VIEWS_REORDER_PLOTS_METRICS
-      | typeof EventName.VIEWS_PLOTS_METRICS_SELECTED
-  ) {
-    this.sendCheckpointPlotsData()
-    sendTelemetryEvent(event, undefined, undefined)
   }
 
   private waitForInitialData(experiments: Experiments) {

--- a/extension/src/plots/webview/messages.ts
+++ b/extension/src/plots/webview/messages.ts
@@ -1,0 +1,183 @@
+import { PlotSize, Section, SectionCollapsed } from './contract'
+import { Logger } from '../../common/logger'
+import { Experiments } from '../../experiments'
+import { sendTelemetryEvent } from '../../telemetry'
+import { EventName } from '../../telemetry/constants'
+import { Toast } from '../../vscode/toast'
+import {
+  MessageFromWebview,
+  MessageFromWebviewType,
+  PlotsTemplatesReordered
+} from '../../webview/contract'
+import { PlotsModel } from '../model'
+import { PathsModel } from '../paths/model'
+import { PlotsData } from '../data'
+
+export class WebviewMessages {
+  private readonly paths: PathsModel
+  private readonly plots: PlotsModel
+  private readonly data: PlotsData
+  private readonly experiments: Experiments
+
+  private readonly sendSectionCollapsed: () => void
+  private readonly sendTemplatePlots: () => void
+  private readonly sendComparisonPlots: () => void
+  private readonly sendCheckpointPlotsData: () => void
+  private readonly selectPlots: () => void
+
+  constructor(
+    paths: PathsModel,
+    plots: PlotsModel,
+    data: PlotsData,
+    experiments: Experiments,
+    sendSectionCollapsed: () => void,
+    sendTemplatePlots: () => void,
+    sendComparisonPlots: () => void,
+    sendCheckpointPlotsData: () => void,
+    selectPlots: () => void
+  ) {
+    this.paths = paths
+    this.plots = plots
+    this.data = data
+    this.experiments = experiments
+    this.sendSectionCollapsed = sendSectionCollapsed
+    this.sendTemplatePlots = sendTemplatePlots
+    this.sendComparisonPlots = sendComparisonPlots
+    this.sendCheckpointPlotsData = sendCheckpointPlotsData
+    this.selectPlots = selectPlots
+  }
+
+  public handleMessageFromWebview(message: MessageFromWebview) {
+    switch (message.type) {
+      case MessageFromWebviewType.TOGGLE_METRIC:
+        return this.setSelectedMetrics(message.payload)
+      case MessageFromWebviewType.RESIZE_PLOTS:
+        return this.setPlotSize(message.payload.section, message.payload.size)
+      case MessageFromWebviewType.TOGGLE_PLOTS_SECTION:
+        return this.setSectionCollapsed(message.payload)
+      case MessageFromWebviewType.REORDER_PLOTS_COMPARISON:
+        return this.setComparisonOrder(message.payload)
+      case MessageFromWebviewType.REORDER_PLOTS_TEMPLATES:
+        return this.setTemplateOrder(message.payload)
+      case MessageFromWebviewType.REORDER_PLOTS_METRICS:
+        return this.setMetricOrder(message.payload)
+      case MessageFromWebviewType.SELECT_PLOTS:
+        return this.selectPlotsFromWebview()
+      case MessageFromWebviewType.SELECT_EXPERIMENTS:
+        return this.selectExperimentsFromWebview()
+      case MessageFromWebviewType.REFRESH_REVISION:
+        return this.attemptToRefreshRevData(message.payload)
+      case MessageFromWebviewType.REFRESH_REVISIONS:
+        return this.attemptToRefreshSelectedData(message.payload)
+      case MessageFromWebviewType.TOGGLE_EXPERIMENT:
+        return this.setExperimentStatus(message.payload)
+      default:
+        Logger.error(`Unexpected message: ${JSON.stringify(message)}`)
+    }
+  }
+
+  private setSelectedMetrics(metrics: string[]) {
+    this.plots?.setSelectedMetrics(metrics)
+    this.sendCheckpointPlotsAndEvent(EventName.VIEWS_PLOTS_METRICS_SELECTED)
+  }
+
+  private setPlotSize(section: Section, size: PlotSize) {
+    this.plots?.setPlotSize(section, size)
+    sendTelemetryEvent(
+      EventName.VIEWS_PLOTS_SECTION_RESIZED,
+      { section, size },
+      undefined
+    )
+  }
+
+  private setSectionCollapsed(collapsed: Partial<SectionCollapsed>) {
+    this.plots?.setSectionCollapsed(collapsed)
+    this.sendSectionCollapsed()
+    sendTelemetryEvent(
+      EventName.VIEWS_PLOTS_SECTION_TOGGLE,
+      collapsed,
+      undefined
+    )
+  }
+
+  private setComparisonOrder(order: string[]) {
+    this.plots.setComparisonOrder(order)
+    this.sendComparisonPlots()
+    sendTelemetryEvent(
+      EventName.VIEWS_PLOTS_REVISIONS_REORDERED,
+      undefined,
+      undefined
+    )
+  }
+
+  private setTemplateOrder(order: PlotsTemplatesReordered) {
+    this.paths.setTemplateOrder(order)
+    this.sendTemplatePlots()
+    sendTelemetryEvent(
+      EventName.VIEWS_REORDER_PLOTS_TEMPLATES,
+      undefined,
+      undefined
+    )
+  }
+
+  private setMetricOrder(order: string[]) {
+    this.plots.setMetricOrder(order)
+    this.sendCheckpointPlotsAndEvent(EventName.VIEWS_REORDER_PLOTS_METRICS)
+  }
+
+  private selectPlotsFromWebview() {
+    this.selectPlots()
+    sendTelemetryEvent(EventName.VIEWS_PLOTS_SELECT_PLOTS, undefined, undefined)
+  }
+
+  private selectExperimentsFromWebview() {
+    this.experiments?.selectExperiments()
+    sendTelemetryEvent(
+      EventName.VIEWS_PLOTS_SELECT_EXPERIMENTS,
+      undefined,
+      undefined
+    )
+  }
+
+  private setExperimentStatus(id: string) {
+    this.experiments?.toggleExperimentStatus(id)
+    sendTelemetryEvent(
+      EventName.VIEWS_PLOTS_EXPERIMENT_TOGGLE,
+      undefined,
+      undefined
+    )
+  }
+
+  private attemptToRefreshRevData(revision: string) {
+    Toast.infoWithOptions(`Attempting to refresh plots data for ${revision}.`)
+    this.plots?.setupManualRefresh(revision)
+    this.data.update()
+    sendTelemetryEvent(
+      EventName.VIEWS_PLOTS_MANUAL_REFRESH,
+      { revisions: 1 },
+      undefined
+    )
+  }
+
+  private attemptToRefreshSelectedData(revisions: string[]) {
+    Toast.infoWithOptions('Attempting to refresh visible plots data.')
+    for (const revision of revisions) {
+      this.plots?.setupManualRefresh(revision)
+    }
+    this.data.update()
+    sendTelemetryEvent(
+      EventName.VIEWS_PLOTS_MANUAL_REFRESH,
+      { revisions: revisions.length },
+      undefined
+    )
+  }
+
+  private sendCheckpointPlotsAndEvent(
+    event:
+      | typeof EventName.VIEWS_REORDER_PLOTS_METRICS
+      | typeof EventName.VIEWS_PLOTS_METRICS_SELECTED
+  ) {
+    this.sendCheckpointPlotsData()
+    sendTelemetryEvent(event, undefined, undefined)
+  }
+}

--- a/extension/src/plots/webview/messages.ts
+++ b/extension/src/plots/webview/messages.ts
@@ -11,12 +11,10 @@ import {
 } from '../../webview/contract'
 import { PlotsModel } from '../model'
 import { PathsModel } from '../paths/model'
-import { PlotsData } from '../data'
 
 export class WebviewMessages {
   private readonly paths: PathsModel
   private readonly plots: PlotsModel
-  private readonly data: PlotsData
   private readonly experiments: Experiments
 
   private readonly sendSectionCollapsed: () => void
@@ -24,27 +22,28 @@ export class WebviewMessages {
   private readonly sendComparisonPlots: () => void
   private readonly sendCheckpointPlotsData: () => void
   private readonly selectPlots: () => void
+  private readonly updateData: () => void
 
   constructor(
     paths: PathsModel,
     plots: PlotsModel,
-    data: PlotsData,
     experiments: Experiments,
     sendSectionCollapsed: () => void,
     sendTemplatePlots: () => void,
     sendComparisonPlots: () => void,
     sendCheckpointPlotsData: () => void,
-    selectPlots: () => void
+    selectPlots: () => void,
+    updateData: () => void
   ) {
     this.paths = paths
     this.plots = plots
-    this.data = data
     this.experiments = experiments
     this.sendSectionCollapsed = sendSectionCollapsed
     this.sendTemplatePlots = sendTemplatePlots
     this.sendComparisonPlots = sendComparisonPlots
     this.sendCheckpointPlotsData = sendCheckpointPlotsData
     this.selectPlots = selectPlots
+    this.updateData = updateData
   }
 
   public handleMessageFromWebview(message: MessageFromWebview) {
@@ -77,12 +76,12 @@ export class WebviewMessages {
   }
 
   private setSelectedMetrics(metrics: string[]) {
-    this.plots?.setSelectedMetrics(metrics)
+    this.plots.setSelectedMetrics(metrics)
     this.sendCheckpointPlotsAndEvent(EventName.VIEWS_PLOTS_METRICS_SELECTED)
   }
 
   private setPlotSize(section: Section, size: PlotSize) {
-    this.plots?.setPlotSize(section, size)
+    this.plots.setPlotSize(section, size)
     sendTelemetryEvent(
       EventName.VIEWS_PLOTS_SECTION_RESIZED,
       { section, size },
@@ -91,7 +90,7 @@ export class WebviewMessages {
   }
 
   private setSectionCollapsed(collapsed: Partial<SectionCollapsed>) {
-    this.plots?.setSectionCollapsed(collapsed)
+    this.plots.setSectionCollapsed(collapsed)
     this.sendSectionCollapsed()
     sendTelemetryEvent(
       EventName.VIEWS_PLOTS_SECTION_TOGGLE,
@@ -131,7 +130,7 @@ export class WebviewMessages {
   }
 
   private selectExperimentsFromWebview() {
-    this.experiments?.selectExperiments()
+    this.experiments.selectExperiments()
     sendTelemetryEvent(
       EventName.VIEWS_PLOTS_SELECT_EXPERIMENTS,
       undefined,
@@ -140,7 +139,7 @@ export class WebviewMessages {
   }
 
   private setExperimentStatus(id: string) {
-    this.experiments?.toggleExperimentStatus(id)
+    this.experiments.toggleExperimentStatus(id)
     sendTelemetryEvent(
       EventName.VIEWS_PLOTS_EXPERIMENT_TOGGLE,
       undefined,
@@ -150,8 +149,8 @@ export class WebviewMessages {
 
   private attemptToRefreshRevData(revision: string) {
     Toast.infoWithOptions(`Attempting to refresh plots data for ${revision}.`)
-    this.plots?.setupManualRefresh(revision)
-    this.data.update()
+    this.plots.setupManualRefresh(revision)
+    this.updateData()
     sendTelemetryEvent(
       EventName.VIEWS_PLOTS_MANUAL_REFRESH,
       { revisions: 1 },
@@ -162,9 +161,9 @@ export class WebviewMessages {
   private attemptToRefreshSelectedData(revisions: string[]) {
     Toast.infoWithOptions('Attempting to refresh visible plots data.')
     for (const revision of revisions) {
-      this.plots?.setupManualRefresh(revision)
+      this.plots.setupManualRefresh(revision)
     }
-    this.data.update()
+    this.updateData()
     sendTelemetryEvent(
       EventName.VIEWS_PLOTS_MANUAL_REFRESH,
       { revisions: revisions.length },


### PR DESCRIPTION
# 2/2 `main` <- #2026 <- this

Matches the pattern implements in #2026 but for `Plots`.

<img width="1082" alt="image" src="https://user-images.githubusercontent.com/37993418/178912351-35c6e2f1-fd35-4449-bf07-02b907db95f0.png">

<img width="845" alt="image" src="https://user-images.githubusercontent.com/37993418/178912534-f0da9c83-7753-44e2-b210-ca4be99a177a.png">
