### PR TITLE
Refine data status consumption

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -901,7 +901,7 @@
         {
           "command": "dvc.checkoutTarget",
           "group": "inline",
-          "when": "scmProvider == dvc && scmResourceGroup == uncommitted && dvc.commands.available && !dvc.scm.command.running"
+          "when": "scmProvider == dvc && scmResourceGroup == uncommitted && scmResourceState != notInCache && dvc.commands.available && !dvc.scm.command.running"
         },
         {
           "command": "dvc.commitTarget",

--- a/extension/src/cli/dvc/reader.ts
+++ b/extension/src/cli/dvc/reader.ts
@@ -6,7 +6,7 @@ import { typeCheckCommands } from '..'
 import { trim, trimAndSplit } from '../../util/stdout'
 import { Plot } from '../../plots/webview/contract'
 
-type Changes = {
+export type Changes = {
   added?: string[]
   deleted?: string[]
   modified?: string[]

--- a/extension/src/repository/decorationProvider.test.ts
+++ b/extension/src/repository/decorationProvider.test.ts
@@ -162,7 +162,7 @@ describe('DecorationProvider', () => {
     )
   })
 
-  it('should provide decorations based on the expected priority', () => {
+  it('should provide a single decoration which is based on a set priority', () => {
     const logs = new Set([logDir, logAcc, logLoss])
 
     const initialState = {

--- a/extension/src/repository/decorationProvider.test.ts
+++ b/extension/src/repository/decorationProvider.test.ts
@@ -2,6 +2,7 @@ import { join } from 'path'
 import { EventEmitter, Uri } from 'vscode'
 import { Disposable, Disposer } from '@hediet/std/disposable'
 import { DecorationProvider, DecorationState } from './decorationProvider'
+import { standardizePath } from '../fileSystem/path'
 
 jest.mock('vscode')
 jest.mock('@hediet/std/disposable')
@@ -24,15 +25,15 @@ beforeEach(() => {
 
 describe('DecorationProvider', () => {
   const dvcRoot = __dirname
-  const model = join(dvcRoot, 'model.pt')
-  const dataDir = join(dvcRoot, 'data')
-  const features = join(dataDir, 'features')
-  const logDir = join(dvcRoot, 'logs')
-  const logAcc = join(logDir, 'acc.tsv')
-  const logLoss = join(logDir, 'loss.tsv')
-  const dataXml = join(dataDir, 'data.xml')
-  const dataCsv = join(dataDir, 'data.csv')
-  const prepared = join(dataDir, 'prepared')
+  const model = standardizePath(join(dvcRoot, 'model.pt')) as string
+  const dataDir = standardizePath(join(dvcRoot, 'data')) as string
+  const features = standardizePath(join(dataDir, 'features')) as string
+  const logDir = standardizePath(join(dvcRoot, 'logs')) as string
+  const logAcc = standardizePath(join(logDir, 'acc.tsv')) as string
+  const logLoss = standardizePath(join(logDir, 'loss.tsv')) as string
+  const dataXml = standardizePath(join(dataDir, 'data.xml')) as string
+  const dataCsv = standardizePath(join(dataDir, 'data.csv')) as string
+  const prepared = standardizePath(join(dataDir, 'prepared')) as string
 
   const emptySet = new Set<string>()
 

--- a/extension/src/repository/decorationProvider.ts
+++ b/extension/src/repository/decorationProvider.ts
@@ -20,6 +20,19 @@ type DecorationStatus =
 
 export type DecorationState = Record<DecorationStatus, Set<string>>
 
+const decorationPriority: DecorationStatus[] = [
+  DecorationDataStatus.NOT_IN_CACHE,
+  DecorationDataStatus.UNCOMMITTED_ADDED,
+  DecorationDataStatus.UNCOMMITTED_DELETED,
+  DecorationDataStatus.UNCOMMITTED_MODIFIED,
+  DecorationDataStatus.UNCOMMITTED_RENAMED,
+  DecorationDataStatus.COMMITTED_ADDED,
+  DecorationDataStatus.COMMITTED_DELETED,
+  DecorationDataStatus.COMMITTED_MODIFIED,
+  DecorationDataStatus.COMMITTED_RENAMED,
+  DecorationDataStatus.TRACKED
+]
+
 export class DecorationProvider
   extends Disposable
   implements FileDecorationProvider
@@ -95,6 +108,7 @@ export class DecorationProvider
     committedModified: DecorationProvider.DecorationCommittedModified,
     committedRenamed: DecorationProvider.DecorationCommittedRenamed,
     notInCache: DecorationProvider.DecorationNotInCache,
+    tracked: DecorationProvider.DecorationTracked,
     uncommittedAdded: DecorationProvider.DecorationUncommittedAdded,
     uncommittedDeleted: DecorationProvider.DecorationUncommittedDeleted,
     uncommittedModified: DecorationProvider.DecorationUncommittedModified,
@@ -117,17 +131,14 @@ export class DecorationProvider
   public provideFileDecoration(uri: Uri): FileDecoration | undefined {
     const path = uri.fsPath
 
-    const decoration = Object.keys(this.decorationMapping).find(status => {
+    const decoration = decorationPriority.find(status => {
       if (this.state[status as DecorationStatus]?.has(path)) {
         return status
       }
-    }) as DecorationStatus
+    })
 
     if (decoration) {
       return this.decorationMapping[decoration]
-    }
-    if (this.state.tracked?.has(path)) {
-      return DecorationProvider.DecorationTracked
     }
   }
 

--- a/extension/src/repository/model/collect.test.ts
+++ b/extension/src/repository/model/collect.test.ts
@@ -141,7 +141,7 @@ describe('collectDataStatus', () => {
     )
   })
 
-  it('should return paths as not in cache and deleted when provided with duplicate paths', () => {
+  it('should not deduplicate path when they are shown as both not in cache and deleted', () => {
     const not_in_cache = ['model.pt', 'misclassified.jpg', 'predictions.json']
 
     const duplicates = {
@@ -163,7 +163,7 @@ describe('collectDataStatus', () => {
     expect(tracked).toStrictEqual(absNotInCache)
   })
 
-  it('should return paths as both committed added and', () => {
+  it('should not deduplicate path when they are shown as both committed and uncommitted', () => {
     const data = join('data', 'MNIST', 'raw')
     const paths = [
       join(data, 't10k-images-idx3-ubyte'),

--- a/extension/src/repository/model/collect.test.ts
+++ b/extension/src/repository/model/collect.test.ts
@@ -141,7 +141,7 @@ describe('collectDataStatus', () => {
     )
   })
 
-  it('should not deduplicate path when they are shown as both not in cache and deleted', () => {
+  it('should not deduplicate paths when they are shown as both not in cache and deleted', () => {
     const not_in_cache = ['model.pt', 'misclassified.jpg', 'predictions.json']
 
     const duplicates = {
@@ -163,7 +163,7 @@ describe('collectDataStatus', () => {
     expect(tracked).toStrictEqual(absNotInCache)
   })
 
-  it('should not deduplicate path when they are shown as both committed and uncommitted', () => {
+  it('should not deduplicate paths when they are shown as both committed and uncommitted', () => {
     const data = join('data', 'MNIST', 'raw')
     const paths = [
       join(data, 't10k-images-idx3-ubyte'),

--- a/extension/src/repository/model/collect.test.ts
+++ b/extension/src/repository/model/collect.test.ts
@@ -141,28 +141,64 @@ describe('collectDataStatus', () => {
     )
   })
 
-  it('should return only not in cache when provided with duplicate paths', () => {
+  it('should return paths as not in cache and deleted when provided with duplicate paths', () => {
     const not_in_cache = ['model.pt', 'misclassified.jpg', 'predictions.json']
 
     const duplicates = {
-      committed: {
-        modified: ['model.pt', 'misclassified.jpg', 'predictions.json']
-      },
       not_in_cache,
       uncommitted: {
         deleted: not_in_cache
       }
     }
 
-    const { committedModified, notInCache, uncommittedDeleted, tracked } =
-      collectDataStatus(dvcDemoPath, duplicates)
+    const { notInCache, uncommittedDeleted, tracked } = collectDataStatus(
+      dvcDemoPath,
+      duplicates
+    )
 
     const absNotInCache = makeAbsPathSet(dvcDemoPath, ...not_in_cache)
 
-    expect(committedModified).toStrictEqual(emptySet)
-    expect(uncommittedDeleted).toStrictEqual(emptySet)
+    expect(uncommittedDeleted).toStrictEqual(absNotInCache)
     expect(notInCache).toStrictEqual(absNotInCache)
     expect(tracked).toStrictEqual(absNotInCache)
+  })
+
+  it('should return paths as both committed added and', () => {
+    const data = join('data', 'MNIST', 'raw')
+    const paths = [
+      join(data, 't10k-images-idx3-ubyte'),
+      join(data, 't10k-images-idx3-ubyte.gz'),
+      join(data, 't10k-labels-idx1-ubyte')
+    ]
+    const dataStatusOutput = {
+      committed: {
+        deleted: [
+          'data/MNIST/raw/t10k-images-idx3-ubyte',
+          'data/MNIST/raw/t10k-images-idx3-ubyte.gz',
+          'data/MNIST/raw/t10k-labels-idx1-ubyte'
+        ],
+        modified: [data + sep]
+      },
+      uncommitted: {
+        added: paths,
+        modified: [data + sep]
+      }
+    }
+
+    const modified = makeAbsPathSet(dvcDemoPath, data)
+    const addedAndDeleted = makeAbsPathSet(dvcDemoPath, ...paths)
+
+    const {
+      committedDeleted,
+      committedModified,
+      uncommittedAdded,
+      uncommittedModified
+    } = collectDataStatus(dvcDemoPath, dataStatusOutput)
+
+    expect(committedDeleted).toStrictEqual(addedAndDeleted)
+    expect(committedModified).toStrictEqual(modified)
+    expect(uncommittedAdded).toStrictEqual(addedAndDeleted)
+    expect(uncommittedModified).toStrictEqual(modified)
   })
 })
 

--- a/extension/src/repository/model/collect.ts
+++ b/extension/src/repository/model/collect.ts
@@ -2,7 +2,7 @@ import { join, relative, resolve } from 'path'
 import { Uri } from 'vscode'
 import { Resource } from '../commands'
 import { addToMapSet } from '../../util/map'
-import { DataStatusOutput } from '../../cli/dvc/reader'
+import { Changes, DataStatusOutput } from '../../cli/dvc/reader'
 import { DecorationDataStatus } from '../decorationProvider'
 import { relativeWithUri } from '../../fileSystem'
 import {

--- a/extension/src/repository/model/index.ts
+++ b/extension/src/repository/model/index.ts
@@ -1,7 +1,12 @@
 import { basename, extname, relative } from 'path'
 import { Uri } from 'vscode'
 import omit from 'lodash.omit'
-import { collectDataStatus, collectTree, DataStatus, PathItem } from './collect'
+import {
+  collectDataStatus,
+  collectTree,
+  DataStatusAccumulator,
+  PathItem
+} from './collect'
 import { UndecoratedDataStatus } from '../constants'
 import {
   SourceControlDataStatus,
@@ -64,7 +69,10 @@ export class RepositoryModel extends Disposable {
     }
   }
 
-  private collectHasChanges(data: DataStatus, hasGitChanges: boolean) {
+  private collectHasChanges(
+    data: DataStatusAccumulator,
+    hasGitChanges: boolean
+  ) {
     this.hasChanges = !!(
       hasGitChanges ||
       data.committedAdded.size > 0 ||
@@ -80,7 +88,7 @@ export class RepositoryModel extends Disposable {
     )
   }
 
-  private getDecorationState(data: DataStatus) {
+  private getDecorationState(data: DataStatusAccumulator) {
     return {
       ...omit(data, ...Object.values(UndecoratedDataStatus)),
       tracked: data.trackedDecorations

--- a/extension/src/repository/sourceControlManagement.ts
+++ b/extension/src/repository/sourceControlManagement.ts
@@ -3,16 +3,16 @@ import { BaseDataStatus } from './constants'
 import { PathItem } from './model/collect'
 import { Disposable } from '../class/dispose'
 
-export type SCMState = {
-  committed: SourceControlResource[]
-  uncommitted: SourceControlResource[]
-  untracked: SourceControlResource[]
-  notInCache: SourceControlResource[]
-}
-
 export const SourceControlDataStatus = Object.assign({}, BaseDataStatus, {
   UNTRACKED: 'untracked'
 } as const)
+
+export type SCMState = {
+  committed: SourceControlResource[]
+  uncommitted: SourceControlResource[]
+  [SourceControlDataStatus.UNTRACKED]: SourceControlResource[]
+  [SourceControlDataStatus.NOT_IN_CACHE]: SourceControlResource[]
+}
 
 export type SourceControlStatus =
   typeof SourceControlDataStatus[keyof typeof SourceControlDataStatus]


### PR DESCRIPTION
# 2/5 `main` <- #2091 <- this <- #2266 <- #2267 <- #2299

This PR improves our use of the new data status command. 

We now:

- Show resources in multiple SCM groups when they are returned by data status.
- Apply a single decoration to each resource based on a prioritized list. We apply not in cache first, then uncommitted, then committed statuses the implementation matches the git extension's approach. 
- Do not show checkout inline for resources that are uncommitted and also not in cache (action would not work).


### Demo

https://user-images.githubusercontent.com/37993418/183329636-d9b3e429-0a92-4c61-8cab-95e66c2d63ea.mov

**Note:** Still need https://github.com/iterative/dvc/issues/8062 to be fixed before I can provide a non-confusing demo of not in cache behaviour.