### PR TITLE
Add select python interpreter option to setup workspace toast message

### DIFF
--- a/extension/resources/walkthrough/install-dvc.md
+++ b/extension/resources/walkthrough/install-dvc.md
@@ -22,3 +22,6 @@ right environment:
 <p align="center">
   <img src="images/install-dvc-setup-wizard.png" alt="DVC Setup Wizard" />
 </p>
+
+> **Note**: The correct Python interpreter must be set for the current workspace
+> when relying on the Python extension for auto environment activation.

--- a/extension/src/extensions/python.ts
+++ b/extension/src/extensions/python.ts
@@ -1,4 +1,4 @@
-import { Event, Uri } from 'vscode'
+import { commands, Event, Uri } from 'vscode'
 import { executeProcess } from '../processExecution'
 import { getExtensionAPI, isInstalled } from '../vscode/extensions'
 
@@ -54,3 +54,7 @@ export const getOnDidChangePythonExecutionDetails = async () => {
 }
 
 export const isPythonExtensionInstalled = () => isInstalled(PYTHON_EXTENSION_ID)
+
+export const selectPythonInterpreter = () => {
+  commands.executeCommand('python.setInterpreter')
+}

--- a/extension/src/setup.test.ts
+++ b/extension/src/setup.test.ts
@@ -286,7 +286,7 @@ describe('setup', () => {
     expect(mockedInitialize).not.toBeCalled()
   })
 
-  it('should try to select the python interpreter if the workspace contains a DVC project, the cli cannot be found and the user selects select the python interpreter', async () => {
+  it('should try to select the python interpreter if the workspace contains a DVC project, the cli cannot be found and the user decides to select the python interpreter', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
     mockedHasRoots.mockReturnValueOnce(true)
     mockedCanRunCli.mockRejectedValueOnce(new Error('command not found: dvc'))

--- a/extension/src/setup.ts
+++ b/extension/src/setup.ts
@@ -15,7 +15,10 @@ import { getFirstWorkspaceFolder } from './vscode/workspaceFolders'
 import { Response } from './vscode/response'
 import { getSelectTitle, Title } from './vscode/title'
 import { Toast } from './vscode/toast'
-import { isPythonExtensionInstalled } from './extensions/python'
+import {
+  isPythonExtensionInstalled,
+  selectPythonInterpreter
+} from './extensions/python'
 
 const setConfigPath = async (
   option: ConfigKey,
@@ -166,15 +169,19 @@ const warnUserCLIInaccessible = async (
     return
   }
   const response = await Toast.warnWithOptions(
-    'An error was thrown when trying to access the CLI.',
+    'An error was thrown when trying to access the CLI. Please ensure the correct interpreter is set for auto Python environment activation.',
     Response.SETUP_WORKSPACE,
+    Response.SELECT_INTERPRETER,
     Response.NEVER
   )
-  if (response === Response.SETUP_WORKSPACE) {
-    extension.setupWorkspace()
-  }
-  if (response === Response.NEVER) {
-    setUserConfigValue(ConfigKey.DO_NOT_SHOW_CLI_UNAVAILABLE, true)
+
+  switch (response) {
+    case Response.SELECT_INTERPRETER:
+      return selectPythonInterpreter()
+    case Response.SETUP_WORKSPACE:
+      return extension.setupWorkspace()
+    case Response.NEVER:
+      return setUserConfigValue(ConfigKey.DO_NOT_SHOW_CLI_UNAVAILABLE, true)
   }
 }
 

--- a/extension/src/setup.ts
+++ b/extension/src/setup.ts
@@ -16,6 +16,7 @@ import { Response } from './vscode/response'
 import { getSelectTitle, Title } from './vscode/title'
 import { Toast } from './vscode/toast'
 import {
+  getPythonBinPath,
   isPythonExtensionInstalled,
   selectPythonInterpreter
 } from './extensions/python'
@@ -162,17 +163,40 @@ export const setupWorkspace = async (): Promise<boolean> => {
   return pickCliPath()
 }
 
+const getToastText = async (
+  isPythonExtensionInstalled: boolean
+): Promise<string> => {
+  const text = 'An error was thrown when trying to access the CLI.'
+  if (!isPythonExtensionInstalled) {
+    return text
+  }
+  const binPath = await getPythonBinPath()
+
+  return (
+    text +
+    ` For auto Python environment activation ensure the correct interpreter is set. Active Python interpreter: ${binPath}. `
+  )
+}
+
+const getToastOptions = (isPythonExtensionInstalled: boolean): Response[] => {
+  return isPythonExtensionInstalled
+    ? [Response.SETUP_WORKSPACE, Response.SELECT_INTERPRETER, Response.NEVER]
+    : [Response.SETUP_WORKSPACE, Response.NEVER]
+}
+
 const warnUserCLIInaccessible = async (
   extension: IExtension
 ): Promise<void> => {
   if (getConfigValue<boolean>(ConfigKey.DO_NOT_SHOW_CLI_UNAVAILABLE)) {
     return
   }
+
+  const isMsPythonInstalled = isPythonExtensionInstalled()
+  const warningText = await getToastText(isMsPythonInstalled)
+
   const response = await Toast.warnWithOptions(
-    'An error was thrown when trying to access the CLI. Please ensure the correct interpreter is set for auto Python environment activation.',
-    Response.SETUP_WORKSPACE,
-    Response.SELECT_INTERPRETER,
-    Response.NEVER
+    warningText,
+    ...getToastOptions(isMsPythonInstalled)
   )
 
   switch (response) {

--- a/extension/src/vscode/response.ts
+++ b/extension/src/vscode/response.ts
@@ -7,6 +7,7 @@ export enum Response {
   NEVER = "Don't Show Again",
   NO = 'No',
   SELECT_MOST_RECENT = 'Select Most Recent',
+  SELECT_INTERPRETER = 'Select Python Interpreter',
   SETUP_WORKSPACE = 'Setup The Workspace',
   SHOW = 'Show',
   TURN_OFF = 'Turn Off',


### PR DESCRIPTION
Closes #2176

Users can get into a situation where they currently have the wrong Python interpreter selected and expect the environment to auto-activate. This prompt should remind them that they need to set the correct interpreter. 

### Demo

https://user-images.githubusercontent.com/37993418/184568267-5f22caf2-580b-4d83-885c-de5bbd4ffd17.mov

**Edit**: Toast updated to 

<img width="480" alt="image" src="https://user-images.githubusercontent.com/37993418/184580196-988b77b8-576d-4d44-8d89-f7bb3beaa54d.png">
