### PR TITLE
Mock vs code commands in scheduled CLI test

### DIFF
--- a/extension/src/vscode/mockModule.ts
+++ b/extension/src/vscode/mockModule.ts
@@ -16,7 +16,8 @@ mock('vscode', {
   EventEmitter: MockEventEmitter,
   Uri: {
     file: URI.file
-  }
+  },
+  commands: { executeCommand: () => undefined }
 })
 
 mock('@hediet/std/disposable', {


### PR DESCRIPTION
The scheduled CLI tests failed today because of a change introduced in #2131. This PR provides the appropriate mock to fix the issue.

See [here](https://github.com/iterative/vscode-dvc/runs/7643377866?check_suite_focus=true) for details.