### PR TITLE
Fix `yarn build` by reverting "chore(deps): update dependency vsce to v2.9.3"

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1556,7 +1556,7 @@
     "sinon-chai": "3.7.0",
     "ts-jest": "28.0.7",
     "ts-loader": "9.3.1",
-    "vsce": "2.9.3",
+    "vsce": "2.9.2",
     "vscode-uri": "3.0.3",
     "wdio-vscode-service": "3.0.3",
     "webdriverio": "7.20.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17707,10 +17707,10 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
-vsce@2.9.3:
-  version "2.9.3"
-  resolved "https://registry.yarnpkg.com/vsce/-/vsce-2.9.3.tgz#df75156aba51e05e15510408a61988aa1b0bb6cd"
-  integrity sha512-hOLsxbev7Khho+bzDV/TV3jeTClzt8gFfkJvE1c5HidrgFsyE5aEg+e7XssaEU7LYLXDnWnpMt298UP7P/4Ycw==
+vsce@2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/vsce/-/vsce-2.9.2.tgz#be5d2ca5899f31ba84225d6b19ea1376589df897"
+  integrity sha512-xyLqL4U82BilUX1t6Ym2opQEa2tLGWYjbgB7+ETeNVXlIJz5sWBJjQJSYJVFOKJSpiOtQclolu88cj7oY6vvPQ==
   dependencies:
     azure-devops-node-api "^11.0.1"
     chalk "^2.4.2"


### PR DESCRIPTION
Reverts iterative/vscode-dvc#2084 since updating the `vsce` package breaks `yarn build`

Error thrown when you try to run `yarn build`:
```
dvc:package: $ vsce package --yarn -o ./dvc.vsix
dvc:package:  ERROR  Command failed: yarn list --prod --json
dvc:package: {"type":"error","data":"No lockfile in this directory. Run `yarn install` to generate one."}
```