### PR TITLE
Add option to sort by starred experiments

### DIFF
--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -191,7 +191,9 @@ export class Experiments extends BaseRepository<TableData> {
 
   public async addSort() {
     const columns = this.columns.getTerminalNodes()
-    const sortToAdd = await pickSortToAdd(columns)
+    const columnLikes = addStarredToColumns(columns)
+
+    const sortToAdd = await pickSortToAdd(columnLikes)
     if (!sortToAdd) {
       return
     }

--- a/extension/src/experiments/model/sortBy/quickPick.ts
+++ b/extension/src/experiments/model/sortBy/quickPick.ts
@@ -3,10 +3,10 @@ import { definedAndNonEmpty } from '../../../util/array'
 import { quickPickManyValues, quickPickValue } from '../../../vscode/quickPick'
 import { Title } from '../../../vscode/title'
 import { Toast } from '../../../vscode/toast'
+import { ColumnLike } from '../../columns/like'
 import { pickFromColumnLikes } from '../../columns/quickPick'
-import { Column } from '../../webview/contract'
 
-export const pickSortToAdd = async (columns: Column[]) => {
+export const pickSortToAdd = async (columns: ColumnLike[] | undefined) => {
   const picked = await pickFromColumnLikes(columns, {
     title: Title.SELECT_PARAM_OR_METRIC_SORT
   })


### PR DESCRIPTION
# 2/4 `main` <- #2164 <- this <- #2170 <-#2171

This PR gives users the ability to sort experiments by their starred status.

### Demo

https://user-images.githubusercontent.com/37993418/183797952-6c6b0dfa-08f4-410e-bfa0-9741126b8ab4.mov


