### PR TITLE
Handle newly introduced deps (before dvc commit)

### DIFF
--- a/extension/src/cli/reader.ts
+++ b/extension/src/cli/reader.ts
@@ -79,7 +79,7 @@ export interface BaseExperimentFields {
   checkpoint_parent?: string
 }
 
-type Dep = { hash: string; size: number; nfiles: null | number }
+type Dep = { hash: null | string; size: null | number; nfiles: null | number }
 type Out = Dep & { use_cache: boolean; is_data_source: boolean }
 
 export type Deps = RelPathObject<Dep>

--- a/extension/src/experiments/columns/collect/index.test.ts
+++ b/extension/src/experiments/columns/collect/index.test.ts
@@ -5,6 +5,7 @@ import { Column, ColumnType } from '../../webview/contract'
 import outputFixture from '../../../test/fixtures/expShow/output'
 import columnsFixture from '../../../test/fixtures/expShow/columns'
 import workspaceChangesFixture from '../../../test/fixtures/expShow/workspaceChanges'
+import uncommittedDepsFixture from '../../../test/fixtures/expShow/uncommittedDeps'
 import { ExperimentsOutput } from '../../../cli/reader'
 
 describe('collectColumns', () => {
@@ -475,6 +476,15 @@ describe('collectColumns', () => {
         buildDepPath('model.pkl'),
         buildDepPath('src', 'evaluate.py')
       ]
+    )
+  })
+
+  it('should mark new dep files as changes', () => {
+    const changes = collectChanges(uncommittedDepsFixture)
+    expect(changes).toStrictEqual(
+      Object.keys(uncommittedDepsFixture.workspace.baseline.data?.deps || {})
+        .map(dep => `deps:${dep}`)
+        .sort()
     )
   })
 })

--- a/extension/src/experiments/columns/extract.ts
+++ b/extension/src/experiments/columns/extract.ts
@@ -56,10 +56,12 @@ const extractDeps = (
   const acc: DepColumns = {}
 
   for (const [path, { hash }] of Object.entries(columns)) {
-    const value = shortenForLabel(hash)
-    acc[path] = {
-      changes: !!value && !!branch && branch?.deps?.[path]?.value !== value,
-      value
+    const value = shortenForLabel<string | null>(hash)
+    if (value) {
+      acc[path] = {
+        changes: !!branch && branch?.deps?.[path]?.value !== value,
+        value
+      }
     }
   }
 

--- a/extension/src/experiments/model/index.test.ts
+++ b/extension/src/experiments/model/index.test.ts
@@ -10,6 +10,7 @@ import {
   deeplyNestedOutput,
   rows as deeplyNestedRows
 } from '../../test/fixtures/expShow/deeplyNested'
+import uncommittedDepsFixture from '../../test/fixtures/expShow/uncommittedDeps'
 import { buildMockMemento } from '../../test/util'
 import { buildMetricOrParamPath } from '../columns/paths'
 import { Experiment, ColumnType } from '../webview/contract'
@@ -157,6 +158,13 @@ describe('ExperimentsModel', () => {
       }
     }
     expect(changed).toStrictEqual([shaWithChange])
+  })
+
+  it('should handle deps have all null properties (never been committed)', () => {
+    const model = new ExperimentsModel('', buildMockMemento())
+    model.transformAndSet(uncommittedDepsFixture)
+    const [workspace] = model.getExperiments()
+    expect(workspace.deps).toStrictEqual({})
   })
 
   it('should return the expected rows when given the deeply nested output fixture', () => {

--- a/extension/src/test/fixtures/expShow/uncommittedDeps.ts
+++ b/extension/src/test/fixtures/expShow/uncommittedDeps.ts
@@ -1,0 +1,79 @@
+import { ExperimentsOutput } from '../../../cli/reader'
+
+const data: ExperimentsOutput = {
+  workspace: {
+    baseline: {
+      data: {
+        timestamp: null,
+        deps: {
+          data: {
+            hash: null,
+            size: null,
+            nfiles: null
+          },
+          'train.py': {
+            hash: null,
+            size: null,
+            nfiles: null
+          },
+          'requirements.txt': {
+            hash: null,
+            size: null,
+            nfiles: null
+          },
+          model: {
+            hash: null,
+            size: null,
+            nfiles: null
+          },
+          'inference.py': {
+            hash: null,
+            size: null,
+            nfiles: null
+          },
+          predictions: {
+            hash: null,
+            size: null,
+            nfiles: null
+          }
+        },
+        outs: {
+          model: {
+            hash: null,
+            size: null,
+            nfiles: null,
+            use_cache: true,
+            is_data_source: false
+          },
+          predictions: {
+            hash: null,
+            size: null,
+            nfiles: null,
+            use_cache: true,
+            is_data_source: false
+          }
+        },
+        queued: false,
+        running: false,
+        executor: null,
+        metrics: {}
+      }
+    }
+  },
+  '852d4fbd10638ceca4de50ee68d6125b2915f23b': {
+    baseline: {
+      data: {
+        timestamp: '2022-08-13T09:13:15',
+        deps: {},
+        outs: {},
+        queued: false,
+        running: false,
+        executor: null,
+        metrics: {},
+        name: 'main'
+      }
+    }
+  }
+}
+
+export default data

--- a/extension/src/util/string.ts
+++ b/extension/src/util/string.ts
@@ -1,8 +1,3 @@
 export const shortenForLabel = <T extends string | null>(
   strOrNull: T
-): T | string => {
-  if (typeof strOrNull === 'string') {
-    return strOrNull?.slice(0, 7)
-  }
-  return strOrNull
-}
+): T | string => (strOrNull ? strOrNull.slice(0, 7) : strOrNull)

--- a/extension/src/util/string.ts
+++ b/extension/src/util/string.ts
@@ -1,1 +1,8 @@
-export const shortenForLabel = (str: string): string => str.slice(0, 7)
+export const shortenForLabel = <T extends string | null>(
+  strOrNull: T
+): T | string => {
+  if (typeof strOrNull === 'string') {
+    return strOrNull?.slice(0, 7)
+  }
+  return strOrNull
+}


### PR DESCRIPTION
# 1/2 `main` <- this <- #2203 

Related to https://github.com/iterative/vscode-dvc/issues/2177.

When a `dep` is first introduced it with be returned under the workspace record in the `exp show` data like this: 

```
  workspace: {
    baseline: {
      data: {
        ...
        deps: {
          'train.py': {
            hash: null,
            size: null,
            nfiles: null
          },
     ...
```

This previously made the extension fall over. I have changed the types/code to accommodate this situation. See comments inline for details.

### Screenshot

<img width="1728" alt="Screen Shot 2022-08-17 at 1 36 33 pm" src="https://user-images.githubusercontent.com/37993418/185029728-3e7977b6-dd68-4fa6-b356-811b3854a1be.png">

