### PR TITLE
Left align timestamp column text

### DIFF
--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -653,7 +653,7 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
   @extend %baseInnerCell;
   @extend %truncateLeftParent;
   line-height: normal;
-  text-align: right;
+  text-align: left;
 }
 
 .timestampDate {
@@ -669,6 +669,7 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
   @extend %headerCellPadding;
   overflow-x: hidden;
   text-overflow: ellipsis;
+  text-align: left;
 }
 
 .thead {


### PR DESCRIPTION
Current: 

<img width="672" alt="image" src="https://user-images.githubusercontent.com/43496356/184683646-b00edbe9-8cc7-4228-aab7-c8e432d37e5d.png">


PR: 

<img width="765" alt="image" src="https://user-images.githubusercontent.com/43496356/184683528-77e8ab0e-198a-415d-9ba6-4b4a1dc765e7.png">

Part of #2031 
