### PR TITLE
Add shortcut to sort experiments by starred

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1249,7 +1249,7 @@
         {
           "command": "dvc.views.experimentsSortByTree.removeAllSorts",
           "when": "view == dvc.views.experimentsSortByTree && dvc.experiments.sorted",
-          "group": "navigation@2"
+          "group": "navigation@3"
         },
         {
           "command": "dvc.addExperimentsTableFilter",

--- a/extension/package.json
+++ b/extension/package.json
@@ -107,6 +107,12 @@
         "icon": "$(star-full)"
       },
       {
+        "title": "%command.addStarredExperimentsTableSort%",
+        "command": "dvc.addStarredExperimentsTableSort",
+        "category": "DVC",
+        "icon": "$(star-full)"
+      },
+      {
         "title": "%command.addTarget%",
         "command": "dvc.addTarget",
         "category": "DVC",
@@ -555,6 +561,10 @@
         },
         {
           "command": "dvc.addStarredExperimentsTableFilter",
+          "when": "dvc.commands.available && dvc.project.available"
+        },
+        {
+          "command": "dvc.addStarredExperimentsTableSort",
           "when": "dvc.commands.available && dvc.project.available"
         },
         {
@@ -1010,6 +1020,11 @@
           "when": "view == dvc.views.experimentsSortByTree && dvc.commands.available && viewItem == dvcRoot"
         },
         {
+          "command": "dvc.addStarredExperimentsTableSort",
+          "group": "inline",
+          "when": "view == dvc.views.experimentsSortByTree && dvc.commands.available && viewItem == dvcRoot"
+        },
+        {
           "command": "dvc.views.experimentsSortByTree.removeSort",
           "group": "inline",
           "when": "view == dvc.views.experimentsSortByTree && dvc.commands.available && viewItem != dvcRoot"
@@ -1225,6 +1240,11 @@
           "command": "dvc.addExperimentsTableSort",
           "when": "view == dvc.views.experimentsSortByTree",
           "group": "navigation@1"
+        },
+        {
+          "command": "dvc.addStarredExperimentsTableSort",
+          "when": "view == dvc.views.experimentsSortByTree",
+          "group": "navigation@2"
         },
         {
           "command": "dvc.views.experimentsSortByTree.removeAllSorts",

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -4,6 +4,7 @@
   "command.addExperimentsTableFilter": "Add Filter To Experiments Table",
   "command.addExperimentsTableSort": "Add Or Update Sort On Experiments Table",
   "command.addStarredExperimentsTableFilter": "Filter Experiments Table to Starred",
+  "command.addStarredExperimentsTableSort": "Sort Experiments Table by Starred",
   "command.addTarget": "Add Target",
   "command.applyExperiment": "Apply Experiment To Workspace",
   "command.branchExperiment": "Create New Branch From Experiment",

--- a/extension/src/commands/external.ts
+++ b/extension/src/commands/external.ts
@@ -52,6 +52,7 @@ export enum RegisteredCommands {
   EXPERIMENT_SELECT = 'dvc.views.experimentsTree.selectExperiments',
   EXPERIMENT_SHOW = 'dvc.showExperiments',
   EXPERIMENT_SORT_ADD = 'dvc.addExperimentsTableSort',
+  EXPERIMENT_SORT_ADD_STARRED = 'dvc.addStarredExperimentsTableSort',
   EXPERIMENT_SORT_REMOVE = 'dvc.views.experimentsSortByTree.removeSort',
   EXPERIMENT_SORTS_REMOVE = 'dvc.removeExperimentsTableSorts',
   EXPERIMENT_SORTS_REMOVE_ALL = 'dvc.views.experimentsSortByTree.removeAllSorts',

--- a/extension/src/experiments/commands/register.ts
+++ b/extension/src/experiments/commands/register.ts
@@ -204,6 +204,11 @@ const registerExperimentQuickPickCommands = (
   )
 
   internalCommands.registerExternalCommand(
+    RegisteredCommands.EXPERIMENT_SORT_ADD_STARRED,
+    (dvcRoot?: string) => experiments.addStarredSort(dvcRoot)
+  )
+
+  internalCommands.registerExternalCommand(
     RegisteredCommands.EXPERIMENT_SORTS_REMOVE,
     () => experiments.removeSorts()
   )

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -10,6 +10,7 @@ import {
   pickFiltersToRemove
 } from './model/filterBy/quickPick'
 import { tooManySelected } from './model/status'
+import { starredSort } from './model/sortBy/constants'
 import { pickSortsToRemove, pickSortToAdd } from './model/sortBy/quickPick'
 import { ColumnsModel } from './columns/model'
 import { CheckpointsModel } from './checkpoints/model'
@@ -199,6 +200,11 @@ export class Experiments extends BaseRepository<TableData> {
       return
     }
     this.experiments.addSort(sortToAdd)
+    return this.notifyChanged()
+  }
+
+  public addStarredSort() {
+    this.experiments.addSort(starredSort)
     return this.notifyChanged()
   }
 

--- a/extension/src/experiments/model/sortBy/constants.ts
+++ b/extension/src/experiments/model/sortBy/constants.ts
@@ -1,0 +1,1 @@
+export const starredSort = { descending: true, path: 'starred' }

--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -96,6 +96,14 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
     return this.getRepository(dvcRoot).addSort()
   }
 
