### PR TITLE
Add shortcut to filter experiments to starred

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -101,6 +101,12 @@
         "icon": "$(add)"
       },
       {
+        "title": "%command.addStarredExperimentsTableFilter%",
+        "command": "dvc.addStarredExperimentsTableFilter",
+        "category": "DVC",
+        "icon": "$(star-full)"
+      },
+      {
         "title": "%command.addTarget%",
         "command": "dvc.addTarget",
         "category": "DVC",
@@ -545,6 +551,10 @@
         },
         {
           "command": "dvc.addExperimentsTableSort",
+          "when": "dvc.commands.available && dvc.project.available"
+        },
+        {
+          "command": "dvc.addStarredExperimentsTableFilter",
           "when": "dvc.commands.available && dvc.project.available"
         },
         {
@@ -1015,6 +1025,11 @@
           "when": "view == dvc.views.experimentsFilterByTree && dvc.commands.available && viewItem == dvcRoot"
         },
         {
+          "command": "dvc.addStarredExperimentsTableFilter",
+          "group": "inline",
+          "when": "view == dvc.views.experimentsFilterByTree && dvc.commands.available && viewItem == dvcRoot"
+        },
+        {
           "command": "dvc.views.experimentsFilterByTree.removeFilter",
           "group": "inline",
           "when": "view == dvc.views.experimentsFilterByTree && dvc.commands.available && viewItem != dvcRoot"
@@ -1222,9 +1237,14 @@
           "group": "navigation@1"
         },
         {
+          "command": "dvc.addStarredExperimentsTableFilter",
+          "when": "view == dvc.views.experimentsFilterByTree",
+          "group": "navigation@2"
+        },
+        {
           "command": "dvc.views.experimentsFilterByTree.removeAllFilters",
           "when": "view == dvc.views.experimentsFilterByTree && dvc.experiments.filtered",
-          "group": "navigation@2"
+          "group": "navigation@3"
         },
         {
           "command": "dvc.showPlots",

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -3,6 +3,7 @@
   "description": "Machine learning experiment management with tracking, plots, and data versioning.",
   "command.addExperimentsTableFilter": "Add Filter To Experiments Table",
   "command.addExperimentsTableSort": "Add Or Update Sort On Experiments Table",
+  "command.addStarredExperimentsTableFilter": "Filter Experiments Table to Starred",
   "command.addTarget": "Add Target",
   "command.applyExperiment": "Apply Experiment To Workspace",
   "command.branchExperiment": "Create New Branch From Experiment",

--- a/extension/src/commands/external.ts
+++ b/extension/src/commands/external.ts
@@ -44,6 +44,7 @@ export enum RegisteredCommands {
   EXPERIMENT_COLUMNS_SELECT = 'dvc.views.experimentsColumnsTree.selectColumns',
   EXPERIMENT_DISABLE_AUTO_APPLY_FILTERS = 'dvc.views.experimentsTree.disableAutoApplyFilters',
   EXPERIMENT_FILTER_ADD = 'dvc.addExperimentsTableFilter',
+  EXPERIMENT_FILTER_ADD_STARRED = 'dvc.addStarredExperimentsTableFilter',
   EXPERIMENT_FILTER_REMOVE = 'dvc.views.experimentsFilterByTree.removeFilter',
   EXPERIMENT_FILTERS_REMOVE = 'dvc.removeExperimentsTableFilters',
   EXPERIMENT_FILTERS_REMOVE_ALL = 'dvc.views.experimentsFilterByTree.removeAllFilters',

--- a/extension/src/experiments/commands/register.ts
+++ b/extension/src/experiments/commands/register.ts
@@ -189,6 +189,11 @@ const registerExperimentQuickPickCommands = (
   )
 
   internalCommands.registerExternalCommand(
+    RegisteredCommands.EXPERIMENT_FILTER_ADD_STARRED,
+    (dvcRoot?: string) => experiments.addStarredFilter(dvcRoot)
+  )
+
+  internalCommands.registerExternalCommand(
     RegisteredCommands.EXPERIMENT_FILTERS_REMOVE,
     () => experiments.removeFilters()
   )

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -18,6 +18,7 @@ import { askToDisableAutoApplyFilters } from './toast'
 import { Experiment, ColumnType, TableData } from './webview/contract'
 import { WebviewMessages } from './webview/messages'
 import { DecorationProvider } from './model/decorationProvider'
+import { starredFilter } from './model/filterBy/constants'
 import { ResourceLocator } from '../resourceLocator'
 import { AvailableCommands, InternalCommands } from '../commands/internal'
 import { ExperimentsOutput } from '../cli/reader'
@@ -230,6 +231,11 @@ export class Experiments extends BaseRepository<TableData> {
     }
 
     this.experiments.addFilter(filterToAdd)
+    return this.notifyChanged()
+  }
+
+  public addStarredFilter() {
+    this.experiments.addFilter(starredFilter)
     return this.notifyChanged()
   }
 

--- a/extension/src/experiments/model/filterBy/constants.ts
+++ b/extension/src/experiments/model/filterBy/constants.ts
@@ -1,0 +1,7 @@
+import { Operator } from '.'
+
+export const starredFilter = {
+  operator: Operator.IS_TRUE,
+  path: 'starred',
+  value: undefined
+}

--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -72,6 +72,14 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
     return this.getRepository(dvcRoot).addFilter()
   }
 
