### PR TITLE
Share an experiment from context menus

### DIFF
--- a/demo/dvc.yaml
+++ b/demo/dvc.yaml
@@ -2,21 +2,21 @@ stages:
   train:
     cmd: python train.py
     deps:
-      - data/MNIST/raw
-      - train.py
+    - data/MNIST
+    - train.py
     params:
-      - params.yaml:
+    - params.yaml:
     outs:
-      - model.pt:
-          checkpoint: true
+    - model.pt:
+        checkpoint: true
     metrics:
       - training_metrics.json:
           persist: true
           cache: false
     plots:
-      - training_metrics
-      - misclassified.jpg
-      - predictions.json:
-          template: confusion
-          x: actual
-          y: predicted
+    - training_metrics
+    - misclassified.jpg
+    - predictions.json:
+        template: confusion
+        x: actual
+        y: predicted

--- a/demo/dvc.yaml
+++ b/demo/dvc.yaml
@@ -2,21 +2,21 @@ stages:
   train:
     cmd: python train.py
     deps:
-    - data/MNIST
-    - train.py
+      - data/MNIST/raw
+      - train.py
     params:
-    - params.yaml:
+      - params.yaml:
     outs:
-    - model.pt:
-        checkpoint: true
+      - model.pt:
+          checkpoint: true
     metrics:
       - training_metrics.json:
           persist: true
           cache: false
     plots:
-    - training_metrics
-    - misclassified.jpg
-    - predictions.json:
-        template: confusion
-        x: actual
-        y: predicted
+      - training_metrics
+      - misclassified.jpg
+      - predictions.json:
+          template: confusion
+          x: actual
+          y: predicted

--- a/extension/package.json
+++ b/extension/package.json
@@ -461,6 +461,12 @@
         "icon": "$(play)"
       },
       {
+        "title": "%command.views.experiments.shareExperiment%",
+        "command": "dvc.views.experiments.shareExperiment",
+        "category": "DVC",
+        "icon": "$(repo-push)"
+      },
+      {
         "title": "%command.views.experimentsTree.selectExperiments%",
         "command": "dvc.views.experimentsTree.selectExperiments",
         "category": "DVC",
@@ -784,6 +790,10 @@
           "when": "false"
         },
         {
+          "command": "dvc.views.experiments.shareExperiment",
+          "when": "false"
+        },
+        {
           "command": "dvc.views.experimentsFilterByTree.removeAllFilters",
           "when": "false"
         },
@@ -1088,6 +1098,11 @@
           "command": "dvc.views.experiments.queueExperiment",
           "group": "1_modify@3",
           "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(workspace|branch|experiment|queued)$/ && !dvc.experiment.running"
+        },
+        {
+          "command": "dvc.views.experiments.shareExperiment",
+          "group": "2_share@1",
+          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem == experiment && !dvc.experiment.running"
         },
         {
           "command": "dvc.views.experimentsTree.selectExperiments",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1080,29 +1080,29 @@
           "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(experiment|queued)$/ && !dvc.experiment.running"
         },
         {
+          "command": "dvc.views.experiments.shareExperiment",
+          "group": "1_share@1",
+          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(checkpoint|experiment)$/ && !dvc.experiment.running"
+        },
+        {
           "command": "dvc.views.experiments.runExperiment",
-          "group": "1_modify@1",
+          "group": "2_modify@1",
           "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(workspace|branch|experiment|queued)$/ && !dvc.experiment.running && !dvc.experiment.checkpoints"
         },
         {
           "command": "dvc.views.experiments.resetAndRunCheckpointExperiment",
-          "group": "1_modify@1",
+          "group": "2_modify@1",
           "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(workspace|branch|experiment|queued)$/ && !dvc.experiment.running && dvc.experiment.checkpoints"
         },
         {
           "command": "dvc.views.experiments.resumeCheckpointExperiment",
-          "group": "1_modify@2",
+          "group": "2_modify@2",
           "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(workspace|branch|experiment|queued)$/ && !dvc.experiment.running && dvc.experiment.checkpoints"
         },
         {
           "command": "dvc.views.experiments.queueExperiment",
-          "group": "1_modify@3",
+          "group": "2_modify@3",
           "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(workspace|branch|experiment|queued)$/ && !dvc.experiment.running"
-        },
-        {
-          "command": "dvc.views.experiments.shareExperiment",
-          "group": "2_share@1",
-          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(checkpoint|experiment)$/ && !dvc.experiment.running"
         },
         {
           "command": "dvc.views.experimentsTree.selectExperiments",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1102,7 +1102,7 @@
         {
           "command": "dvc.views.experiments.shareExperiment",
           "group": "2_share@1",
-          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem == experiment && !dvc.experiment.running"
+          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(checkpoint|experiment)$/ && !dvc.experiment.running"
         },
         {
           "command": "dvc.views.experimentsTree.selectExperiments",

--- a/extension/package.json
+++ b/extension/package.json
@@ -461,8 +461,8 @@
         "icon": "$(play)"
       },
       {
-        "title": "%command.views.experiments.shareExperiment%",
-        "command": "dvc.views.experiments.shareExperiment",
+        "title": "%command.views.experiments.shareExperimentAsBranch%",
+        "command": "dvc.views.experiments.shareExperimentAsBranch",
         "category": "DVC",
         "icon": "$(repo-push)"
       },
@@ -790,7 +790,7 @@
           "when": "false"
         },
         {
-          "command": "dvc.views.experiments.shareExperiment",
+          "command": "dvc.views.experiments.shareExperimentAsBranch",
           "when": "false"
         },
         {
@@ -1080,7 +1080,7 @@
           "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(experiment|queued)$/ && !dvc.experiment.running"
         },
         {
-          "command": "dvc.views.experiments.shareExperiment",
+          "command": "dvc.views.experiments.shareExperimentAsBranch",
           "group": "1_share@1",
           "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(checkpoint|experiment)$/ && !dvc.experiment.running"
         },

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -67,7 +67,7 @@
   "command.views.experiments.runExperiment": "Modify Param(s) and Run",
   "command.views.experiments.resumeCheckpointExperiment": "Modify Param(s) and Resume",
   "command.views.experiments.resetAndRunCheckpointExperiment": "Modify Param(s), Reset and Run",
