### PR TITLE
Update cell hover styles

### DIFF
--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -133,10 +133,6 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
       background-color: $row-hover-background-color;
     }
 
-    .unselectedExperiment:not(.rowSelected) .experimentCell:hover & {
-      background-color: $cell-hover-background-color;
-    }
-
     .workspaceWithChanges.unselectedExperiment & {
       border: 1px solid $changed-color;
     }
@@ -164,12 +160,6 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
       background-color: $row-hover-background-color;
       border-left-color: $row-hover-background-color;
       border-bottom-color: $row-hover-background-color;
-    }
-
-    .runningExperiment:not(.rowSelected) .experimentCell:hover & {
-      background-color: $cell-hover-background-color;
-      border-left-color: $cell-hover-background-color;
-      border-bottom-color: $cell-hover-background-color;
     }
 
     .workspaceWithChanges.runningExperiment & {
@@ -289,9 +279,17 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
         background-color: $row-hover-background-color;
       }
 
-      .td:hover:not(.experimentCell),
-      .experimentCell:hover:before {
-        background-color: $cell-hover-background-color;
+      .td:hover {
+        border-right-color: $border-color;
+        border-left-color: $border-color;
+
+        &:first-child:before {
+          border-right-color: $border-color;
+        }
+
+        &:last-child {
+          border-right-color: transparent;
+        }
       }
     }
 
@@ -444,6 +442,8 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
     font-size: 0.8rem;
     line-height: 2rem;
     align-items: center;
+    border-right: 1px solid transparent;
+    border-left: 1px solid transparent;
 
     &:first-child {
       .innerCell {
@@ -461,6 +461,12 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
     display: flex;
     flex-flow: row nowrap;
     text-align: left;
+    border-right: none;
+    border-left: none;
+
+    &:before {
+      border-right: 1px solid transparent;
+    }
 
     .innerCell {
       justify-content: flex-start;

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -130,7 +130,11 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
     }
 
     .unselectedExperiment:not(.rowSelected):hover & {
-      background-color: $row-hover-background-color;
+      background-image: linear-gradient(
+          $row-hover-background-color,
+          $row-hover-background-color
+        ),
+        linear-gradient($bg-color, $bg-color);
     }
 
     .workspaceWithChanges.unselectedExperiment & {
@@ -138,7 +142,11 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
     }
 
     .rowSelected.unselectedExperiment & {
-      background-color: $row-bg-selected-color;
+      background-image: linear-gradient(
+          $row-bg-selected-color,
+          $row-bg-selected-color
+        ),
+        linear-gradient($bg-color, $bg-color);
     }
 
     .queuedExperiment & {
@@ -157,7 +165,11 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
     }
 
     .runningExperiment:not(.rowSelected):hover & {
-      background-color: $row-hover-background-color;
+      background-image: linear-gradient(
+          $row-hover-background-color,
+          $row-hover-background-color
+        ),
+        linear-gradient($bg-color, $bg-color);
       border-left-color: $row-hover-background-color;
       border-bottom-color: $row-hover-background-color;
     }
@@ -168,7 +180,11 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
     }
 
     .rowSelected.runningExperiment & {
-      background-color: $row-bg-selected-color;
+      background-image: linear-gradient(
+          $row-bg-selected-color,
+          $row-bg-selected-color
+        ),
+        linear-gradient($bg-color, $bg-color);
       border-left-color: $row-bg-selected-color;
       border-bottom-color: $row-bg-selected-color;
     }

--- a/webview/src/shared/variables.scss
+++ b/webview/src/shared/variables.scss
@@ -21,7 +21,6 @@ $meta-cell-color: var(--vscode-descriptionForeground);
 
 $hover-background-color: var(--vscode-list-hoverBackground);
 $row-hover-background-color: var(--vscode-list-hoverBackground);
-$cell-hover-background-color: var(--vscode-dropdown-background);
 
 $accent-color: var(--button-primary-background);
 


### PR DESCRIPTION
# 2/2 `main` <- #2197 <- this
* add cell horizontal borders instead of updating cell background color, fixing invisible (or near invisible) checkboxes in some themes.

**Example of `main` cell hover style:** 

<img width="949" alt="image" src="https://user-images.githubusercontent.com/43496356/184962664-469b4827-0044-4926-bc67-b1a16e465244.png">

**Example of PR cell hover style:**

https://user-images.githubusercontent.com/43496356/184978628-df891c38-c2a1-46be-8f0a-890302709822.mov

Part of #2133 followup