+  public async addStarredFilter(overrideRoot?: string) {
+    const dvcRoot = await this.getDvcRoot(overrideRoot)
+    if (!dvcRoot) {
+      return
+    }
+    return this.getRepository(dvcRoot).addStarredFilter()
+  }
+
   public async removeFilters() {
     const dvcRoot = await this.getFocusedOrOnlyOrPickProject()
     if (!dvcRoot) {

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -112,6 +112,7 @@ export interface IEventNamePropertyMapping {
   [EventName.EXPERIMENT_BRANCH]: undefined
   [EventName.EXPERIMENT_COLUMNS_SELECT]: undefined
   [EventName.EXPERIMENT_FILTER_ADD]: undefined
+  [EventName.EXPERIMENT_FILTER_ADD_STARRED]: undefined
   [EventName.EXPERIMENT_FILTER_REMOVE]: undefined
   [EventName.EXPERIMENT_FILTERS_REMOVE]: undefined
   [EventName.EXPERIMENT_FILTERS_REMOVE_ALL]: undefined

--- a/extension/src/test/suite/experiments/model/filterBy/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/filterBy/tree.test.ts
@@ -528,6 +528,6 @@ suite('Experiments Filter By Tree Test Suite', () => {
       )
 
       expect(mockAddFilter).to.be.calledWith(starredFilter)
-    }).timeout(WEBVIEW_TEST_TIMEOUT)
+    })
   })
 })

--- a/extension/src/test/suite/experiments/model/filterBy/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/filterBy/tree.test.ts
@@ -33,6 +33,7 @@ import {
   ExperimentsFilterByTree,
   FilterItem
 } from '../../../../../experiments/model/filterBy/tree'
+import { starredFilter } from '../../../../../experiments/model/filterBy/constants'
 
 suite('Experiments Filter By Tree Test Suite', () => {
   const disposable = Disposable.fn()
@@ -479,12 +480,6 @@ suite('Experiments Filter By Tree Test Suite', () => {
         'getFocusedOrOnlyOrPickProject'
       ).returns(dvcDemoPath)
 
-      const starredFilter = {
-        operator: Operator.IS_TRUE,
-        path: 'starred',
-        value: undefined
-      }
-
       await addFilterViaQuickInput(experiments, starredFilter)
 
       const [workspace, main] = rowsFixture
@@ -512,6 +507,27 @@ suite('Experiments Filter By Tree Test Suite', () => {
       }
 
       expect(messageSpy).to.be.calledWith(filteredTableData)
+    }).timeout(WEBVIEW_TEST_TIMEOUT)
+
+    it('should provide a shortcut to filter to starred experiments', async () => {
+      const { experiments, experimentsModel } = buildExperiments(disposable)
+
+      await experiments.isReady()
+
+      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
+      stub(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (WorkspaceExperiments as any).prototype,
+        'getFocusedOrOnlyOrPickProject'
+      ).returns(dvcDemoPath)
+
+      const mockAddFilter = stub(experimentsModel, 'addFilter')
+
+      await commands.executeCommand(
+        RegisteredCommands.EXPERIMENT_FILTER_ADD_STARRED
+      )
+
+      expect(mockAddFilter).to.be.calledWith(starredFilter)
     }).timeout(WEBVIEW_TEST_TIMEOUT)
   })
 })


### PR DESCRIPTION
# 3/4 `main` <- #2164 <- #2169 <- this <- #2171

This PR adds a command to the palette and the experiments filter by tree view/title which will add the starred filter to the table filters.

### Demo

https://user-images.githubusercontent.com/37993418/183807159-157892f0-08c5-4070-9524-67b37805a5d8.mov