+  public async addStarredSort(overrideRoot?: string) {
+    const dvcRoot = await this.getDvcRoot(overrideRoot)
+    if (!dvcRoot) {
+      return
+    }
+    return this.getRepository(dvcRoot).addStarredSort()
+  }
+
   public async removeSorts() {
     const dvcRoot = await this.getFocusedOrOnlyOrPickProject()
     if (!dvcRoot) {

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -128,6 +128,7 @@ export interface IEventNamePropertyMapping {
   [EventName.EXPERIMENT_SELECT]: undefined
   [EventName.EXPERIMENT_SHOW]: undefined
   [EventName.EXPERIMENT_SORT_ADD]: undefined
+  [EventName.EXPERIMENT_SORT_ADD_STARRED]: undefined
   [EventName.EXPERIMENT_SORT_REMOVE]: undefined
   [EventName.EXPERIMENT_SORTS_REMOVE]: undefined
   [EventName.EXPERIMENT_SORTS_REMOVE_ALL]: undefined

--- a/extension/src/test/suite/experiments/model/sortBy/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/sortBy/tree.test.ts
@@ -301,13 +301,13 @@ suite('Experiments Sort By Tree Test Suite', () => {
         'getFocusedOrOnlyOrPickProject'
       ).returns(dvcDemoPath)
 
-      const mockAddFilter = stub(experimentsModel, 'addSort')
+      const mockAddSort = stub(experimentsModel, 'addSort')
 
       await commands.executeCommand(
         RegisteredCommands.EXPERIMENT_SORT_ADD_STARRED
       )
 
-      expect(mockAddFilter).to.be.calledWith(starredSort)
+      expect(mockAddSort).to.be.calledWith(starredSort)
     })
   })
 })

--- a/extension/src/test/suite/experiments/model/sortBy/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/sortBy/tree.test.ts
@@ -18,6 +18,7 @@ import { buildMetricOrParamPath } from '../../../../../experiments/columns/paths
 import { RegisteredCommands } from '../../../../../commands/external'
 import { ExperimentsOutput } from '../../../../../cli/reader'
 import { WEBVIEW_TEST_TIMEOUT } from '../../../timeouts'
+import { starredSort } from '../../../../../experiments/model/sortBy/constants'
 
 suite('Experiments Sort By Tree Test Suite', () => {
   const testData = {
@@ -287,5 +288,26 @@ suite('Experiments Sort By Tree Test Suite', () => {
         'should not call get repository in removeSorts without a root'
       ).not.to.be.called
     }).timeout(WEBVIEW_TEST_TIMEOUT)
+
+    it('should provide a shortcut to sort by starred experiments', async () => {
+      const { experiments, experimentsModel } = buildExperiments(disposable)
+
+      await experiments.isReady()
+
+      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
+      stub(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (WorkspaceExperiments as any).prototype,
+        'getFocusedOrOnlyOrPickProject'
+      ).returns(dvcDemoPath)
+
+      const mockAddFilter = stub(experimentsModel, 'addSort')
+
+      await commands.executeCommand(
+        RegisteredCommands.EXPERIMENT_SORT_ADD_STARRED
+      )
+
+      expect(mockAddFilter).to.be.calledWith(starredSort)
+    })
   })
 })


### PR DESCRIPTION
# 4/4 `main` <- #2164 <- #2169 <-#2170 <- this

This PR adds a command to the palette and the experiments sort by tree view/title which will add the starred sort to the table sorts.

### Demo

https://user-images.githubusercontent.com/37993418/183809112-e71f6311-3d8c-4dd2-8e40-a89d87546b79.mov


