### PR TITLE
Improve table styles

### DIFF
--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -126,7 +126,7 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
       height: 4px;
       vertical-align: middle;
       border: 1px solid currentColor;
-      background-color: $bg-color;
+      background-color: inherit;
     }
 
     .workspaceWithChanges.unselectedExperiment & {
@@ -145,7 +145,7 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
       border-right: 1.5px solid currentColor;
       border-top: 1.5px solid currentColor;
       animation: spin 1s cubic-bezier(0.53, 0.21, 0.29, 0.67) infinite;
-      background-color: $bg-color;
+      background-color: inherit;
     }
 
     .workspaceWithChanges.runningExperiment & {

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -129,16 +129,20 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
       background-color: $bg-color;
     }
 
-    .unselectedExperiment:hover & {
+    .unselectedExperiment:not(.rowSelected):hover & {
       background-color: $row-hover-background-color;
     }
 
-    .unselectedExperiment .experimentCell:hover & {
+    .unselectedExperiment:not(.rowSelected) .experimentCell:hover & {
       background-color: $cell-hover-background-color;
     }
 
     .workspaceWithChanges.unselectedExperiment & {
       border: 1px solid $changed-color;
+    }
+
+    .rowSelected.unselectedExperiment & {
+      background-color: $row-bg-selected-color;
     }
 
     .queuedExperiment & {
@@ -156,13 +160,13 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
       background-color: $bg-color;
     }
 
-    .runningExperiment:hover & {
+    .runningExperiment:not(.rowSelected):hover & {
       background-color: $row-hover-background-color;
       border-left-color: $row-hover-background-color;
       border-bottom-color: $row-hover-background-color;
     }
 
-    .runningExperiment .experimentCell:hover & {
+    .runningExperiment:not(.rowSelected) .experimentCell:hover & {
       background-color: $cell-hover-background-color;
       border-left-color: $cell-hover-background-color;
       border-bottom-color: $cell-hover-background-color;
@@ -171,6 +175,12 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
     .workspaceWithChanges.runningExperiment & {
       border-right-color: $changed-color;
       border-top-color: $changed-color;
+    }
+
+    .rowSelected.runningExperiment & {
+      background-color: $row-bg-selected-color;
+      border-left-color: $row-bg-selected-color;
+      border-bottom-color: $row-bg-selected-color;
     }
   }
 }

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -126,7 +126,15 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
       height: 4px;
       vertical-align: middle;
       border: 1px solid currentColor;
-      background-color: inherit;
+      background-color: $bg-color;
+    }
+
+    .unselectedExperiment:hover & {
+      background-color: $row-hover-background-color;
+    }
+
+    .unselectedExperiment .experimentCell:hover & {
+      background-color: $cell-hover-background-color;
     }
 
     .workspaceWithChanges.unselectedExperiment & {
@@ -145,7 +153,19 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
       border-right: 1.5px solid currentColor;
       border-top: 1.5px solid currentColor;
       animation: spin 1s cubic-bezier(0.53, 0.21, 0.29, 0.67) infinite;
-      background-color: inherit;
+      background-color: $bg-color;
+    }
+
+    .runningExperiment:hover & {
+      background-color: $row-hover-background-color;
+      border-left-color: $row-hover-background-color;
+      border-bottom-color: $row-hover-background-color;
+    }
+
+    .runningExperiment .experimentCell:hover & {
+      background-color: $cell-hover-background-color;
+      border-left-color: $cell-hover-background-color;
+      border-bottom-color: $cell-hover-background-color;
     }
 
     .workspaceWithChanges.runningExperiment & {
@@ -254,12 +274,14 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
     position: relative;
 
     &:hover:not(.rowSelected) {
-      .td {
+      .td:not(.experimentCell),
+      .experimentCell:before {
         background-color: $row-hover-background-color;
+      }
 
-        &:hover {
-          background-color: $cell-hover-background-color;
-        }
+      .td:hover:not(.experimentCell),
+      .experimentCell:hover:before {
+        background-color: $cell-hover-background-color;
       }
     }
 
@@ -709,6 +731,17 @@ $badge-size: 0.85rem;
 }
 
 .experimentCell {
+  &:before {
+    content: '';
+    top: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+    position: absolute;
+    background-color: transparent;
+  }
+
   .innerCell {
     .indicatorCount {
       display: none;

--- a/webview/src/shared/variables.scss
+++ b/webview/src/shared/variables.scss
@@ -3,7 +3,7 @@ $bg-color: var(--vscode-editor-background);
 $bullet-size: 9px;
 $watermark-color: var(--vscode-descriptionForeground);
 
-$border-color: var(--checkbox-border);
+$border-color: var(--vscode-checkbox-border);
 $metrics-color: var(--vscode-dvc-metrics);
 $params-color: var(--vscode-dvc-params);
 $deps-color: var(--vscode-dvc-deps);


### PR DESCRIPTION
# 1/2 `main` <- this <- #2198 
* add vscode prefix to `--checkbox-border` variable
* keep cell spinners and unselected circles the same bg color as cells
* keep the sticky column from losing opacity on row hover 

**Example of cell spinners and unselected circles**

https://user-images.githubusercontent.com/43496356/184926283-3adc63b2-3fa6-4e2f-9771-01fbd682d27e.mov

**Example of now fully opaque experiment column**

https://user-images.githubusercontent.com/43496356/184946778-bc6421e6-ba2d-415e-aa1f-99db7cb738c1.mov

Followup to #2133