### PR TITLE
Remove experiments from star/unstar text in experiments table

### DIFF
--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -675,7 +675,7 @@ describe('App', () => {
         'Modify, Reset and Run',
         'Modify and Resume',
         'Modify and Queue',
-        'Star Experiment'
+        'Star'
       ])
     })
 
@@ -695,7 +695,7 @@ describe('App', () => {
         'Modify, Reset and Run',
         'Modify and Resume',
         'Modify and Queue',
-        'Star Experiment',
+        'Star',
         'Remove'
       ])
     })
@@ -741,7 +741,7 @@ describe('App', () => {
       jest.advanceTimersByTime(100)
       const menuitems = screen.getAllByRole('menuitem')
       const itemLabels = menuitems.map(item => item.textContent)
-      expect(itemLabels).toContain('Star Experiments')
+      expect(itemLabels).toContain('Star')
     })
 
     it('should allow batch selection from the bottom up too', () => {
@@ -806,7 +806,7 @@ describe('App', () => {
     })
   })
 
-  describe('Star Experiments', () => {
+  describe('Star', () => {
     beforeAll(() => {
       jest.useFakeTimers()
     })
@@ -849,7 +849,7 @@ describe('App', () => {
 
       jest.advanceTimersByTime(100)
 
-      const starOption = screen.getByText('Star Experiment')
+      const starOption = screen.getByText('Star')
       fireEvent.click(starOption)
 
       expect(mockPostMessage).toBeCalledTimes(1)
@@ -871,7 +871,7 @@ describe('App', () => {
       fireEvent.contextMenu(mainRow, { bubbles: true })
       jest.advanceTimersByTime(100)
 
-      const starOption = screen.getByText('Star Experiments')
+      const starOption = screen.getByText('Star')
       fireEvent.click(starOption)
 
       expect(mockPostMessage).toBeCalledTimes(1)

--- a/webview/src/experiments/components/table/Row.tsx
+++ b/webview/src/experiments/components/table/Row.tsx
@@ -86,11 +86,11 @@ const getMultiSelectMenuOptions = (
   return [
     toggleStarOption(
       unstarredExperiments.map(value => value.row.values.id),
-      'Star Experiments'
+      'Star'
     ),
     toggleStarOption(
       starredExperiments.map(value => value.row.values.id),
-      'Unstar Experiments'
+      'Unstar'
     ),
     experimentMenuOption(
       removableRowIds,
@@ -194,7 +194,7 @@ const getSingleSelectMenuOptions = (
     ),
     experimentMenuOption(
       [id],
-      starred ? 'Unstar Experiment' : 'Star Experiment',
+      starred ? 'Unstar' : 'Star',
       MessageFromWebviewType.TOGGLE_EXPERIMENT_STAR,
       isWorkspace,
       !hasRunningExperiment


### PR DESCRIPTION
Follow up from [this comment](https://github.com/iterative/vscode-dvc/pull/2219/files#r949777138). We don't need to have "experiment/experiments" in the context menu as it is obvious what the context menu relates to.

### Demo

https://user-images.githubusercontent.com/37993418/185862518-4223966f-5789-4fa8-988c-ed9aa0fe9e85.mov


