### PR TITLE
Block users from attempting to run concurrent SCM commands

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -561,7 +561,7 @@
         },
         {
           "command": "dvc.checkout",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.commands.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.scm.command.running"
         },
         {
           "command": "dvc.checkCLICompatible",
@@ -573,7 +573,7 @@
         },
         {
           "command": "dvc.commit",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.commands.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.scm.command.running"
         },
         {
           "command": "dvc.commitTarget",
@@ -613,7 +613,7 @@
         },
         {
           "command": "dvc.init",
-          "when": "dvc.commands.available && !dvc.cli.incompatible && !dvc.project.available && !dvc.commands.running"
+          "when": "dvc.commands.available && !dvc.cli.incompatible && !dvc.project.available && !dvc.scm.command.running"
         },
         {
           "command": "dvc.moveTargets",
@@ -625,7 +625,7 @@
         },
         {
           "command": "dvc.pull",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.commands.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.scm.command.running"
         },
         {
           "command": "dvc.pullTarget",
@@ -633,7 +633,7 @@
         },
         {
           "command": "dvc.push",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.commands.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.scm.command.running"
         },
         {
           "command": "dvc.pushTarget",
@@ -689,7 +689,7 @@
         },
         {
           "command": "dvc.discardWorkspaceChanges",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.commands.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.scm.command.running"
         },
         {
           "command": "dvc.runExperiment",
@@ -836,34 +836,34 @@
         {
           "command": "dvc.addTarget",
           "group": "inline",
-          "when": "scmProvider == dvc && scmResourceState == untracked && dvc.commands.available && !dvc.commands.running"
+          "when": "scmProvider == dvc && scmResourceState == untracked && dvc.commands.available && !dvc.scm.command.running"
         },
         {
           "command": "dvc.checkoutTarget",
           "group": "inline",
-          "when": "scmProvider == dvc && scmResourceGroup == changes && scmResourceState != untracked && scmResourceState != notInCache && dvc.commands.available && !dvc.commands.running"
+          "when": "scmProvider == dvc && scmResourceGroup == changes && scmResourceState != untracked && scmResourceState != notInCache && dvc.commands.available && !dvc.scm.command.running"
         },
         {
           "command": "dvc.commitTarget",
           "group": "inline",
-          "when": "scmProvider == dvc && scmResourceGroup == changes && scmResourceState != untracked && scmResourceState != deleted && dvc.commands.available && !dvc.commands.running"
+          "when": "scmProvider == dvc && scmResourceGroup == changes && scmResourceState != untracked && scmResourceState != deleted && dvc.commands.available && !dvc.scm.command.running"
         },
         {
           "command": "dvc.pullTarget",
           "group": "inline",
-          "when": "scmProvider == dvc && scmResourceGroup == notInCache && dvc.commands.available && !dvc.commands.running"
+          "when": "scmProvider == dvc && scmResourceGroup == notInCache && dvc.commands.available && !dvc.scm.command.running"
         }
       ],
       "scm/resourceGroup/context": [
         {
           "command": "dvc.checkout",
           "group": "inline",
-          "when": "scmProvider == dvc && scmResourceGroup == changes && !dvc.commands.running"
+          "when": "scmProvider == dvc && scmResourceGroup == changes && !dvc.scm.command.running"
         },
         {
           "command": "dvc.commit",
           "group": "inline",
-          "when": "scmProvider == dvc && scmResourceGroup == changes && !dvc.commands.running"
+          "when": "scmProvider == dvc && scmResourceGroup == changes && !dvc.scm.command.running"
         },
         {
           "command": "dvc.gitStageAll",
@@ -942,17 +942,17 @@
         {
           "command": "dvc.moveTargets",
           "group": "1_DVC@1",
-          "when": "view == dvc.views.trackedExplorerTree && viewItem =~ /^dirData$/ && !dvc.commands.running"
+          "when": "view == dvc.views.trackedExplorerTree && viewItem =~ /^dirData$/ && !dvc.scm.command.running"
         },
         {
           "command": "dvc.pullTarget",
           "group": "1_DVC@2",
-          "when": "view == dvc.views.trackedExplorerTree && !dvc.commands.running"
+          "when": "view == dvc.views.trackedExplorerTree && !dvc.scm.command.running"
         },
         {
           "command": "dvc.pushTarget",
           "group": "1_DVC@3",
-          "when": "view == dvc.views.trackedExplorerTree && viewItem != virtual && !dvc.commands.running"
+          "when": "view == dvc.views.trackedExplorerTree && viewItem != virtual && !dvc.scm.command.running"
         },
         {
           "command": "dvc.compareSelected",
@@ -992,7 +992,7 @@
         {
           "command": "dvc.removeTarget",
           "group": "7_modification@2",
-          "when": "view == dvc.views.trackedExplorerTree && viewItem =~ /^.*Data$/ && !dvc.commands.running"
+          "when": "view == dvc.views.trackedExplorerTree && viewItem =~ /^.*Data$/ && !dvc.scm.command.running"
         },
         {
           "command": "dvc.addExperimentsTableSort",

--- a/extension/package.json
+++ b/extension/package.json
@@ -553,15 +553,15 @@
         },
         {
           "command": "dvc.applyExperiment",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.commands.running"
         },
         {
           "command": "dvc.branchExperiment",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.commands.running"
         },
         {
           "command": "dvc.checkout",
-          "when": "dvc.commands.available && dvc.project.available"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.commands.running"
         },
         {
           "command": "dvc.checkCLICompatible",
@@ -573,7 +573,7 @@
         },
         {
           "command": "dvc.commit",
-          "when": "dvc.commands.available && dvc.project.available"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.commands.running"
         },
         {
           "command": "dvc.commitTarget",
@@ -597,7 +597,7 @@
         },
         {
           "command": "dvc.experimentGarbageCollect",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.commands.running"
         },
         {
           "command": "dvc.findInFolder",
@@ -613,7 +613,7 @@
         },
         {
           "command": "dvc.init",
-          "when": "dvc.commands.available && !dvc.cli.incompatible && !dvc.project.available"
+          "when": "dvc.commands.available && !dvc.cli.incompatible && !dvc.project.available && !dvc.commands.running"
         },
         {
           "command": "dvc.moveTargets",
@@ -625,7 +625,7 @@
         },
         {
           "command": "dvc.pull",
-          "when": "dvc.commands.available && dvc.project.available"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.commands.running"
         },
         {
           "command": "dvc.pullTarget",
@@ -633,7 +633,7 @@
         },
         {
           "command": "dvc.push",
-          "when": "dvc.commands.available && dvc.project.available"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.commands.running"
         },
         {
           "command": "dvc.pushTarget",
@@ -641,31 +641,31 @@
         },
         {
           "command": "dvc.modifyExperimentParamsAndQueue",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.commands.running"
         },
         {
           "command": "dvc.modifyExperimentParamsAndRun",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.experiment.checkpoints"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.experiment.checkpoints && !dvc.commands.running"
         },
         {
           "command": "dvc.modifyExperimentParamsAndResume",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && dvc.experiment.checkpoints"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && dvc.experiment.checkpoints && !dvc.commands.running"
         },
         {
           "command": "dvc.modifyExperimentParamsResetAndRun",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && dvc.experiment.checkpoints"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && dvc.experiment.checkpoints && !dvc.commands.running"
         },
         {
           "command": "dvc.queueExperiment",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.commands.running"
         },
         {
           "command": "dvc.removeExperiment",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.commands.running"
         },
         {
           "command": "dvc.removeExperimentQueue",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.commands.running"
         },
         {
           "command": "dvc.removeExperimentsTableFilters",
@@ -677,7 +677,7 @@
         },
         {
           "command": "dvc.removeQueuedExperiment",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.commands.running"
         },
         {
           "command": "dvc.removeTarget",
@@ -689,23 +689,23 @@
         },
         {
           "command": "dvc.discardWorkspaceChanges",
-          "when": "dvc.commands.available && dvc.project.available"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.commands.running"
         },
         {
           "command": "dvc.runExperiment",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.experiment.checkpoints"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.experiment.checkpoints && !dvc.commands.running"
         },
         {
           "command": "dvc.resumeCheckpointExperiment",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && dvc.experiment.checkpoints"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && dvc.experiment.checkpoints && !dvc.commands.running"
         },
         {
           "command": "dvc.resetAndRunCheckpointExperiment",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && dvc.experiment.checkpoints"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && dvc.experiment.checkpoints && !dvc.commands.running"
         },
         {
           "command": "dvc.startExperimentsQueue",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.commands.running"
         },
         {
           "command": "dvc.selectForCompare",
@@ -836,34 +836,34 @@
         {
           "command": "dvc.addTarget",
           "group": "inline",
-          "when": "scmProvider == dvc && scmResourceState == untracked && dvc.commands.available"
+          "when": "scmProvider == dvc && scmResourceState == untracked && dvc.commands.available && !dvc.commands.running"
         },
         {
           "command": "dvc.checkoutTarget",
           "group": "inline",
-          "when": "scmProvider == dvc && scmResourceGroup == changes && scmResourceState != untracked && scmResourceState != notInCache && dvc.commands.available"
+          "when": "scmProvider == dvc && scmResourceGroup == changes && scmResourceState != untracked && scmResourceState != notInCache && dvc.commands.available && !dvc.commands.running"
         },
         {
           "command": "dvc.commitTarget",
           "group": "inline",
-          "when": "scmProvider == dvc && scmResourceGroup == changes && scmResourceState != untracked && scmResourceState != deleted && dvc.commands.available"
+          "when": "scmProvider == dvc && scmResourceGroup == changes && scmResourceState != untracked && scmResourceState != deleted && dvc.commands.available && !dvc.commands.running"
         },
         {
           "command": "dvc.pullTarget",
           "group": "inline",
-          "when": "scmProvider == dvc && scmResourceGroup == notInCache && dvc.commands.available"
+          "when": "scmProvider == dvc && scmResourceGroup == notInCache && dvc.commands.available && !dvc.commands.running"
         }
       ],
       "scm/resourceGroup/context": [
         {
           "command": "dvc.checkout",
           "group": "inline",
-          "when": "scmProvider == dvc && scmResourceGroup == changes"
+          "when": "scmProvider == dvc && scmResourceGroup == changes && !dvc.commands.running"
         },
         {
           "command": "dvc.commit",
           "group": "inline",
-          "when": "scmProvider == dvc && scmResourceGroup == changes"
+          "when": "scmProvider == dvc && scmResourceGroup == changes && !dvc.commands.running"
         },
         {
           "command": "dvc.gitStageAll",
@@ -942,17 +942,17 @@
         {
           "command": "dvc.moveTargets",
           "group": "1_DVC@1",
-          "when": "view == dvc.views.trackedExplorerTree && viewItem =~ /^dirData$/"
+          "when": "view == dvc.views.trackedExplorerTree && viewItem =~ /^dirData$/ && !dvc.commands.running"
         },
         {
           "command": "dvc.pullTarget",
           "group": "1_DVC@2",
-          "when": "view == dvc.views.trackedExplorerTree"
+          "when": "view == dvc.views.trackedExplorerTree && !dvc.commands.running"
         },
         {
           "command": "dvc.pushTarget",
           "group": "1_DVC@3",
-          "when": "view == dvc.views.trackedExplorerTree && viewItem != virtual"
+          "when": "view == dvc.views.trackedExplorerTree && viewItem != virtual && !dvc.commands.running"
         },
         {
           "command": "dvc.compareSelected",
@@ -992,7 +992,7 @@
         {
           "command": "dvc.removeTarget",
           "group": "7_modification@2",
-          "when": "view == dvc.views.trackedExplorerTree && viewItem =~ /^.*Data$/"
+          "when": "view == dvc.views.trackedExplorerTree && viewItem =~ /^.*Data$/ && !dvc.commands.running"
         },
         {
           "command": "dvc.addExperimentsTableSort",

--- a/extension/package.json
+++ b/extension/package.json
@@ -553,11 +553,11 @@
         },
         {
           "command": "dvc.applyExperiment",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.commands.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running"
         },
         {
           "command": "dvc.branchExperiment",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.commands.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running"
         },
         {
           "command": "dvc.checkout",
@@ -597,7 +597,7 @@
         },
         {
           "command": "dvc.experimentGarbageCollect",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.commands.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running"
         },
         {
           "command": "dvc.findInFolder",
@@ -641,31 +641,31 @@
         },
         {
           "command": "dvc.modifyExperimentParamsAndQueue",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.commands.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running"
         },
         {
           "command": "dvc.modifyExperimentParamsAndRun",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.experiment.checkpoints && !dvc.commands.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.experiment.checkpoints"
         },
         {
           "command": "dvc.modifyExperimentParamsAndResume",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && dvc.experiment.checkpoints && !dvc.commands.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && dvc.experiment.checkpoints"
         },
         {
           "command": "dvc.modifyExperimentParamsResetAndRun",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && dvc.experiment.checkpoints && !dvc.commands.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && dvc.experiment.checkpoints"
         },
         {
           "command": "dvc.queueExperiment",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.commands.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running"
         },
         {
           "command": "dvc.removeExperiment",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.commands.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running"
         },
         {
           "command": "dvc.removeExperimentQueue",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.commands.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running "
         },
         {
           "command": "dvc.removeExperimentsTableFilters",
@@ -677,7 +677,7 @@
         },
         {
           "command": "dvc.removeQueuedExperiment",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.commands.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running"
         },
         {
           "command": "dvc.removeTarget",
@@ -693,19 +693,19 @@
         },
         {
           "command": "dvc.runExperiment",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.experiment.checkpoints && !dvc.commands.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.experiment.checkpoints"
         },
         {
           "command": "dvc.resumeCheckpointExperiment",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && dvc.experiment.checkpoints && !dvc.commands.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && dvc.experiment.checkpoints"
         },
         {
           "command": "dvc.resetAndRunCheckpointExperiment",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && dvc.experiment.checkpoints && !dvc.commands.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && dvc.experiment.checkpoints"
         },
         {
           "command": "dvc.startExperimentsQueue",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running && !dvc.commands.running"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running"
         },
         {
           "command": "dvc.selectForCompare",

--- a/extension/package.json
+++ b/extension/package.json
@@ -665,7 +665,7 @@
         },
         {
           "command": "dvc.removeExperimentQueue",
-          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running "
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running"
         },
         {
           "command": "dvc.removeExperimentsTableFilters",

--- a/extension/src/cli/executor.test.ts
+++ b/extension/src/cli/executor.test.ts
@@ -588,9 +588,12 @@ describe('CliExecutor', () => {
       })
 
       expect(mockedSetContextValue).toBeCalledTimes(2)
-      expect(mockedSetContextValue).toBeCalledWith('dvc.commands.running', true)
+      expect(mockedSetContextValue).toBeCalledWith(
+        'dvc.scm.command.running',
+        true
+      )
       expect(mockedSetContextValue).toHaveBeenLastCalledWith(
-        'dvc.commands.running',
+        'dvc.scm.command.running',
         false
       )
     })

--- a/extension/src/cli/executor.test.ts
+++ b/extension/src/cli/executor.test.ts
@@ -8,11 +8,13 @@ import { createProcess } from '../processExecution'
 import { getMockedProcess } from '../test/util/jest'
 import { getProcessEnv } from '../env'
 import { Config } from '../config'
+import { setContextValue } from '../vscode/context'
 
 jest.mock('vscode')
 jest.mock('@hediet/std/disposable')
 jest.mock('../processExecution')
 jest.mock('../env')
+jest.mock('../vscode/context')
 
 const mockedDisposable = jest.mocked(Disposable)
 
@@ -23,6 +25,8 @@ const mockedEnv = {
   DVC_NO_ANALYTICS: 'true',
   PATH: '/some/special/path'
 }
+
+const mockedSetContextValue = jest.mocked(setContextValue)
 
 beforeEach(() => {
   jest.resetAllMocks()
@@ -582,6 +586,13 @@ describe('CliExecutor', () => {
         env: mockedEnv,
         executable: 'dvc'
       })
+
+      expect(mockedSetContextValue).toBeCalledTimes(2)
+      expect(mockedSetContextValue).toBeCalledWith('dvc.commands.running', true)
+      expect(mockedSetContextValue).toHaveBeenLastCalledWith(
+        'dvc.commands.running',
+        false
+      )
     })
   })
 })

--- a/extension/src/cli/executor.ts
+++ b/extension/src/cli/executor.ts
@@ -20,7 +20,7 @@ export const autoRegisteredCommands = {
   EXPERIMENT_REMOVE: 'experimentRemove',
   EXPERIMENT_REMOVE_QUEUE: 'experimentRemoveQueue',
   INIT: 'init',
-  IS_EXECUTOR_RUNNING: 'isExecutorRunning',
+  IS_SCM_COMMAND_RUNNING: 'isScmCommandRunning',
   MOVE: 'move',
   PULL: 'pull',
   PUSH: 'push',
@@ -33,7 +33,7 @@ export class CliExecutor extends Cli {
     this
   )
 
-  private isRunning = false
+  private scmCommandRunning = false
 
   public add(cwd: string, target: string) {
     return this.blockAndExecuteProcess(cwd, Command.ADD, target)
@@ -101,8 +101,8 @@ export class CliExecutor extends Cli {
     )
   }
 
-  public isExecutorRunning() {
-    return this.isRunning
+  public isScmCommandRunning() {
+    return this.scmCommandRunning
   }
 
   public init(cwd: string) {
@@ -130,7 +130,7 @@ export class CliExecutor extends Cli {
   }
 
   private executeExperimentProcess(cwd: string, ...args: Args) {
-    return this.blockAndExecuteProcess(cwd, Command.EXPERIMENT, ...args)
+    return this.executeProcess(cwd, Command.EXPERIMENT, ...args)
   }
 
   private async blockAndExecuteProcess(cwd: string, ...args: Args) {
@@ -141,7 +141,7 @@ export class CliExecutor extends Cli {
   }
 
   private setRunning(running: boolean) {
-    this.isRunning = running
-    setContextValue('dvc.commands.running', running)
+    this.scmCommandRunning = running
+    setContextValue('dvc.scm.command.running', running)
   }
 }

--- a/extension/src/cli/executor.ts
+++ b/extension/src/cli/executor.ts
@@ -7,6 +7,7 @@ import {
   Flag,
   GcPreserveFlag
 } from './constants'
+import { setContextValue } from '../vscode/context'
 
 export const autoRegisteredCommands = {
   ADD: 'add',
@@ -19,6 +20,7 @@ export const autoRegisteredCommands = {
   EXPERIMENT_REMOVE: 'experimentRemove',
   EXPERIMENT_REMOVE_QUEUE: 'experimentRemoveQueue',
   INIT: 'init',
+  IS_EXECUTOR_RUNNING: 'isExecutorRunning',
   MOVE: 'move',
   PULL: 'pull',
   PUSH: 'push',
@@ -31,16 +33,18 @@ export class CliExecutor extends Cli {
     this
   )
 
+  private isRunning = false
+
   public add(cwd: string, target: string) {
-    return this.executeProcess(cwd, Command.ADD, target)
+    return this.blockAndExecuteProcess(cwd, Command.ADD, target)
   }
 
   public checkout(cwd: string, ...args: Args) {
-    return this.executeProcess(cwd, Command.CHECKOUT, ...args)
+    return this.blockAndExecuteProcess(cwd, Command.CHECKOUT, ...args)
   }
 
   public commit(cwd: string, ...args: Args) {
-    return this.executeProcess(cwd, Command.COMMIT, ...args)
+    return this.blockAndExecuteProcess(cwd, Command.COMMIT, ...args)
   }
 
   public experimentApply(cwd: string, experimentName: string) {
@@ -97,27 +101,47 @@ export class CliExecutor extends Cli {
     )
   }
 
+  public isExecutorRunning() {
+    return this.isRunning
+  }
+
   public init(cwd: string) {
-    return this.executeProcess(cwd, Command.INITIALIZE, Flag.SUBDIRECTORY)
+    return this.blockAndExecuteProcess(
+      cwd,
+      Command.INITIALIZE,
+      Flag.SUBDIRECTORY
+    )
   }
 
   public move(cwd: string, target: string, destination: string) {
-    return this.executeProcess(cwd, Command.MOVE, target, destination)
+    return this.blockAndExecuteProcess(cwd, Command.MOVE, target, destination)
   }
 
   public pull(cwd: string, ...args: Args) {
-    return this.executeProcess(cwd, Command.PULL, ...args)
+    return this.blockAndExecuteProcess(cwd, Command.PULL, ...args)
   }
 
   public push(cwd: string, ...args: Args) {
-    return this.executeProcess(cwd, Command.PUSH, ...args)
+    return this.blockAndExecuteProcess(cwd, Command.PUSH, ...args)
   }
 
   public remove(cwd: string, ...args: Args) {
-    return this.executeProcess(cwd, Command.REMOVE, ...args)
+    return this.blockAndExecuteProcess(cwd, Command.REMOVE, ...args)
   }
 
   private executeExperimentProcess(cwd: string, ...args: Args) {
-    return this.executeProcess(cwd, Command.EXPERIMENT, ...args)
+    return this.blockAndExecuteProcess(cwd, Command.EXPERIMENT, ...args)
+  }
+
+  private async blockAndExecuteProcess(cwd: string, ...args: Args) {
+    this.setRunning(true)
+    const output = await this.executeProcess(cwd, ...args)
+    this.setRunning(false)
+    return output
+  }
+
+  private setRunning(running: boolean) {
+    this.isRunning = running
+    setContextValue('dvc.commands.running', running)
   }
 }

--- a/extension/src/repository/commands/index.test.ts
+++ b/extension/src/repository/commands/index.test.ts
@@ -25,6 +25,13 @@ mockedInternalCommands.registerCommand(mockedCommandId, (...args) =>
   mockedFunc(...args)
 )
 
+const mockedIsExecutorRunning = jest.fn()
+
+mockedInternalCommands.registerCommand(
+  'isExecutorRunning',
+  mockedIsExecutorRunning
+)
+
 const TRY_FORCE = 'Use `-f|--force` to force.'
 
 jest.mock('vscode')
@@ -182,6 +189,7 @@ describe('getSimpleResourceCommand', () => {
 describe('getRootCommand', () => {
   it('should return a function that returns early if a cwd is not provided', async () => {
     mockedGetCwd.mockResolvedValueOnce(undefined)
+    mockedIsExecutorRunning.mockResolvedValueOnce(false)
     const stdout = 'I cannot run without a cwd'
     mockedFunc.mockResolvedValueOnce(stdout)
 
@@ -199,6 +207,7 @@ describe('getRootCommand', () => {
 
   it('should return a function that only calls the first function if it succeeds', async () => {
     mockedGetCwd.mockImplementationOnce(uri => uri?.fsPath)
+    mockedIsExecutorRunning.mockResolvedValueOnce(false)
     const stdout = 'all went well, congrats'
     mockedFunc.mockResolvedValueOnce(stdout)
 
@@ -219,6 +228,7 @@ describe('getRootCommand', () => {
 
   it('should return a function that throws an error if the underlying function fails without a force prompt', async () => {
     mockedGetCwd.mockImplementationOnce(uri => uri?.fsPath)
+    mockedIsExecutorRunning.mockResolvedValueOnce(false)
     const stderr = 'I deed'
     mockedFunc.mockRejectedValueOnce({ stderr })
 
@@ -239,6 +249,7 @@ describe('getRootCommand', () => {
 
   it('should return a function that calls warnOfConsequences if the first function fails with a force prompt', async () => {
     mockedGetCwd.mockImplementationOnce(uri => uri?.fsPath)
+    mockedIsExecutorRunning.mockResolvedValueOnce(false)
     const stderr = `I deed, but ${TRY_FORCE}`
     const userCancelled = undefined
     mockedFunc.mockRejectedValueOnce({ stderr })
@@ -260,6 +271,7 @@ describe('getRootCommand', () => {
 
   it('should return a function that does not call the force func if the user selects cancel', async () => {
     mockedGetCwd.mockImplementationOnce(uri => uri?.fsPath)
+    mockedIsExecutorRunning.mockResolvedValueOnce(false)
     const stderr = `You don't have to do this, but ${TRY_FORCE}`
     const userCancelled = 'Cancel'
     mockedFunc.mockRejectedValueOnce({ stderr })
@@ -281,6 +293,7 @@ describe('getRootCommand', () => {
 
   it('should return a function that does not call the force func if no stderr is returned in the underlying error', async () => {
     mockedGetCwd.mockImplementationOnce(uri => uri?.fsPath)
+    mockedIsExecutorRunning.mockResolvedValueOnce(false)
     const userCancelled = 'Cancel'
     mockedFunc.mockRejectedValueOnce({})
     mockedGetWarningResponse.mockResolvedValueOnce(userCancelled)
@@ -302,6 +315,7 @@ describe('getRootCommand', () => {
 
   it('should return a function that calls the force function if the first function fails with a force prompt and the user responds with force', async () => {
     mockedGetCwd.mockImplementationOnce(uri => uri?.fsPath)
+    mockedIsExecutorRunning.mockResolvedValueOnce(false)
     const stderr = `I can fix this... maybe, but ${TRY_FORCE}`
     const forcedStdout = 'ok, nw I forced it'
     const userApproves = 'Force'
@@ -324,5 +338,23 @@ describe('getRootCommand', () => {
     expect(mockedFunc).toHaveBeenCalledWith(mockedDvcRoot)
     expect(mockedFunc).toHaveBeenCalledWith(mockedDvcRoot, '-f')
     expect(mockedFunc).toHaveBeenCalledTimes(2)
+  })
+
+  it('should return a function that returns early if another user initiated command is running', async () => {
+    mockedGetCwd.mockImplementationOnce(uri => uri?.fsPath)
+    mockedIsExecutorRunning.mockResolvedValueOnce(true)
+
+    const commandToRegister = getRootCommand(
+      mockedRepositories,
+      mockedInternalCommands,
+      mockedCommandId
+    )
+
+    const output = await commandToRegister({
+      rootUri: { fsPath: mockedDvcRoot } as Uri
+    })
+
+    expect(output).toBeUndefined()
+    expect(mockedFunc).not.toHaveBeenCalled()
   })
 })

--- a/extension/src/repository/commands/index.test.ts
+++ b/extension/src/repository/commands/index.test.ts
@@ -28,7 +28,7 @@ mockedInternalCommands.registerCommand(mockedCommandId, (...args) =>
 const mockedIsExecutorRunning = jest.fn()
 
 mockedInternalCommands.registerCommand(
-  'isExecutorRunning',
+  'isScmCommandRunning',
   mockedIsExecutorRunning
 )
 

--- a/extension/src/repository/commands/index.test.ts
+++ b/extension/src/repository/commands/index.test.ts
@@ -25,11 +25,11 @@ mockedInternalCommands.registerCommand(mockedCommandId, (...args) =>
   mockedFunc(...args)
 )
 
-const mockedIsExecutorRunning = jest.fn()
+const mockedIsScmCommandRunning = jest.fn()
 
 mockedInternalCommands.registerCommand(
   'isScmCommandRunning',
-  mockedIsExecutorRunning
+  mockedIsScmCommandRunning
 )
 
 const TRY_FORCE = 'Use `-f|--force` to force.'
@@ -189,7 +189,7 @@ describe('getSimpleResourceCommand', () => {
 describe('getRootCommand', () => {
   it('should return a function that returns early if a cwd is not provided', async () => {
     mockedGetCwd.mockResolvedValueOnce(undefined)
-    mockedIsExecutorRunning.mockResolvedValueOnce(false)
+    mockedIsScmCommandRunning.mockResolvedValueOnce(false)
     const stdout = 'I cannot run without a cwd'
     mockedFunc.mockResolvedValueOnce(stdout)
 
@@ -207,7 +207,7 @@ describe('getRootCommand', () => {
 
   it('should return a function that only calls the first function if it succeeds', async () => {
     mockedGetCwd.mockImplementationOnce(uri => uri?.fsPath)
-    mockedIsExecutorRunning.mockResolvedValueOnce(false)
+    mockedIsScmCommandRunning.mockResolvedValueOnce(false)
     const stdout = 'all went well, congrats'
     mockedFunc.mockResolvedValueOnce(stdout)
 
@@ -228,7 +228,7 @@ describe('getRootCommand', () => {
 
   it('should return a function that throws an error if the underlying function fails without a force prompt', async () => {
     mockedGetCwd.mockImplementationOnce(uri => uri?.fsPath)
-    mockedIsExecutorRunning.mockResolvedValueOnce(false)
+    mockedIsScmCommandRunning.mockResolvedValueOnce(false)
     const stderr = 'I deed'
     mockedFunc.mockRejectedValueOnce({ stderr })
 
@@ -249,7 +249,7 @@ describe('getRootCommand', () => {
 
   it('should return a function that calls warnOfConsequences if the first function fails with a force prompt', async () => {
     mockedGetCwd.mockImplementationOnce(uri => uri?.fsPath)
-    mockedIsExecutorRunning.mockResolvedValueOnce(false)
+    mockedIsScmCommandRunning.mockResolvedValueOnce(false)
     const stderr = `I deed, but ${TRY_FORCE}`
     const userCancelled = undefined
     mockedFunc.mockRejectedValueOnce({ stderr })
@@ -271,7 +271,7 @@ describe('getRootCommand', () => {
 
   it('should return a function that does not call the force func if the user selects cancel', async () => {
     mockedGetCwd.mockImplementationOnce(uri => uri?.fsPath)
-    mockedIsExecutorRunning.mockResolvedValueOnce(false)
+    mockedIsScmCommandRunning.mockResolvedValueOnce(false)
     const stderr = `You don't have to do this, but ${TRY_FORCE}`
     const userCancelled = 'Cancel'
     mockedFunc.mockRejectedValueOnce({ stderr })
@@ -293,7 +293,7 @@ describe('getRootCommand', () => {
 
   it('should return a function that does not call the force func if no stderr is returned in the underlying error', async () => {
     mockedGetCwd.mockImplementationOnce(uri => uri?.fsPath)
-    mockedIsExecutorRunning.mockResolvedValueOnce(false)
+    mockedIsScmCommandRunning.mockResolvedValueOnce(false)
     const userCancelled = 'Cancel'
     mockedFunc.mockRejectedValueOnce({})
     mockedGetWarningResponse.mockResolvedValueOnce(userCancelled)
@@ -315,7 +315,7 @@ describe('getRootCommand', () => {
 
   it('should return a function that calls the force function if the first function fails with a force prompt and the user responds with force', async () => {
     mockedGetCwd.mockImplementationOnce(uri => uri?.fsPath)
-    mockedIsExecutorRunning.mockResolvedValueOnce(false)
+    mockedIsScmCommandRunning.mockResolvedValueOnce(false)
     const stderr = `I can fix this... maybe, but ${TRY_FORCE}`
     const forcedStdout = 'ok, nw I forced it'
     const userApproves = 'Force'
@@ -342,7 +342,7 @@ describe('getRootCommand', () => {
 
   it('should return a function that returns early if another user initiated command is running', async () => {
     mockedGetCwd.mockImplementationOnce(uri => uri?.fsPath)
-    mockedIsExecutorRunning.mockResolvedValueOnce(true)
+    mockedIsScmCommandRunning.mockResolvedValueOnce(true)
 
     const commandToRegister = getRootCommand(
       mockedRepositories,

--- a/extension/src/repository/commands/index.ts
+++ b/extension/src/repository/commands/index.ts
@@ -49,7 +49,7 @@ const shouldTitleCommandReturnNoop = async (
   return (
     !cwd ||
     (await internalCommands.executeCommand<boolean>(
-      AvailableCommands.IS_EXECUTOR_RUNNING
+      AvailableCommands.IS_SCM_COMMAND_RUNNING
     ))
   )
 }

--- a/extension/src/repository/commands/index.ts
+++ b/extension/src/repository/commands/index.ts
@@ -42,6 +42,18 @@ export type Root = { rootUri: Uri }
 
 type RootCommand = (context?: Root) => Promise<string | undefined>
 
+const shouldTitleCommandReturnNoop = async (
+  cwd: string | undefined,
+  internalCommands: InternalCommands
+): Promise<boolean> => {
+  return (
+    !cwd ||
+    (await internalCommands.executeCommand<boolean>(
+      AvailableCommands.IS_EXECUTOR_RUNNING
+    ))
+  )
+}
+
 export const getRootCommand =
   (
     repositories: WorkspaceRepositories,
@@ -51,11 +63,11 @@ export const getRootCommand =
   async context => {
     const cwd = await repositories.getCwd(context?.rootUri)
 
-    if (!cwd) {
+    if (await shouldTitleCommandReturnNoop(cwd, internalCommands)) {
       return
     }
 
-    return tryThenMaybeForce(internalCommands, commandId, cwd)
+    return tryThenMaybeForce(internalCommands, commandId, cwd as string)
   }
 
 export const getStageAllCommand =
@@ -91,11 +103,15 @@ export const getCommitRootCommand =
   async context => {
     const cwd = await repositories.getCwdWithChanges(context?.rootUri)
 
-    if (!cwd) {
+    if (await shouldTitleCommandReturnNoop(cwd, internalCommands)) {
       return
     }
 
-    await tryThenMaybeForce(internalCommands, AvailableCommands.COMMIT, cwd)
+    await tryThenMaybeForce(
+      internalCommands,
+      AvailableCommands.COMMIT,
+      cwd as string
+    )
     return commands.executeCommand('workbench.scm.focus')
   }
 
@@ -107,7 +123,7 @@ export const getResetRootCommand =
   async context => {
     const cwd = await repositories.getCwdWithChanges(context?.rootUri)
 
-    if (!cwd) {
+    if (await shouldTitleCommandReturnNoop(cwd, internalCommands)) {
       return
     }
 
@@ -122,11 +138,11 @@ export const getResetRootCommand =
       return
     }
 
-    await gitResetWorkspace(cwd)
+    await gitResetWorkspace(cwd as string)
 
     return internalCommands.executeCommand(
       AvailableCommands.CHECKOUT,
-      cwd,
+      cwd as string,
       Flag.FORCE
     )
   }

--- a/extension/src/test/suite/repository/sourceControlManagement.test.ts
+++ b/extension/src/test/suite/repository/sourceControlManagement.test.ts
@@ -297,5 +297,24 @@ suite('Source Control Management Test Suite', () => {
         executable: 'git'
       })
     })
+
+    it('should not reset the workspace if there is another user initiated command running', async () => {
+      const mockCheckout = stub(CliExecutor.prototype, 'checkout').resolves('')
+      const mockGitReset = stub(ProcessExecution, 'executeProcess').resolves('')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      stub(WorkspaceRepositories.prototype as any, 'hasChanges').returns(true)
+
+      stub(CliExecutor.prototype, 'isExecutorRunning').returns(true)
+
+      await commands.executeCommand(
+        RegisteredCommands.DISCARD_WORKSPACE_CHANGES,
+        {
+          rootUri
+        }
+      )
+
+      expect(mockCheckout).not.to.be.called
+      expect(mockGitReset).not.to.be.called
+    })
   })
 })

--- a/extension/src/test/suite/repository/sourceControlManagement.test.ts
+++ b/extension/src/test/suite/repository/sourceControlManagement.test.ts
@@ -304,7 +304,7 @@ suite('Source Control Management Test Suite', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       stub(WorkspaceRepositories.prototype as any, 'hasChanges').returns(true)
 
-      stub(CliExecutor.prototype, 'isExecutorRunning').returns(true)
+      stub(CliExecutor.prototype, 'isScmCommandRunning').returns(true)
 
       await commands.executeCommand(
         RegisteredCommands.DISCARD_WORKSPACE_CHANGES,


### PR DESCRIPTION
Fixes https://github.com/iterative/vscode-dvc/issues/606.

The main approach here is to block all of the user-facing SCM commands from being available whenever one is running. This works well with the exception of the `"scm/title"` & `"view/title"` commands. Having these removed from the UI whilst commands are running looked unstable (almost like another bug). I've copied what the git extension does and turned these into no-ops for the time being.

### Demo

https://user-images.githubusercontent.com/37993418/182267033-b1a92c7b-f4fe-4c9c-853f-02bdde86a046.mov


