### PR TITLE
Handle dep being added under the current commit

### DIFF
--- a/extension/src/experiments/columns/extract.ts
+++ b/extension/src/experiments/columns/extract.ts
@@ -58,7 +58,7 @@ const extractDeps = (
   for (const [path, { hash }] of Object.entries(columns)) {
     const value = shortenForLabel(hash)
     acc[path] = {
-      changes: !!value && !!branch && branch?.deps?.[path].value !== value,
+      changes: !!value && !!branch && branch?.deps?.[path]?.value !== value,
       value
     }
   }


### PR DESCRIPTION
There was a bug introduced in https://github.com/iterative/vscode-dvc/pull/2029. The code expects all `deps` to be constant across experiments. Adding a new dep in the workspace would result in a 🧱d extension.

Reported here: https://iterativeai.slack.com/archives/C01RB7BTG4C/p1660181765476829