### PR TITLE
Fix partially hidden header context menus

### DIFF
--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -680,7 +680,7 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
   box-shadow: none;
   position: sticky;
   top: 0;
-  z-index: 4;
+  z-index: 5;
 }
 
 .tableIndicators {


### PR DESCRIPTION
stops context menu from being blocked by the workspace row

**Current:**

<img width="377" alt="image" src="https://user-images.githubusercontent.com/43496356/185179814-730c338d-0554-4d2d-ac65-a4cb34f26b94.png">

**PR:**

<img width="395" alt="image" src="https://user-images.githubusercontent.com/43496356/185180028-25c985b7-05a3-463d-9cf2-9d28ff8cc2c2.png">

Part of #2133 followup