### PR TITLE
Hide remove all buttons from trees when there is nothing to remove

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1213,7 +1213,7 @@
         },
         {
           "command": "dvc.views.experimentsSortByTree.removeAllSorts",
-          "when": "view == dvc.views.experimentsSortByTree",
+          "when": "view == dvc.views.experimentsSortByTree && dvc.experiments.sorted",
           "group": "navigation@2"
         },
         {
@@ -1223,7 +1223,7 @@
         },
         {
           "command": "dvc.views.experimentsFilterByTree.removeAllFilters",
-          "when": "view == dvc.views.experimentsFilterByTree",
+          "when": "view == dvc.views.experimentsFilterByTree && dvc.experiments.filtered",
           "group": "navigation@2"
         },
         {


### PR DESCRIPTION
Closes https://github.com/iterative/vscode-dvc/issues/1564

### Demo

https://user-images.githubusercontent.com/37993418/182448676-c305f845-b701-4968-b73e-474ee3db0e18.mov


**Note**: Personally I think adding/removing icons to each `view/title` section looks more like a bug. I think it was better to have icons consistently placed as they were previously.