-  "command.views.experiments.shareExperiment": "Share",
+  "command.views.experiments.shareExperimentAsBranch": "Share as Branch",
   "command.views.experimentsTree.selectExperiments": "Select Experiments to Display in Plots",
   "command.views.plotsPathsTree.selectPlots": "Select Plots to Display",
   "command.views.plotsPathsTree.refreshPlots": "Refresh Plots for Selected Experiments",

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -67,7 +67,7 @@
   "command.views.experiments.runExperiment": "Modify Param(s) and Run",
   "command.views.experiments.resumeCheckpointExperiment": "Modify Param(s) and Resume",
   "command.views.experiments.resetAndRunCheckpointExperiment": "Modify Param(s), Reset and Run",
-  "command.views.experiments.shareExperimentAsBranch": "Share as Branch",
+  "command.views.experiments.shareExperimentAsBranchAsBranch": "Share as Branch",
   "command.views.experimentsTree.selectExperiments": "Select Experiments to Display in Plots",
   "command.views.plotsPathsTree.selectPlots": "Select Plots to Display",
   "command.views.plotsPathsTree.refreshPlots": "Refresh Plots for Selected Experiments",

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -67,6 +67,7 @@
   "command.views.experiments.runExperiment": "Modify Param(s) and Run",
   "command.views.experiments.resumeCheckpointExperiment": "Modify Param(s) and Resume",
   "command.views.experiments.resetAndRunCheckpointExperiment": "Modify Param(s), Reset and Run",
+  "command.views.experiments.shareExperiment": "Share Experiment",
   "command.views.experimentsTree.selectExperiments": "Select Experiments to Display in Plots",
   "command.views.plotsPathsTree.selectPlots": "Select Plots to Display",
   "command.views.plotsPathsTree.refreshPlots": "Refresh Plots for Selected Experiments",

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -67,7 +67,7 @@
   "command.views.experiments.runExperiment": "Modify Param(s) and Run",
   "command.views.experiments.resumeCheckpointExperiment": "Modify Param(s) and Resume",
   "command.views.experiments.resetAndRunCheckpointExperiment": "Modify Param(s), Reset and Run",
-  "command.views.experiments.shareExperiment": "Share Experiment",
+  "command.views.experiments.shareExperiment": "Share",
   "command.views.experimentsTree.selectExperiments": "Select Experiments to Display in Plots",
   "command.views.plotsPathsTree.selectPlots": "Select Plots to Display",
   "command.views.plotsPathsTree.refreshPlots": "Refresh Plots for Selected Experiments",

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -67,7 +67,7 @@
   "command.views.experiments.runExperiment": "Modify Param(s) and Run",
   "command.views.experiments.resumeCheckpointExperiment": "Modify Param(s) and Resume",
   "command.views.experiments.resetAndRunCheckpointExperiment": "Modify Param(s), Reset and Run",
-  "command.views.experiments.shareExperimentAsBranchAsBranch": "Share as Branch",
+  "command.views.experiments.shareExperimentAsBranch": "Share as Branch",
   "command.views.experimentsTree.selectExperiments": "Select Experiments to Display in Plots",
   "command.views.plotsPathsTree.selectPlots": "Select Plots to Display",
   "command.views.plotsPathsTree.refreshPlots": "Refresh Plots for Selected Experiments",

--- a/extension/src/commands/external.ts
+++ b/extension/src/commands/external.ts
@@ -14,7 +14,7 @@ export enum RegisteredCliCommands {
   EXPERIMENT_VIEW_APPLY = 'dvc.views.experiments.applyExperiment',
   EXPERIMENT_VIEW_BRANCH = 'dvc.views.experiments.branchExperiment',
   EXPERIMENT_VIEW_REMOVE = 'dvc.views.experiments.removeExperiment',
-  EXPERIMENT_VIEW_SHARE = 'dvc.views.experiments.shareExperiment',
+  EXPERIMENT_VIEW_SHARE_AS_BRANCH = 'dvc.views.experiments.shareExperimentAsBranch',
 
   EXPERIMENT_VIEW_QUEUE = 'dvc.views.experiments.queueExperiment',
   EXPERIMENT_VIEW_RESUME = 'dvc.views.experiments.resumeCheckpointExperiment',

--- a/extension/src/commands/external.ts
+++ b/extension/src/commands/external.ts
@@ -14,6 +14,7 @@ export enum RegisteredCliCommands {
   EXPERIMENT_VIEW_APPLY = 'dvc.views.experiments.applyExperiment',
   EXPERIMENT_VIEW_BRANCH = 'dvc.views.experiments.branchExperiment',
   EXPERIMENT_VIEW_REMOVE = 'dvc.views.experiments.removeExperiment',
+  EXPERIMENT_VIEW_SHARE = 'dvc.views.experiments.shareExperiment',
 
   EXPERIMENT_VIEW_QUEUE = 'dvc.views.experiments.queueExperiment',
   EXPERIMENT_VIEW_RESUME = 'dvc.views.experiments.resumeCheckpointExperiment',

--- a/extension/src/experiments/commands/register.ts
+++ b/extension/src/experiments/commands/register.ts
@@ -156,13 +156,13 @@ const registerExperimentInputCommands = (
     RegisteredCliCommands.EXPERIMENT_BRANCH,
     () =>
       experiments.getCwdExpNameAndInputThenRun(
-        Title.ENTER_BRANCH_NAME,
         (cwd, ...args: Args) =>
           experiments.runCommand(
             AvailableCommands.EXPERIMENT_BRANCH,
             cwd,
             ...args
-          )
+          ),
+        Title.ENTER_BRANCH_NAME
       )
   )
 
@@ -170,16 +170,16 @@ const registerExperimentInputCommands = (
     RegisteredCliCommands.EXPERIMENT_VIEW_BRANCH,
     ({ dvcRoot, id }: ExperimentDetails) =>
       experiments.getExpNameAndInputThenRun(
-        Title.ENTER_BRANCH_NAME,
-        dvcRoot,
-        id,
         (name: string, input: string) =>
           experiments.runCommand(
             AvailableCommands.EXPERIMENT_BRANCH,
             dvcRoot,
             name,
             input
-          )
+          ),
+        Title.ENTER_BRANCH_NAME,
+        dvcRoot,
+        id
       )
   )
 
