### PR TITLE
Add selected for plotting indicator to experiments webview

### DIFF
--- a/extension/src/experiments/webview/messages.ts
+++ b/extension/src/experiments/webview/messages.ts
@@ -113,6 +113,9 @@ export class WebviewMessages {
       case MessageFromWebviewType.FOCUS_SORTS_TREE:
         return this.focusSortsTree()
 
+      case MessageFromWebviewType.OPEN_PLOTS_WEBVIEW:
+        return commands.executeCommand(RegisteredCommands.PLOTS_SHOW)
+
       default:
         Logger.error(`Unexpected message: ${JSON.stringify(message)}`)
     }

--- a/extension/src/webview/contract.ts
+++ b/extension/src/webview/contract.ts
@@ -16,6 +16,7 @@ export enum MessageFromWebviewType {
   CREATE_BRANCH_FROM_EXPERIMENT = 'create-branch-from-experiment',
   FOCUS_FILTERS_TREE = 'focus-filters-tree',
   FOCUS_SORTS_TREE = 'focus-sorts-tree',
+  OPEN_PLOTS_WEBVIEW = 'open-plots-webview',
   OPEN_PARAMS_FILE_TO_THE_SIDE = 'open-params-file-to-the-side',
   REMOVE_COLUMN_SORT = 'remove-column-sort',
   REMOVE_EXPERIMENT = 'remove-experiment',
@@ -144,6 +145,7 @@ export type MessageFromWebview =
   | { type: MessageFromWebviewType.SELECT_COLUMNS }
   | { type: MessageFromWebviewType.FOCUS_FILTERS_TREE }
   | { type: MessageFromWebviewType.FOCUS_SORTS_TREE }
+  | { type: MessageFromWebviewType.OPEN_PLOTS_WEBVIEW }
 
 export type MessageToWebview<T extends WebviewData> = {
   type: MessageToWebviewType.SET_DATA

--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -897,7 +897,9 @@ describe('App', () => {
 
       const tooltip = screen.getByRole('tooltip')
 
-      expect(tooltip).toHaveTextContent('5 Experiments Selected for Plotting')
+      expect(tooltip).toHaveTextContent(
+        '5 Experiments Selected for Plotting (Max 7)'
+      )
 
       setTableData({
         ...tableDataFixture,
@@ -908,7 +910,9 @@ describe('App', () => {
       })
 
       expect(selectedForPlotsIndicator).toHaveTextContent('')
-      expect(tooltip).toHaveTextContent('No Experiments Selected for Plotting')
+      expect(tooltip).toHaveTextContent(
+        'No Experiments Selected for Plotting (Max 7)'
+      )
 
       setTableData({
         ...tableDataFixture,
@@ -934,7 +938,9 @@ describe('App', () => {
       })
 
       expect(selectedForPlotsIndicator).toHaveTextContent('1')
-      expect(tooltip).toHaveTextContent('1 Experiment Selected for Plotting')
+      expect(tooltip).toHaveTextContent(
+        '1 Experiment Selected for Plotting (Max 7)'
+      )
     })
 
     it('should show an indicator with the amount of applied sorts', () => {

--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -909,6 +909,32 @@ describe('App', () => {
 
       expect(selectedForPlotsIndicator).toHaveTextContent('')
       expect(tooltip).toHaveTextContent('No Experiments Selected for Plotting')
+
+      setTableData({
+        ...tableDataFixture,
+        rows: [
+          { ...tableDataFixture.rows[0], selected: false },
+          {
+            ...tableDataFixture.rows[1],
+            selected: false,
+            subRows: [
+              {
+                ...(tableDataFixture.rows[1]?.subRows?.[0] as Row),
+                selected: false,
+                subRows: [
+                  {
+                    ...(tableDataFixture.rows[1]?.subRows?.[1] as Row),
+                    selected: true
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      })
+
+      expect(selectedForPlotsIndicator).toHaveTextContent('1')
+      expect(tooltip).toHaveTextContent('1 Experiment Selected for Plotting')
     })
 
     it('should show an indicator with the amount of applied sorts', () => {

--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -882,7 +882,35 @@ describe('App', () => {
     })
   })
 
-  describe('Sort and Filter Indicators', () => {
+  describe('Header Indicators', () => {
+    it('should show an indicator with the amount of experiments selected for plotting', () => {
+      renderTable({
+        ...tableDataFixture
+      })
+      const selectedForPlotsIndicator =
+        screen.getByLabelText('selected for plots')
+      expect(selectedForPlotsIndicator).toHaveTextContent('5')
+
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+
+      fireEvent.mouseEnter(selectedForPlotsIndicator)
+
+      const tooltip = screen.getByRole('tooltip')
+
+      expect(tooltip).toHaveTextContent('5 Experiments Selected for Plotting')
+
+      setTableData({
+        ...tableDataFixture,
+        rows: [
+          { ...tableDataFixture.rows[0], selected: false },
+          { ...tableDataFixture.rows[1], selected: false, subRows: [] }
+        ]
+      })
+
+      expect(selectedForPlotsIndicator).toHaveTextContent('')
+      expect(tooltip).toHaveTextContent('No Experiments Selected for Plotting')
+    })
+
     it('should show an indicator with the amount of applied sorts', () => {
       renderTable({
         ...tableDataFixture,
@@ -994,6 +1022,12 @@ describe('App', () => {
     fireEvent.click(screen.getByLabelText('filters'))
     expect(mockPostMessage).toBeCalledWith({
       type: MessageFromWebviewType.FOCUS_FILTERS_TREE
+    })
+
+    mockPostMessage.mockClear()
+    fireEvent.click(screen.getByLabelText('selected for plots'))
+    expect(mockPostMessage).toBeCalledWith({
+      type: MessageFromWebviewType.OPEN_PLOTS_WEBVIEW
     })
   })
 })

--- a/webview/src/experiments/components/table/Indicators.tsx
+++ b/webview/src/experiments/components/table/Indicators.tsx
@@ -123,6 +123,25 @@ const formatFilteredCountMessage = (filteredCounts: FilteredCounts): string =>
     .filter(Boolean)
     .join(', ')} Filtered`
 
+const addToSelected = (
+  selectedForPlotsCount: number,
+  row: Row<Experiment>
+): number => selectedForPlotsCount + (row.original?.selected ? 1 : 0)
+
+const getSelectedForPlotsCount = (rows: Row<Experiment>[]): number => {
+  let selectedForPlotsCount = 0
+
+  for (const row of rows) {
+    selectedForPlotsCount = addToSelected(selectedForPlotsCount, row)
+
+    for (const subRow of row.subRows || []) {
+      selectedForPlotsCount = addToSelected(selectedForPlotsCount, subRow)
+    }
+  }
+
+  return selectedForPlotsCount
+}
+
 export const Indicators = ({
   rows,
   sorts,
@@ -133,35 +152,21 @@ export const Indicators = ({
   filters?: string[]
   filteredCounts: FilteredCounts
   rows: Row<Experiment>[]
-  // eslint-disable-next-line sonarjs/cognitive-complexity
 }) => {
   const sortsCount = sorts?.length
   const filtersCount = filters?.length
 
-  let numberSelected = 0
-
-  for (const row of rows) {
-    const { selected } = row.original
-    if (selected) {
-      numberSelected = numberSelected + 1
-    }
-    for (const subRow of row.subRows || []) {
-      const { selected } = subRow.original
-      if (selected) {
-        numberSelected = numberSelected + 1
-      }
-    }
-  }
+  const selectedForPlotsCount = getSelectedForPlotsCount(rows)
 
   return (
     <div className={styles.tableIndicators}>
       <Indicator
-        count={numberSelected}
+        count={selectedForPlotsCount}
         aria-label="selected for plots"
         onClick={openPlotsWebview}
         tooltipContent={formatCountMessage(
           'Experiment',
-          numberSelected,
+          selectedForPlotsCount,
           'Selected for Plotting'
         )}
       >

--- a/webview/src/experiments/components/table/Indicators.tsx
+++ b/webview/src/experiments/components/table/Indicators.tsx
@@ -166,7 +166,7 @@ export const Indicators = ({
         tooltipContent={formatCountMessage(
           'Experiment',
           selectedForPlotsCount,
-          'Selected for Plotting'
+          'Selected for Plotting (Max 7)'
         )}
       >
         <Icon width={16} height={16} icon={SvgGraphScatter} />

--- a/webview/src/experiments/components/table/Indicators.tsx
+++ b/webview/src/experiments/components/table/Indicators.tsx
@@ -128,15 +128,14 @@ const addToSelected = (
   row: Row<Experiment>
 ): number => selectedForPlotsCount + (row.original?.selected ? 1 : 0)
 
-const getSelectedForPlotsCount = (rows: Row<Experiment>[]): number => {
+const getSelectedForPlotsCount = (rows: Row<Experiment>[] = []): number => {
   let selectedForPlotsCount = 0
 
   for (const row of rows) {
     selectedForPlotsCount = addToSelected(selectedForPlotsCount, row)
 
-    for (const subRow of row.subRows || []) {
-      selectedForPlotsCount = addToSelected(selectedForPlotsCount, subRow)
-    }
+    selectedForPlotsCount =
+      selectedForPlotsCount + getSelectedForPlotsCount(row.subRows)
   }
 
   return selectedForPlotsCount

--- a/webview/src/experiments/components/table/Indicators.tsx
+++ b/webview/src/experiments/components/table/Indicators.tsx
@@ -96,6 +96,8 @@ const focusFiltersTree = () =>
   sendMessage({ type: MessageFromWebviewType.FOCUS_FILTERS_TREE })
 const focusSortsTree = () =>
   sendMessage({ type: MessageFromWebviewType.FOCUS_SORTS_TREE })
+const openPlotsWebview = () =>
+  sendMessage({ type: MessageFromWebviewType.OPEN_PLOTS_WEBVIEW })
 
 const formatCountMessage = (
   item: string,
@@ -156,7 +158,7 @@ export const Indicators = ({
       <Indicator
         count={numberSelected}
         aria-label="selected for plots"
-        onClick={focusSortsTree}
+        onClick={openPlotsWebview}
         tooltipContent={formatCountMessage(
           'Experiment',
           numberSelected,

--- a/webview/src/experiments/components/table/Indicators.tsx
+++ b/webview/src/experiments/components/table/Indicators.tsx
@@ -1,6 +1,4 @@
 import React, { MouseEventHandler, ReactNode } from 'react'
-import { Experiment } from 'dvc/src/experiments/webview/contract'
-import { Row } from 'react-table'
 import { SortDefinition } from 'dvc/src/experiments/model/sortBy'
 import cx from 'classnames'
 import { MessageFromWebviewType } from 'dvc/src/webview/contract'
@@ -123,26 +121,8 @@ const formatFilteredCountMessage = (filteredCounts: FilteredCounts): string =>
     .filter(Boolean)
     .join(', ')} Filtered`
 
-const addToSelected = (
-  selectedForPlotsCount: number,
-  row: Row<Experiment>
-): number => selectedForPlotsCount + (row.original?.selected ? 1 : 0)
-
-const getSelectedForPlotsCount = (rows: Row<Experiment>[] = []): number => {
-  let selectedForPlotsCount = 0
-
-  for (const row of rows) {
-    selectedForPlotsCount = addToSelected(selectedForPlotsCount, row)
-
-    selectedForPlotsCount =
-      selectedForPlotsCount + getSelectedForPlotsCount(row.subRows)
-  }
-
-  return selectedForPlotsCount
-}
-
 export const Indicators = ({
-  rows,
+  selectedForPlotsCount,
   sorts,
   filters,
   filteredCounts
@@ -150,12 +130,10 @@ export const Indicators = ({
   sorts?: SortDefinition[]
   filters?: string[]
   filteredCounts: FilteredCounts
-  rows: Row<Experiment>[]
+  selectedForPlotsCount: number
 }) => {
   const sortsCount = sorts?.length
   const filtersCount = filters?.length
-
-  const selectedForPlotsCount = getSelectedForPlotsCount(rows)
 
   return (
     <div className={styles.tableIndicators}>

--- a/webview/src/experiments/components/table/TableHead.tsx
+++ b/webview/src/experiments/components/table/TableHead.tsx
@@ -16,6 +16,7 @@ import {
   OnDragOver,
   OnDragStart
 } from '../../../shared/components/dragDrop/DragDropWorkbench'
+import { getSelectedForPlotsCount } from '../../util/rows'
 
 interface TableHeadProps {
   instance: TableInstance<Experiment>
@@ -96,13 +97,15 @@ export const TableHead = ({
     threshold: 1
   })
 
+  const selectedForPlotsCount = getSelectedForPlotsCount(rows)
+
   return (
     <div
       className={cx(styles.thead, needsShadow && styles.headWithShadow)}
       ref={ref}
     >
       <Indicators
-        rows={rows}
+        selectedForPlotsCount={selectedForPlotsCount}
         sorts={sorts}
         filters={filters}
         filteredCounts={filteredCounts}

--- a/webview/src/experiments/components/table/TableHead.tsx
+++ b/webview/src/experiments/components/table/TableHead.tsx
@@ -31,7 +31,8 @@ export const TableHead = ({
     headerGroups,
     setColumnOrder,
     state: { columnOrder },
-    allColumns
+    allColumns,
+    rows
   },
   root,
   filteredCounts,
@@ -101,6 +102,7 @@ export const TableHead = ({
       ref={ref}
     >
       <Indicators
+        rows={rows}
         sorts={sorts}
         filters={filters}
         filteredCounts={filteredCounts}

--- a/webview/src/experiments/util/rows.ts
+++ b/webview/src/experiments/util/rows.ts
@@ -1,0 +1,22 @@
+import { Experiment } from 'dvc/src/experiments/webview/contract'
+import { Row } from 'react-table'
+
+const addToSelected = (
+  selectedForPlotsCount: number,
+  row: Row<Experiment>
+): number => selectedForPlotsCount + (row.original?.selected ? 1 : 0)
+
+export const getSelectedForPlotsCount = (
+  rows: Row<Experiment>[] = []
+): number => {
+  let selectedForPlotsCount = 0
+
+  for (const row of rows) {
+    selectedForPlotsCount = addToSelected(selectedForPlotsCount, row)
+
+    selectedForPlotsCount =
+      selectedForPlotsCount + getSelectedForPlotsCount(row.subRows)
+  }
+
+  return selectedForPlotsCount
+}

--- a/webview/src/shared/components/icons/GraphScatter.tsx
+++ b/webview/src/shared/components/icons/GraphScatter.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+import { SVGProps } from 'react'
+
+const SvgGraphScatter = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    width={16}
+    height={16}
+    viewBox="0 0 16 16"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="currentColor"
+    {...props}
+  >
+    <path d="M15 13V14H1.5L1 13.5V0H2V13H15Z" />
+    <rect x={5} y={2} width={2} height={2} />
+    <rect x={12} y={1} width={2} height={2} />
+    <rect x={8} y={5} width={2} height={2} />
+    <rect x={5} y={9} width={2} height={2} />
+    <rect x={12} y={8} width={2} height={2} />
+  </svg>
+)
+
+export default SvgGraphScatter


### PR DESCRIPTION
Based on the conversation we had in the planning meeting regarding how we link filled circles with the fact that those experiments have been selected for plotting. 

From my understanding, this was one of the @sroy3 ideas.

We can display an indicator with the graph icon that shows how many experiments are selected for plotting. 

We can also provide an action to open the plots webview:

https://user-images.githubusercontent.com/37993418/179870922-1750d7a0-a19f-4f6f-b356-8776afc29d75.mov

~Code is only a prototype and needs to be restructured.~

What does everyone think?

@sroy3 @wolmir @julieg18 @shcheklein @maxagin 
