### PR TITLE
Do not retry CLI process when unexpected error is received

### DIFF
--- a/extension/src/cli/constants.ts
+++ b/extension/src/cli/constants.ts
@@ -2,7 +2,7 @@ export const MIN_CLI_VERSION = '2.11.0'
 export const LATEST_TESTED_CLI_VERSION = '2.13.0'
 export const MAX_CLI_VERSION = '3'
 
-export const EMPTY_REPO_ERROR = 'unexpected error - Empty git repo'
+export const UNEXPECTED_ERROR_CODE = 255
 
 export enum Command {
   ADD = 'add',

--- a/extension/src/cli/constants.ts
+++ b/extension/src/cli/constants.ts
@@ -2,6 +2,8 @@ export const MIN_CLI_VERSION = '2.11.0'
 export const LATEST_TESTED_CLI_VERSION = '2.13.0'
 export const MAX_CLI_VERSION = '3'
 
+export const EMPTY_REPO_ERROR = 'unexpected error - Empty git repo'
+
 export enum Command {
   ADD = 'add',
   CHECKOUT = 'checkout',

--- a/extension/src/cli/reader.test.ts
+++ b/extension/src/cli/reader.test.ts
@@ -79,7 +79,7 @@ describe('CliReader', () => {
       })
     })
 
