### PR TITLE
Do not use turbo cache on main

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,7 +32,7 @@ jobs:
           cache: 'yarn'
 
       - name: Turbo cache
-        if: ${{ github.ref != 'refs/heads/main' }}
+        if: ${{ github.ref_name != 'main' }}
         id: turbo-cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,6 +32,7 @@ jobs:
           cache: 'yarn'
 
       - name: Turbo cache
+        if: ${{ github.ref != 'refs/heads/main' }}
         id: turbo-cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/cross-platform-test.yml
+++ b/.github/workflows/cross-platform-test.yml
@@ -29,6 +29,7 @@ jobs:
           cache: yarn
 
       - name: Turbo cache
+        if: ${{ github.ref != 'refs/heads/main' }}
         id: turbo-cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/cross-platform-test.yml
+++ b/.github/workflows/cross-platform-test.yml
@@ -29,7 +29,7 @@ jobs:
           cache: yarn
 
       - name: Turbo cache
-        if: ${{ github.ref != 'refs/heads/main' }}
+        if: ${{ github.ref_name != 'main' }}
         id: turbo-cache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
We've been filling up a cache on `main` that we (generally) never hit. It is now causing jobs to timeout. I've added a conditional statement to not use the cache on `main`.