@@ -187,9 +187,6 @@ const registerExperimentInputCommands = (
     RegisteredCliCommands.EXPERIMENT_VIEW_SHARE_AS_BRANCH,
     ({ dvcRoot, id }: ExperimentDetails) =>
       experiments.getExpNameAndInputThenRun(
-        Title.ENTER_BRANCH_NAME,
-        dvcRoot,
-        id,
         async (name: string, input: string) => {
           await experiments.runCommand(
             AvailableCommands.EXPERIMENT_BRANCH,
@@ -204,7 +201,10 @@ const registerExperimentInputCommands = (
           )
           await experiments.runCommand(AvailableCommands.PUSH, dvcRoot)
           return Toast.showOutput(gitPushBranch(dvcRoot, input))
-        }
+        },
+        Title.ENTER_BRANCH_NAME,
+        dvcRoot,
+        id
       )
   )
 }

--- a/extension/src/experiments/commands/register.ts
+++ b/extension/src/experiments/commands/register.ts
@@ -8,6 +8,7 @@ import {
 import { Title } from '../../vscode/title'
 import { gitPushBranch } from '../../git'
 import { Toast } from '../../vscode/toast'
+import { Args } from '../../cli/constants'
 
 type ExperimentDetails = { dvcRoot: string; id: string }
 
@@ -151,22 +152,22 @@ const registerExperimentInputCommands = (
   experiments: WorkspaceExperiments,
   internalCommands: InternalCommands
 ): void => {
-  // internalCommands.registerExternalCliCommand(
-  //   RegisteredCliCommands.EXPERIMENT_BRANCH,
-  //   () =>
-  //     experiments.getCwdExpNameAndInputThenRun(
-  //       Title.ENTER_BRANCH_NAME,
-  //       (cwd, ...args: Args) =>
-  //         experiments.runCommand(
-  //           AvailableCommands.EXPERIMENT_BRANCH,
-  //           cwd,
-  //           ...args
-  //         )
-  //     )
-  // )
+  internalCommands.registerExternalCliCommand(
+    RegisteredCliCommands.EXPERIMENT_BRANCH,
+    () =>
+      experiments.getCwdExpNameAndInputThenRun(
+        Title.ENTER_BRANCH_NAME,
+        (cwd, ...args: Args) =>
+          experiments.runCommand(
+            AvailableCommands.EXPERIMENT_BRANCH,
+            cwd,
+            ...args
+          )
+      )
+  )
 
   internalCommands.registerExternalCliCommand(
-    RegisteredCliCommands.EXPERIMENT_VIEW_BRANCH,
+    RegisteredCliCommands.EXPERIMENT_VIEW_SHARE,
     ({ dvcRoot, id }: ExperimentDetails) =>
       experiments.getExpNameAndInputThenRun(
         Title.ENTER_BRANCH_NAME,

--- a/extension/src/experiments/commands/register.ts
+++ b/extension/src/experiments/commands/register.ts
@@ -184,7 +184,7 @@ const registerExperimentInputCommands = (
   )
 
   internalCommands.registerExternalCliCommand(
-    RegisteredCliCommands.EXPERIMENT_VIEW_SHARE,
+    RegisteredCliCommands.EXPERIMENT_VIEW_SHARE_AS_BRANCH,
     ({ dvcRoot, id }: ExperimentDetails) =>
       experiments.getExpNameAndInputThenRun(
         Title.ENTER_BRANCH_NAME,

--- a/extension/src/experiments/commands/register.ts
+++ b/extension/src/experiments/commands/register.ts
@@ -203,8 +203,7 @@ const registerExperimentInputCommands = (
             name
           )
           await experiments.runCommand(AvailableCommands.PUSH, dvcRoot)
-          const std = gitPushBranch(dvcRoot, input)
-          return Toast.showOutput(std)
+          return Toast.showOutput(gitPushBranch(dvcRoot, input))
         }
       )
   )

--- a/extension/src/experiments/commands/register.ts
+++ b/extension/src/experiments/commands/register.ts
@@ -6,6 +6,7 @@ import {
   RegisteredCommands
 } from '../../commands/external'
 import { Title } from '../../vscode/title'
+import { Args } from '../../cli/constants'
 
 type ExperimentDetails = { dvcRoot: string; id: string }
 
@@ -153,8 +154,13 @@ const registerExperimentInputCommands = (
     RegisteredCliCommands.EXPERIMENT_BRANCH,
     () =>
       experiments.getCwdExpNameAndInputThenRun(
-        AvailableCommands.EXPERIMENT_BRANCH,
-        Title.ENTER_BRANCH_NAME
+        Title.ENTER_BRANCH_NAME,
+        (cwd, ...args: Args) =>
+          experiments.runCommand(
+            AvailableCommands.EXPERIMENT_BRANCH,
+            cwd,
+            ...args
+          )
       )
   )
 
@@ -162,10 +168,15 @@ const registerExperimentInputCommands = (
     RegisteredCliCommands.EXPERIMENT_VIEW_BRANCH,
     ({ dvcRoot, id }: ExperimentDetails) =>
       experiments.getExpNameAndInputThenRun(
-        AvailableCommands.EXPERIMENT_BRANCH,
         Title.ENTER_BRANCH_NAME,
         dvcRoot,
-        id
+        id,
+        (...args: Args) =>
+          experiments.runCommand(
+            AvailableCommands.EXPERIMENT_BRANCH,
+            dvcRoot,
+            ...args
+          )
       )
   )
 }

--- a/extension/src/experiments/commands/register.ts
+++ b/extension/src/experiments/commands/register.ts
@@ -167,6 +167,23 @@ const registerExperimentInputCommands = (
   )
 
   internalCommands.registerExternalCliCommand(
+    RegisteredCliCommands.EXPERIMENT_VIEW_BRANCH,
+    ({ dvcRoot, id }: ExperimentDetails) =>
+      experiments.getExpNameAndInputThenRun(
+        Title.ENTER_BRANCH_NAME,
+        dvcRoot,
+        id,
+        (name: string, input: string) =>
+          experiments.runCommand(
+            AvailableCommands.EXPERIMENT_BRANCH,
+            dvcRoot,
+            name,
+            input
+          )
+      )
+  )
+
+  internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.EXPERIMENT_VIEW_SHARE,
     ({ dvcRoot, id }: ExperimentDetails) =>
       experiments.getExpNameAndInputThenRun(

--- a/extension/src/experiments/webview/messages.ts
+++ b/extension/src/experiments/webview/messages.ts
@@ -116,7 +116,7 @@ export class WebviewMessages {
       case MessageFromWebviewType.OPEN_PLOTS_WEBVIEW:
         return commands.executeCommand(RegisteredCommands.PLOTS_SHOW)
 
-      case MessageFromWebviewType.SHARE_EXPERIMENT:
+      case MessageFromWebviewType.SHARE_EXPERIMENT_AS_BRANCH:
         return commands.executeCommand(
           RegisteredCliCommands.EXPERIMENT_VIEW_SHARE,
           { dvcRoot: this.dvcRoot, id: message.payload }

--- a/extension/src/experiments/webview/messages.ts
+++ b/extension/src/experiments/webview/messages.ts
@@ -116,6 +116,12 @@ export class WebviewMessages {
       case MessageFromWebviewType.OPEN_PLOTS_WEBVIEW:
         return commands.executeCommand(RegisteredCommands.PLOTS_SHOW)
 
+      case MessageFromWebviewType.SHARE_EXPERIMENT:
+        return commands.executeCommand(
+          RegisteredCliCommands.EXPERIMENT_VIEW_SHARE,
+          { dvcRoot: this.dvcRoot, id: message.payload }
+        )
+
       default:
         Logger.error(`Unexpected message: ${JSON.stringify(message)}`)
     }

--- a/extension/src/experiments/webview/messages.ts
+++ b/extension/src/experiments/webview/messages.ts
@@ -118,7 +118,7 @@ export class WebviewMessages {
 
       case MessageFromWebviewType.SHARE_EXPERIMENT_AS_BRANCH:
         return commands.executeCommand(
-          RegisteredCliCommands.EXPERIMENT_VIEW_SHARE,
+          RegisteredCliCommands.EXPERIMENT_VIEW_SHARE_AS_BRANCH,
           { dvcRoot: this.dvcRoot, id: message.payload }
         )
 

--- a/extension/src/experiments/workspace.test.ts
+++ b/extension/src/experiments/workspace.test.ts
@@ -12,6 +12,7 @@ import { buildMockMemento } from '../test/util'
 import { buildMockedEventEmitter } from '../test/util/jest'
 import { OutputChannel } from '../vscode/outputChannel'
 import { Title } from '../vscode/title'
+import { Args } from '../cli/constants'
 
 const mockedShowWebview = jest.fn()
 const mockedDisposable = jest.mocked(Disposable)
@@ -185,7 +186,7 @@ describe('Experiments', () => {
     })
   })
 
-  describe('getExpNameAndInputThenRun', () => {
+  describe('getCwdExpNameAndInputThenRun', () => {
     it('should call the correct function with the correct parameters if a project and experiment are picked and an input provided', async () => {
       mockedQuickPickOne.mockResolvedValueOnce(mockedDvcRoot)
       mockedPickCurrentExperiment.mockResolvedValueOnce({
@@ -195,8 +196,9 @@ describe('Experiments', () => {
       mockedGetInput.mockResolvedValueOnce('abc123')
 
       await workspaceExperiments.getCwdExpNameAndInputThenRun(
-        mockedCommandId,
-        'enter your password please' as Title
+        'enter your password please' as Title,
+        (cwd: string, ...args: Args) =>
+          workspaceExperiments.runCommand(mockedCommandId, cwd, ...args)
       )
 
       expect(mockedQuickPickOne).toBeCalledTimes(1)
@@ -209,8 +211,9 @@ describe('Experiments', () => {
       mockedQuickPickOne.mockResolvedValueOnce(undefined)
 
       await workspaceExperiments.getCwdExpNameAndInputThenRun(
-        mockedCommandId,
-        'please name the branch' as Title
+        'please name the branch' as Title,
+        (cwd: string, ...args: Args) =>
+          workspaceExperiments.runCommand(mockedCommandId, cwd, ...args)
       )
 
       expect(mockedQuickPickOne).toBeCalledTimes(1)
@@ -227,8 +230,9 @@ describe('Experiments', () => {
       mockedGetInput.mockResolvedValueOnce(undefined)
 
       await workspaceExperiments.getCwdExpNameAndInputThenRun(
-        mockedCommandId,
-        'please enter your bank account number and sort code' as Title
+        'please enter your bank account number and sort code' as Title,
+        (cwd: string, ...args: Args) =>
+          workspaceExperiments.runCommand(mockedCommandId, cwd, ...args)
       )
 
       expect(mockedQuickPickOne).toBeCalledTimes(1)

--- a/extension/src/experiments/workspace.test.ts
+++ b/extension/src/experiments/workspace.test.ts
@@ -196,9 +196,9 @@ describe('Experiments', () => {
       mockedGetInput.mockResolvedValueOnce('abc123')
 
       await workspaceExperiments.getCwdExpNameAndInputThenRun(
-        'enter your password please' as Title,
         (cwd: string, ...args: Args) =>
-          workspaceExperiments.runCommand(mockedCommandId, cwd, ...args)
+          workspaceExperiments.runCommand(mockedCommandId, cwd, ...args),
+        'enter your password please' as Title
       )
 
       expect(mockedQuickPickOne).toBeCalledTimes(1)
@@ -211,9 +211,9 @@ describe('Experiments', () => {
       mockedQuickPickOne.mockResolvedValueOnce(undefined)
 
       await workspaceExperiments.getCwdExpNameAndInputThenRun(
-        'please name the branch' as Title,
         (cwd: string, ...args: Args) =>
-          workspaceExperiments.runCommand(mockedCommandId, cwd, ...args)
+          workspaceExperiments.runCommand(mockedCommandId, cwd, ...args),
+        'please name the branch' as Title
       )
 
       expect(mockedQuickPickOne).toBeCalledTimes(1)
@@ -230,9 +230,9 @@ describe('Experiments', () => {
       mockedGetInput.mockResolvedValueOnce(undefined)
 
       await workspaceExperiments.getCwdExpNameAndInputThenRun(
-        'please enter your bank account number and sort code' as Title,
         (cwd: string, ...args: Args) =>
-          workspaceExperiments.runCommand(mockedCommandId, cwd, ...args)
+          workspaceExperiments.runCommand(mockedCommandId, cwd, ...args),
+        'please enter your bank account number and sort code' as Title
       )
 
       expect(mockedQuickPickOne).toBeCalledTimes(1)

--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -223,8 +223,8 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
   }
 
   public async getCwdExpNameAndInputThenRun(
-    title: Title,
-    runCommand: (cwd: string, ...args: Args) => Promise<void>
+    runCommand: (cwd: string, ...args: Args) => Promise<void>,
+    title: Title
   ) {
     const cwd = await this.getFocusedOrOnlyOrPickProject()
     if (!cwd) {
@@ -240,10 +240,10 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
   }
 
   public getExpNameAndInputThenRun(
+    runCommand: (...args: Args) => Promise<void>,
     title: Title,
     cwd: string,
-    id: string,
-    runCommand: (...args: Args) => Promise<void>
+    id: string
   ) {
     const name = this.getRepository(cwd)?.getExperimentDisplayName(id)
 

--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -222,10 +222,10 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
     }
   }
 
-  public getCwdExpNameAndInputThenRun = async (
-    commandId: CommandId,
-    title: Title
-  ) => {
+  public async getCwdExpNameAndInputThenRun(
+    title: Title,
+    runCommand: (cwd: string, ...args: Args) => Promise<void>
+  ) {
     const cwd = await this.getFocusedOrOnlyOrPickProject()
     if (!cwd) {
       return
@@ -236,14 +236,14 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
     if (!experiment) {
       return
     }
-    return this.getInputAndRun(commandId, cwd, title, experiment.name)
+    return this.getInputAndRun(runCommand, title, cwd, experiment.name)
   }
 
   public getExpNameAndInputThenRun(
-    commandId: CommandId,
     title: Title,
     cwd: string,
-    id: string
+    id: string,
+    runCommand: (...args: Args) => Promise<void>
   ) {
     const name = this.getRepository(cwd)?.getExperimentDisplayName(id)
 
@@ -251,20 +251,7 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
       return
     }
 
-    return this.getInputAndRun(commandId, cwd, title, name)
-  }
-
-  public async getInputAndRun(
-    commandId: CommandId,
-    cwd: string,
-    title: Title,
-    ...args: Args
-  ) {
-    const input = await getInput(title)
-    if (!input) {
-      return
-    }
-    return this.runCommand(commandId, cwd, ...args, input)
+    return this.getInputAndRun(runCommand, title, name)
   }
 
   public getExpNameThenRun(commandId: CommandId, cwd: string, id: string) {
@@ -358,6 +345,18 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
       return
     }
     return this.runCommand(commandId, cwd, experiment.name)
+  }
+
+  private async getInputAndRun(
+    runCommand: (...args: Args) => Promise<void>,
+    title: Title,
+    ...args: Args
+  ) {
+    const input = await getInput(title)
+    if (!input) {
+      return
+    }
+    return runCommand(...args, input)
   }
 
   private pickCurrentExperiment(cwd: string) {

--- a/extension/src/git.ts
+++ b/extension/src/git.ts
@@ -95,3 +95,13 @@ export const gitStageAll = async (cwd: string) => {
     executable: 'git'
   })
 }
+
+export const gitPushBranch = (
+  cwd: string,
+  branchName: string
+): Promise<string> =>
+  executeProcess({
+    args: ['push', '-u', 'origin', branchName],
+    cwd,
+    executable: 'git'
+  })

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -135,6 +135,7 @@ export interface IEventNamePropertyMapping {
   [EventName.EXPERIMENT_VIEW_APPLY]: undefined
   [EventName.EXPERIMENT_VIEW_BRANCH]: undefined
   [EventName.EXPERIMENT_VIEW_REMOVE]: undefined
+  [EventName.EXPERIMENT_VIEW_SHARE]: undefined
   [EventName.EXPERIMENT_TOGGLE]: undefined
 
   [EventName.EXPERIMENT_VIEW_QUEUE]: undefined

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -135,7 +135,7 @@ export interface IEventNamePropertyMapping {
   [EventName.EXPERIMENT_VIEW_APPLY]: undefined
   [EventName.EXPERIMENT_VIEW_BRANCH]: undefined
   [EventName.EXPERIMENT_VIEW_REMOVE]: undefined
-  [EventName.EXPERIMENT_VIEW_SHARE]: undefined
+  [EventName.EXPERIMENT_VIEW_SHARE_AS_BRANCH]: undefined
   [EventName.EXPERIMENT_TOGGLE]: undefined
 
   [EventName.EXPERIMENT_VIEW_QUEUE]: undefined

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -477,43 +477,6 @@ suite('Experiments Test Suite', () => {
       )
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
-    it('should be able to handle a message to share an experiment to the remote as a branch', async () => {
-      const { experiments } = buildExperiments(disposable)
-      await experiments.isReady()
-
-      const mockBranch = 'mock-branch-input'
-      const inputEvent = getInputBoxEvent(mockBranch)
-
-      const mockExperimentBranch = stub(
-        CliExecutor.prototype,
-        'experimentBranch'
-      ).resolves('undefined')
-
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
-      ).returns(dvcDemoPath)
-      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
-
-      const webview = await experiments.showWebview()
-      const mockMessageReceived = getMessageReceivedEmitter(webview)
-      const mockExperimentId = 'exp-e7a67'
-
-      mockMessageReceived.fire({
-        payload: mockExperimentId,
-        type: MessageFromWebviewType.CREATE_BRANCH_FROM_EXPERIMENT
-      })
-
-      await inputEvent
-      expect(mockExperimentBranch).to.be.calledOnce
-      expect(mockExperimentBranch).to.be.calledWithExactly(
-        dvcDemoPath,
-        mockExperimentId,
-        mockBranch
-      )
-    }).timeout(WEBVIEW_TEST_TIMEOUT)
-
     it('should handle a message to share an experiment as a new branch', async () => {
       const { experiments } = buildExperiments(disposable)
       await experiments.isReady()

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -63,6 +63,8 @@ import { Title } from '../../../vscode/title'
 import { ExperimentFlag } from '../../../cli/constants'
 import { WorkspaceExperiments } from '../../../experiments/workspace'
 import { CliExecutor } from '../../../cli/executor'
+import * as Git from '../../../git'
+import { shortenForLabel } from '../../../util/string'
 
 suite('Experiments Test Suite', () => {
   const disposable = Disposable.fn()
@@ -473,6 +475,102 @@ suite('Experiments Test Suite', () => {
         mockExperimentId,
         mockBranch
       )
+    }).timeout(WEBVIEW_TEST_TIMEOUT)
+
+    it('should be able to handle a message to share an experiment to the remote as a branch', async () => {
+      const { experiments } = buildExperiments(disposable)
+      await experiments.isReady()
+
+      const mockBranch = 'mock-branch-input'
+      const inputEvent = getInputBoxEvent(mockBranch)
+
+      const mockExperimentBranch = stub(
+        CliExecutor.prototype,
+        'experimentBranch'
+      ).resolves('undefined')
+
+      stub(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (WorkspaceExperiments as any).prototype,
+        'getOnlyOrPickProject'
+      ).returns(dvcDemoPath)
+      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
+
+      const webview = await experiments.showWebview()
+      const mockMessageReceived = getMessageReceivedEmitter(webview)
+      const mockExperimentId = 'exp-e7a67'
+
+      mockMessageReceived.fire({
+        payload: mockExperimentId,
+        type: MessageFromWebviewType.CREATE_BRANCH_FROM_EXPERIMENT
+      })
+
+      await inputEvent
+      expect(mockExperimentBranch).to.be.calledOnce
+      expect(mockExperimentBranch).to.be.calledWithExactly(
+        dvcDemoPath,
+        mockExperimentId,
+        mockBranch
+      )
+    }).timeout(WEBVIEW_TEST_TIMEOUT)
+
+    it('should handle a message to share an experiment as a new branch', async () => {
+      const { experiments } = buildExperiments(disposable)
+      await experiments.isReady()
+
+      const testCheckpointId = 'd1343a87c6ee4a2e82d19525964d2fb2cb6756c9'
+      const testCheckpointLabel = shortenForLabel(testCheckpointId)
+      const mockBranch = 'it-is-a-branch-shared-to-the-remote'
+      const inputEvent = getInputBoxEvent(mockBranch)
+
+      const mockExperimentBranch = stub(
+        CliExecutor.prototype,
+        'experimentBranch'
+      ).resolves(
+        `Git branch '${mockBranch}' has been created from experiment '${testCheckpointId}'.        
+       To switch to the new branch run:
+             git checkout ${mockBranch}`
+      )
+      const mockExperimentApply = stub(
+        CliExecutor.prototype,
+        'experimentApply'
+      ).resolves(
+        `Changes for experiment '${testCheckpointId}' have been applied to your current workspace.`
+      )
+      const mockPush = stub(CliExecutor.prototype, 'push').resolves(
+        '10 files updated.'
+      )
+      const mockGitPush = stub(Git, 'gitPushBranch')
+      const branchPushedToRemote = new Promise(resolve =>
+        mockGitPush.callsFake(() => {
+          resolve(undefined)
+          return Promise.resolve(`${mockBranch} pushed to remote`)
+        })
+      )
+
+      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
+
+      const webview = await experiments.showWebview()
+      const mockMessageReceived = getMessageReceivedEmitter(webview)
+
+      mockMessageReceived.fire({
+        payload: testCheckpointId,
+        type: MessageFromWebviewType.SHARE_EXPERIMENT
+      })
+
+      await inputEvent
+      await branchPushedToRemote
+      expect(mockExperimentBranch).to.be.calledWithExactly(
+        dvcDemoPath,
+        testCheckpointLabel,
+        mockBranch
+      )
+      expect(mockExperimentApply).to.be.calledWithExactly(
+        dvcDemoPath,
+        testCheckpointLabel
+      )
+      expect(mockPush).to.be.calledWithExactly(dvcDemoPath)
+      expect(mockGitPush).to.be.calledWithExactly(dvcDemoPath, mockBranch)
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it("should be able to handle a message to modify an experiment's params and queue an experiment", async () => {

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -518,7 +518,7 @@ suite('Experiments Test Suite', () => {
 
       mockMessageReceived.fire({
         payload: testCheckpointId,
-        type: MessageFromWebviewType.SHARE_EXPERIMENT
+        type: MessageFromWebviewType.SHARE_EXPERIMENT_AS_BRANCH
       })
 
       await inputEvent

--- a/extension/src/webview/contract.ts
+++ b/extension/src/webview/contract.ts
@@ -35,6 +35,7 @@ export enum MessageFromWebviewType {
   SELECT_EXPERIMENTS = 'select-experiments',
   SELECT_COLUMNS = 'select-columns',
   SELECT_PLOTS = 'select-plots',
+  SHARE_EXPERIMENT = 'share-experiment',
   TOGGLE_METRIC = 'toggle-metric',
   TOGGLE_PLOTS_SECTION = 'toggle-plots-section',
   VARY_EXPERIMENT_PARAMS_AND_QUEUE = 'vary-experiment-params-and-queue',
@@ -146,6 +147,10 @@ export type MessageFromWebview =
   | { type: MessageFromWebviewType.FOCUS_FILTERS_TREE }
   | { type: MessageFromWebviewType.FOCUS_SORTS_TREE }
   | { type: MessageFromWebviewType.OPEN_PLOTS_WEBVIEW }
+  | {
+      type: MessageFromWebviewType.SHARE_EXPERIMENT
+      payload: string
+    }
 
 export type MessageToWebview<T extends WebviewData> = {
   type: MessageToWebviewType.SET_DATA

--- a/extension/src/webview/contract.ts
+++ b/extension/src/webview/contract.ts
@@ -35,7 +35,7 @@ export enum MessageFromWebviewType {
   SELECT_EXPERIMENTS = 'select-experiments',
   SELECT_COLUMNS = 'select-columns',
   SELECT_PLOTS = 'select-plots',
-  SHARE_EXPERIMENT = 'share-experiment',
+  SHARE_EXPERIMENT_AS_BRANCH = 'share-experiment-as-branch',
   TOGGLE_METRIC = 'toggle-metric',
   TOGGLE_PLOTS_SECTION = 'toggle-plots-section',
   VARY_EXPERIMENT_PARAMS_AND_QUEUE = 'vary-experiment-params-and-queue',
@@ -148,7 +148,7 @@ export type MessageFromWebview =
   | { type: MessageFromWebviewType.FOCUS_SORTS_TREE }
   | { type: MessageFromWebviewType.OPEN_PLOTS_WEBVIEW }
   | {
-      type: MessageFromWebviewType.SHARE_EXPERIMENT
+      type: MessageFromWebviewType.SHARE_EXPERIMENT_AS_BRANCH
       payload: string
     }
 

--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -679,6 +679,27 @@ describe('App', () => {
       ])
     })
 
+    it('should present the correct option for an experiment with checkpoints', () => {
+      renderTableWithoutRunningExperiments()
+
+      const target = screen.getByText('[exp-e7a67]')
+      fireEvent.contextMenu(target, { bubbles: true })
+
+      jest.advanceTimersByTime(100)
+      const menuitems = screen.getAllByRole('menuitem')
+      const itemLabels = menuitems.map(item => item.textContent)
+      expect(itemLabels).toStrictEqual([
+        'Apply to Workspace',
+        'Create new Branch',
+        'Share',
+        'Modify, Reset and Run',
+        'Modify and Resume',
+        'Modify and Queue',
+        'Star Experiment',
+        'Remove'
+      ])
+    })
+
     it('should present the Remove experiment option for the checkpoint tips', () => {
       renderTableWithoutRunningExperiments()
 

--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -691,7 +691,7 @@ describe('App', () => {
       expect(itemLabels).toStrictEqual([
         'Apply to Workspace',
         'Create new Branch',
-        'Share',
+        'Share as Branch',
         'Modify, Reset and Run',
         'Modify and Resume',
         'Modify and Queue',

--- a/webview/src/experiments/components/table/Row.tsx
+++ b/webview/src/experiments/components/table/Row.tsx
@@ -182,8 +182,8 @@ const getSingleSelectMenuOptions = (
       isNotExperimentOrCheckpoint
     ),
     withId(
-      'Share',
-      MessageFromWebviewType.SHARE_EXPERIMENT,
+      'Share as Branch',
+      MessageFromWebviewType.SHARE_EXPERIMENT_AS_BRANCH,
       isNotExperimentOrCheckpoint
     ),
     ...getRunResumeOptions(

--- a/webview/src/experiments/components/table/Row.tsx
+++ b/webview/src/experiments/components/table/Row.tsx
@@ -115,13 +115,12 @@ const getRunResumeOptions = (
     hidden?: boolean,
     divider?: boolean
   ) => MessagesMenuOptionProps,
-  isWorkspace: boolean,
   projectHasCheckpoints: boolean,
   hideVaryAndRun: boolean,
   depth: number
 ) => {
-  const isNotCheckpoint = depth <= 1 || isWorkspace
-  const isExperiment = depth === 1
+  const isCheckpoint = depth > 1
+  const isNotExperiment = depth !== 1
 
   const resetNeedsSeparator = !hideVaryAndRun && projectHasCheckpoints
   const runNeedsSeparator = !hideVaryAndRun && !projectHasCheckpoints
@@ -130,24 +129,24 @@ const getRunResumeOptions = (
     withId(
       'Modify, Reset and Run',
       MessageFromWebviewType.VARY_EXPERIMENT_PARAMS_RESET_AND_RUN,
-      !isNotCheckpoint || !projectHasCheckpoints,
+      isCheckpoint || !projectHasCheckpoints,
       resetNeedsSeparator
     ),
     withId(
       projectHasCheckpoints ? 'Modify and Resume' : 'Modify and Run',
       MessageFromWebviewType.VARY_EXPERIMENT_PARAMS_AND_RUN,
-      !isNotCheckpoint,
+      isCheckpoint,
       runNeedsSeparator
     ),
     withId(
       'Modify and Queue',
       MessageFromWebviewType.VARY_EXPERIMENT_PARAMS_AND_QUEUE,
-      !isNotCheckpoint
+      isCheckpoint
     ),
     withId(
       'Share Experiment',
       MessageFromWebviewType.SHARE_EXPERIMENT,
-      !isExperiment,
+      isNotExperiment,
       true
     )
   ]
@@ -191,7 +190,6 @@ const getSingleSelectMenuOptions = (
     ),
     ...getRunResumeOptions(
       withId,
-      isWorkspace,
       projectHasCheckpoints,
       hideApplyAndCreateBranch,
       depth

--- a/webview/src/experiments/components/table/Row.tsx
+++ b/webview/src/experiments/components/table/Row.tsx
@@ -121,6 +121,7 @@ const getRunResumeOptions = (
   depth: number
 ) => {
   const isNotCheckpoint = depth <= 1 || isWorkspace
+  const isExperiment = depth === 1
 
   const resetNeedsSeparator = !hideVaryAndRun && projectHasCheckpoints
   const runNeedsSeparator = !hideVaryAndRun && !projectHasCheckpoints
@@ -142,6 +143,12 @@ const getRunResumeOptions = (
       'Modify and Queue',
       MessageFromWebviewType.VARY_EXPERIMENT_PARAMS_AND_QUEUE,
       !isNotCheckpoint
+    ),
+    withId(
+      'Share Experiment',
+      MessageFromWebviewType.SHARE_EXPERIMENT,
+      !isExperiment,
+      true
     )
   ]
 }

--- a/webview/src/experiments/components/table/Row.tsx
+++ b/webview/src/experiments/components/table/Row.tsx
@@ -182,7 +182,7 @@ const getSingleSelectMenuOptions = (
       isNotExperimentOrCheckpoint
     ),
     withId(
-      'Share Experiment',
+      'Share',
       MessageFromWebviewType.SHARE_EXPERIMENT,
       isNotExperimentOrCheckpoint
     ),

--- a/webview/src/experiments/components/table/Row.tsx
+++ b/webview/src/experiments/components/table/Row.tsx
@@ -120,7 +120,6 @@ const getRunResumeOptions = (
   depth: number
 ) => {
   const isCheckpoint = depth > 1
-  const isNotExperiment = depth !== 1
 
   const resetNeedsSeparator = !hideVaryAndRun && projectHasCheckpoints
   const runNeedsSeparator = !hideVaryAndRun && !projectHasCheckpoints
@@ -142,12 +141,6 @@ const getRunResumeOptions = (
       'Modify and Queue',
       MessageFromWebviewType.VARY_EXPERIMENT_PARAMS_AND_QUEUE,
       isCheckpoint
-    ),
-    withId(
-      'Share Experiment',
-      MessageFromWebviewType.SHARE_EXPERIMENT,
-      isNotExperiment,
-      true
     )
   ]
 }
@@ -161,7 +154,7 @@ const getSingleSelectMenuOptions = (
   queued?: boolean,
   starred?: boolean
 ) => {
-  const hideApplyAndCreateBranch = queued || isWorkspace || depth <= 0
+  const isNotExperimentOrCheckpoint = queued || isWorkspace || depth <= 0
 
   const withId = (
     label: string,
@@ -181,17 +174,22 @@ const getSingleSelectMenuOptions = (
     withId(
       'Apply to Workspace',
       MessageFromWebviewType.APPLY_EXPERIMENT_TO_WORKSPACE,
-      hideApplyAndCreateBranch
+      isNotExperimentOrCheckpoint
     ),
     withId(
       'Create new Branch',
       MessageFromWebviewType.CREATE_BRANCH_FROM_EXPERIMENT,
-      hideApplyAndCreateBranch
+      isNotExperimentOrCheckpoint
+    ),
+    withId(
+      'Share Experiment',
+      MessageFromWebviewType.SHARE_EXPERIMENT,
+      isNotExperimentOrCheckpoint
     ),
     ...getRunResumeOptions(
       withId,
       projectHasCheckpoints,
-      hideApplyAndCreateBranch,
+      isNotExperimentOrCheckpoint,
       depth
     ),
     experimentMenuOption(


### PR DESCRIPTION
# 1/2 `main` <- this <- #2221 

This PR gives the user the option to share an experiment as a branch from the context menus available in the experiments tree and table.

### Demo

https://user-images.githubusercontent.com/37993418/185542576-243bc77d-8a28-4592-a9a6-c6ebb77a5b16.mov

Note: There are a few things to follow up with in terms of outstanding housekeeping, I also want to add all calls to git into our output channel and add a new (matching) command to the palette. Next step after that is to add a "Commt and Share" command.