-    it('should return the default output if the cli returns an empty repo error', async () => {
+    it('should return the default output if the cli returns an unexpected error (255 exit code)', async () => {
       const cwd = __dirname
       const error = new Error('unexpected error - something something')
       ;(error as MaybeConsoleError).exitCode = UNEXPECTED_ERROR_CODE

--- a/extension/src/cli/reader.test.ts
+++ b/extension/src/cli/reader.test.ts
@@ -2,7 +2,8 @@ import { join } from 'path'
 import { EventEmitter } from 'vscode'
 import { Disposable, Disposer } from '@hediet/std/disposable'
 import { CliResult, CliStarted } from '.'
-import { EMPTY_REPO_ERROR } from './constants'
+import { UNEXPECTED_ERROR_CODE } from './constants'
+import { MaybeConsoleError } from './error'
 import { CliReader, ExperimentsOutput } from './reader'
 import { createProcess } from '../processExecution'
 import { getFailingMockedProcess, getMockedProcess } from '../test/util/jest'
@@ -80,8 +81,10 @@ describe('CliReader', () => {
 
     it('should return the default output if the cli returns an empty repo error', async () => {
       const cwd = __dirname
+      const error = new Error('unexpected error - something something')
+      ;(error as MaybeConsoleError).exitCode = UNEXPECTED_ERROR_CODE
       mockedCreateProcess.mockImplementationOnce(() => {
-        throw new Error(EMPTY_REPO_ERROR)
+        throw error
       })
 
       const cliOutput = await cliReader.expShow(cwd)

--- a/extension/src/cli/retry.test.ts
+++ b/extension/src/cli/retry.test.ts
@@ -17,7 +17,7 @@ describe('retry', () => {
 
     const promiseRefresher = jest.fn().mockImplementation(() => promise())
 
-    const output = await retry(promiseRefresher, 'Definitely did not', [])
+    const output = await retry(promiseRefresher, 'Definitely did not')
 
     expect(output).toStrictEqual(returnValue)
 
@@ -45,7 +45,7 @@ describe('retry', () => {
       .fn()
       .mockImplementation(() => unreliablePromise())
 
-    await retry(promiseRefresher, 'Data update', [])
+    await retry(promiseRefresher, 'Data update')
 
     expect(promiseRefresher).toBeCalledTimes(4)
     expect(mockedDelay).toBeCalledTimes(3)

--- a/extension/src/cli/retry.test.ts
+++ b/extension/src/cli/retry.test.ts
@@ -17,7 +17,7 @@ describe('retry', () => {
 
     const promiseRefresher = jest.fn().mockImplementation(() => promise())
 
-    const output = await retry<string>(promiseRefresher, 'Definitely did not')
+    const output = await retry(promiseRefresher, 'Definitely did not', [])
 
     expect(output).toStrictEqual(returnValue)
 
@@ -45,7 +45,7 @@ describe('retry', () => {
       .fn()
       .mockImplementation(() => unreliablePromise())
 
-    await retry<string>(promiseRefresher, 'Data update')
+    await retry(promiseRefresher, 'Data update', [])
 
     expect(promiseRefresher).toBeCalledTimes(4)
     expect(mockedDelay).toBeCalledTimes(3)

--- a/extension/src/cli/retry.ts
+++ b/extension/src/cli/retry.ts
@@ -1,18 +1,35 @@
 import { delay } from '../util/time'
 import { Logger } from '../common/logger'
 
-export const retry = async <T>(
-  getNewPromise: () => Promise<T>,
+const isNonRetryError = (
+  errorMessage: string,
+  nonRetryErrors: string[]
+): boolean => {
+  for (const partialErrorMessage of nonRetryErrors) {
+    if (errorMessage.includes(partialErrorMessage)) {
+      return true
+    }
+  }
+  return false
+}
+
+export const retry = async (
+  getNewPromise: () => Promise<string>,
   args: string,
+  nonRetryErrors: string[],
   waitBeforeRetry = 500
-): Promise<T> => {
+): Promise<string> => {
   try {
     return await getNewPromise()
   } catch (error: unknown) {
     const errorMessage = (error as Error).message
     Logger.error(`${args} failed with ${errorMessage} retrying...`)
 
+    if (isNonRetryError(errorMessage, nonRetryErrors)) {
+      return ''
+    }
+
     await delay(waitBeforeRetry)
-    return retry(getNewPromise, args, waitBeforeRetry * 2)
+    return retry(getNewPromise, args, nonRetryErrors, waitBeforeRetry * 2)
   }
 }

--- a/extension/src/cli/retry.ts
+++ b/extension/src/cli/retry.ts
@@ -4,7 +4,7 @@ import { delay } from '../util/time'
 import { Logger } from '../common/logger'
 
 const isUnexpectedError = (error: unknown): boolean => {
-  return (error as MaybeConsoleError).exitCode === UNEXPECTED_ERROR_CODE
+  return (error as MaybeConsoleError)?.exitCode === UNEXPECTED_ERROR_CODE
 }
 
 export const retry = async (

--- a/extension/src/experiments/data/collect.ts
+++ b/extension/src/experiments/data/collect.ts
@@ -3,8 +3,8 @@ import { ExperimentsOutput } from '../../cli/reader'
 export const collectFiles = (data: ExperimentsOutput): string[] => {
   const files = new Set<string>(
     Object.keys({
-      ...data?.workspace.baseline?.data?.params,
-      ...data?.workspace.baseline?.data?.metrics
+      ...data?.workspace?.baseline?.data?.params,
+      ...data?.workspace?.baseline?.data?.metrics
     }).filter(Boolean)
   )
 

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -277,6 +277,10 @@ export class Experiments extends BaseRepository<TableData> {
   }
 
   public getExperimentCount() {
+    if (!this.columns.hasColumns()) {
+      return 0
+    }
+
     return this.experiments.getExperimentCount()
   }
 

--- a/extension/src/experiments/model/tree.ts
+++ b/extension/src/experiments/model/tree.ts
@@ -268,7 +268,14 @@ export class ExperimentsTree
 
   private getDescription() {
     const dvcRoots = this.experiments.getDvcRoots()
-    if (!definedAndNonEmpty(dvcRoots)) {
+
+    const total = sum(
+      dvcRoots.map(dvcRoot =>
+        this.experiments.getRepository(dvcRoot).getExperimentCount()
+      )
+    )
+
+    if (!total) {
       return
     }
 
@@ -276,12 +283,6 @@ export class ExperimentsTree
       dvcRoots.map(
         dvcRoot =>
           this.experiments.getRepository(dvcRoot).getSelectedRevisions().length
-      )
-    )
-
-    const total = sum(
-      dvcRoots.map(dvcRoot =>
-        this.experiments.getRepository(dvcRoot).getExperimentCount()
       )
     )
 


### PR DESCRIPTION
Extension of #2194 which is part of #2177.

Whilst talking with Ruslan in the DVC cross-team meeting we decided to exclude all unexpected errors from retries. Made more sense to make this the only change instead of branching off #2194.

For unexpected errors default data is now returned and the extension continues as normal. The user will then end up in this state until they make a commit:

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/37993418/184805176-9ce884d9-fa04-4383-bee0-973185a46eaf.png">

### Demo

https://user-images.githubusercontent.com/37993418/184805533-4f2e5460-fb7f-4f35-adf1-7069b62cc6d6.mov

**Note**: `list`, `diff` and `status` all return empty objects under these circumstances.
