### PR TITLE
Add scheduled data status cli output test

### DIFF
--- a/extension/src/cli/reader.test.ts
+++ b/extension/src/cli/reader.test.ts
@@ -103,7 +103,14 @@ describe('CliReader', () => {
       expect(statusOutput).toStrictEqual(cliOutput)
 
       expect(mockedCreateProcess).toBeCalledWith({
-        args: ['data', 'status', '--with-dirs', '--granular', SHOW_JSON],
+        args: [
+          'data',
+          'status',
+          '--with-dirs',
+          '--granular',
+          '--unchanged',
+          SHOW_JSON
+        ],
         cwd,
         env: mockedEnv,
         executable: 'dvc'

--- a/extension/src/cli/reader.ts
+++ b/extension/src/cli/reader.ts
@@ -103,6 +103,7 @@ export class CliReader extends Cli {
       SubCommand.STATUS,
       Flag.WITH_DIRS,
       Flag.GRANULAR,
+      Flag.UNCHANGED,
       ...args
     )
   }

--- a/extension/src/repository/data/index.ts
+++ b/extension/src/repository/data/index.ts
@@ -19,7 +19,6 @@ import {
   EXPERIMENTS_GIT_REFS
 } from '../../experiments/data/constants'
 import { DeferredDisposable } from '../../class/deferred'
-import { Flag } from '../../cli/constants'
 
 export type Data = {
   dataStatus: DataStatusOutput
@@ -91,8 +90,7 @@ export class RepositoryData extends DeferredDisposable {
     const dataStatus =
       await this.internalCommands.executeCommand<DataStatusOutput>(
         AvailableCommands.DATA_STATUS,
-        this.dvcRoot,
-        Flag.UNCHANGED
+        this.dvcRoot
       )
 
     const [untracked, hasGitChanges] = await Promise.all([

--- a/extension/src/test/cli/dataStatus.test.ts
+++ b/extension/src/test/cli/dataStatus.test.ts
@@ -1,0 +1,64 @@
+import { join, sep } from 'path'
+import { describe, it, suite } from 'mocha'
+import { expect } from 'chai'
+import { TEMP_DIR } from './constants'
+import { cliReader, initializeDemoRepo, initializeEmptyRepo } from './util'
+import { dvcDemoPath } from '../util'
+
+suite('data status --with-dirs --granular --unchanged --show-json', () => {
+  describe('Demo Repository', () => {
+    it('should return the expected output', async () => {
+      await initializeDemoRepo()
+
+      const output = await cliReader.dataStatus(dvcDemoPath)
+
+      const demoRepoTrackedData = [
+        join('data', 'MNIST', 'raw') + sep,
+        join('data', 'MNIST', 'raw', 't10k-images-idx3-ubyte.gz'),
+        join('data', 'MNIST', 'raw', 't10k-images-idx3-ubyte'),
+        join('data', 'MNIST', 'raw', 't10k-labels-idx1-ubyte.gz'),
+        join('data', 'MNIST', 'raw', 't10k-labels-idx1-ubyte'),
+        join('data', 'MNIST', 'raw', 'train-images-idx3-ubyte.gz'),
+        join('data', 'MNIST', 'raw', 'train-images-idx3-ubyte'),
+        join('data', 'MNIST', 'raw', 'train-labels-idx1-ubyte.gz'),
+        join('data', 'MNIST', 'raw', 'train-labels-idx1-ubyte'),
+        'misclassified.jpg',
+        'model.pt',
+        'predictions.json',
+        'training_metrics' + sep,
+        join('training_metrics', 'scalars', 'acc.tsv'),
+        join('training_metrics', 'scalars', 'loss.tsv')
+      ].sort()
+
+      const collectedPaths = [
+        ...(output.committed?.modified || []),
+        ...(output.unchanged || [])
+      ].sort()
+
+      expect(
+        collectedPaths,
+        'all expected paths are either unchanged or committed modified after pulling'
+      ).to.deep.equal(demoRepoTrackedData)
+      expect(
+        output.not_in_cache,
+        'not in cache should be undefined after after pulling'
+      ).to.be.undefined
+      expect(output.committed?.added).to.be.undefined
+      expect(output.committed?.deleted).to.be.undefined
+      expect(output.committed?.renamed).to.be.undefined
+      expect(output.uncommitted?.added).to.be.undefined
+      expect(output.uncommitted?.deleted).to.be.undefined
+      expect(output.uncommitted?.modified).to.be.undefined
+      expect(output.uncommitted?.renamed).to.be.undefined
+    })
+  })
+
+  describe('Empty Repository', () => {
+    it('should return the expected output', async () => {
+      await initializeEmptyRepo()
+      const output = await cliReader.dataStatus(TEMP_DIR)
+
+      expect(output).to.deep.equal({})
+    })
+  })
+})


### PR DESCRIPTION
# 2/2 `main` <- #2091 <- this

As promised [here](https://github.com/iterative/vscode-dvc/pull/2091#discussion_r933663475).

This PR adds a test to the daily CLI output test suite that runs against the `main` branch of DVC.