### PR TITLE
Add test utils for dealing with private class methods

### DIFF
--- a/extension/src/test/suite/cli/runner.test.ts
+++ b/extension/src/test/suite/cli/runner.test.ts
@@ -9,6 +9,7 @@ import { CliResult, CliStarted } from '../../../cli'
 import * as Telemetry from '../../../telemetry'
 import { EventName } from '../../../telemetry/constants'
 import { WEBVIEW_TEST_TIMEOUT } from '../timeouts'
+import { spyOnPrivateMemberMethod } from '../util'
 
 suite('CLI Runner Test Suite', () => {
   const disposable = Disposable.fn()
@@ -49,8 +50,11 @@ suite('CLI Runner Test Suite', () => {
 
       expect(dvcRunner.isExperimentRunning()).to.be.true
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const closeSpy = spy((dvcRunner as any).pseudoTerminal, 'close')
+      const closeSpy = spyOnPrivateMemberMethod(
+        dvcRunner,
+        'pseudoTerminal',
+        'close'
+      )
 
       await dvcRunner.stop()
       expect(closeSpy).to.be.calledOnce

--- a/extension/src/test/suite/experiments/data/index.test.ts
+++ b/extension/src/test/suite/experiments/data/index.test.ts
@@ -8,7 +8,8 @@ import expShowFixture from '../../../fixtures/expShow/output'
 import {
   bypassProcessManagerDebounce,
   getFirstArgOfCall,
-  getMockNow
+  getMockNow,
+  stubPrivateMemberMethod
 } from '../../util'
 import { dvcDemoPath } from '../../../util'
 import {
@@ -191,9 +192,9 @@ suite('Experiments Data Test Suite', () => {
 
       await data.isReady()
       bypassProcessManagerDebounce(mockNow)
-      const mockIsOngoingOrQueued = stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (data as any).processManager,
+      const mockIsOngoingOrQueued = stubPrivateMemberMethod(
+        data,
+        'processManager',
         'isOngoingOrQueued'
       ).returns(false)
 

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -11,7 +11,7 @@ import {
   QuickPickItem,
   ViewColumn
 } from 'vscode'
-import { buildExperiments } from './util'
+import { buildExperiments, stubWorkspaceExperimentsGetters } from './util'
 import { Disposable } from '../../../extension'
 import expShowFixture from '../../fixtures/expShow/output'
 import rowsFixture from '../../fixtures/expShow/rows'
@@ -61,7 +61,6 @@ import { EventName } from '../../../telemetry/constants'
 import * as VscodeContext from '../../../vscode/context'
 import { Title } from '../../../vscode/title'
 import { ExperimentFlag } from '../../../cli/dvc/constants'
-import { WorkspaceExperiments } from '../../../experiments/workspace'
 import { DvcExecutor } from '../../../cli/dvc/executor'
 import { shortenForLabel } from '../../../util/string'
 import { GitExecutor } from '../../../cli/git/executor'
@@ -426,7 +425,8 @@ suite('Experiments Test Suite', () => {
         DvcExecutor.prototype,
         'experimentApply'
       ).resolves(undefined)
-      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
+
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
       mockMessageReceived.fire({
         payload: mockExperimentId,
@@ -452,12 +452,7 @@ suite('Experiments Test Suite', () => {
         'experimentBranch'
       ).resolves('undefined')
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
-      ).returns(dvcDemoPath)
-      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
       const webview = await experiments.showWebview()
       const mockMessageReceived = getMessageReceivedEmitter(webview)
@@ -511,7 +506,7 @@ suite('Experiments Test Suite', () => {
         })
       )
 
-      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
       const webview = await experiments.showWebview()
       const mockMessageReceived = getMessageReceivedEmitter(webview)
@@ -546,12 +541,8 @@ suite('Experiments Test Suite', () => {
         'params.yaml:weight_decay=0'
       ]
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
-      ).returns(dvcDemoPath)
-      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
+
       stub(experiments, 'pickAndModifyParams').resolves(mockModifiedParams)
       const mockQueueExperiment = stub(
         dvcExecutor,
@@ -586,12 +577,8 @@ suite('Experiments Test Suite', () => {
         'params.yaml:weight_decay=0'
       ]
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
-      ).returns(dvcDemoPath)
-      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
+
       stub(experiments, 'pickAndModifyParams').resolves(mockModifiedParams)
       const mockRunExperiment = stub(dvcRunner, 'runExperiment').resolves(
         undefined
@@ -629,13 +616,7 @@ suite('Experiments Test Suite', () => {
 
       stub(experiments, 'pickAndModifyParams').resolves(mockModifiedParams)
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
-      ).returns(dvcDemoPath)
-
-      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
       const webview = await experiments.showWebview()
       const mockMessageReceived = getMessageReceivedEmitter(webview)
@@ -701,13 +682,7 @@ suite('Experiments Test Suite', () => {
         'queued experiment cannot be selected'
       ).to.be.false
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
-      ).returns(dvcDemoPath)
-
-      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
       const webview = await experiments.showWebview()
       const mockMessageReceived = getMessageReceivedEmitter(webview)

--- a/extension/src/test/suite/experiments/model/filterBy/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/filterBy/tree.test.ts
@@ -13,10 +13,14 @@ import {
   Operator
 } from '../../../../../experiments/model/filterBy'
 import { buildMockMemento, dvcDemoPath } from '../../../../util'
-import { experimentsUpdatedEvent } from '../../../util'
+import {
+  experimentsUpdatedEvent,
+  stubPrivateMethod,
+  stubPrivatePrototypeMethod
+} from '../../../util'
 import { buildMetricOrParamPath } from '../../../../../experiments/columns/paths'
 import { RegisteredCommands } from '../../../../../commands/external'
-import { buildExperiments } from '../../util'
+import { buildExperiments, stubWorkspaceExperimentsGetters } from '../../util'
 import {
   ColumnType,
   Experiment,
@@ -60,12 +64,7 @@ suite('Experiments Filter By Tree Test Suite', () => {
       await experiments.isReady()
       await experiments.showWebview()
 
-      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getFocusedOrOnlyOrPickProject'
-      ).returns(dvcDemoPath)
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
       const accuracyPath = buildMetricOrParamPath(
         ColumnType.METRICS,
@@ -169,12 +168,7 @@ suite('Experiments Filter By Tree Test Suite', () => {
 
       await experiments.isReady()
 
-      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getFocusedOrOnlyOrPickProject'
-      ).returns(dvcDemoPath)
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
       const lossPath = buildMetricOrParamPath(
         ColumnType.METRICS,
@@ -237,8 +231,7 @@ suite('Experiments Filter By Tree Test Suite', () => {
 
       mockShowInputBox.resetHistory()
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      stub((WorkspaceExperiments as any).prototype, 'getDvcRoots').returns([
+      stubPrivatePrototypeMethod(WorkspaceExperiments, 'getDvcRoots').returns([
         dvcDemoPath
       ])
       stub(WorkspaceExperiments.prototype, 'isReady').resolves(undefined)
@@ -270,12 +263,7 @@ suite('Experiments Filter By Tree Test Suite', () => {
       }
       const filterId = getFilterId(filter)
 
-      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getFocusedOrOnlyOrPickProject'
-      ).returns(dvcDemoPath)
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
       await addFilterViaQuickInput(experiments, filter)
 
@@ -327,8 +315,7 @@ suite('Experiments Filter By Tree Test Suite', () => {
     it('should handle the user exiting from the choose repository quick pick', async () => {
       const mockShowQuickPick = stub(window, 'showQuickPick')
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      stub((WorkspaceExperiments as any).prototype, 'getDvcRoots').returns([
+      stub(WorkspaceExperiments.prototype, 'getDvcRoots').returns([
         dvcDemoPath,
         'mockRoot'
       ])
@@ -416,8 +403,7 @@ suite('Experiments Filter By Tree Test Suite', () => {
         '3 Experiments, 9 Checkpoints Filtered'
       )
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      stub(experimentsModel as any, 'getFilteredExperiments')
+      stubPrivateMethod(experimentsModel, 'getFilteredExperiments')
         .onFirstCall()
         .returns([
           { id: '0ef13xs', type: ExperimentType.CHECKPOINT } as Experiment & {
@@ -473,12 +459,7 @@ suite('Experiments Filter By Tree Test Suite', () => {
       await experiments.isReady()
       await experiments.showWebview()
 
-      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getFocusedOrOnlyOrPickProject'
-      ).returns(dvcDemoPath)
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
       await addFilterViaQuickInput(experiments, starredFilter)
 
@@ -514,12 +495,7 @@ suite('Experiments Filter By Tree Test Suite', () => {
 
       await experiments.isReady()
 
-      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getFocusedOrOnlyOrPickProject'
-      ).returns(dvcDemoPath)
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
       const mockAddFilter = stub(experimentsModel, 'addFilter')
 

--- a/extension/src/test/suite/experiments/model/sortBy/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/sortBy/tree.test.ts
@@ -11,7 +11,7 @@ import {
   ColumnType
 } from '../../../../../experiments/webview/contract'
 import { QuickPickItemWithValue } from '../../../../../vscode/quickPick'
-import { buildExperiments } from '../../util'
+import { buildExperiments, stubWorkspaceExperimentsGetters } from '../../util'
 import { experimentsUpdatedEvent } from '../../../util'
 import { dvcDemoPath } from '../../../../util'
 import { buildMetricOrParamPath } from '../../../../../experiments/columns/paths'
@@ -158,16 +158,8 @@ suite('Experiments Sort By Tree Test Suite', () => {
             get(exp, selector)
           )
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      stub((WorkspaceExperiments as any).prototype, 'getDvcRoots').returns([
-        dvcDemoPath
-      ])
-      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getFocusedOrOnlyOrPickProject'
-      ).returns(dvcDemoPath)
+      stub(WorkspaceExperiments.prototype, 'getDvcRoots').returns([dvcDemoPath])
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
       // Setup done, perform the test
 
@@ -261,8 +253,7 @@ suite('Experiments Sort By Tree Test Suite', () => {
     it('should handle the user exiting from the choose repository quick pick', async () => {
       const mockShowQuickPick = stub(window, 'showQuickPick')
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      stub((WorkspaceExperiments as any).prototype, 'getDvcRoots').returns([
+      stub(WorkspaceExperiments.prototype, 'getDvcRoots').returns([
         dvcDemoPath,
         'mockRoot'
       ])
@@ -294,12 +285,7 @@ suite('Experiments Sort By Tree Test Suite', () => {
 
       await experiments.isReady()
 
-      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getFocusedOrOnlyOrPickProject'
-      ).returns(dvcDemoPath)
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
       const mockAddSort = stub(experimentsModel, 'addSort')
 

--- a/extension/src/test/suite/experiments/model/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/tree.test.ts
@@ -15,7 +15,12 @@ import { addFilterViaQuickInput } from './filterBy/util'
 import { Disposable } from '../../../../extension'
 import { ExperimentsModel, ExperimentType } from '../../../../experiments/model'
 import { UNSELECTED } from '../../../../experiments/model/status'
-import { experimentsUpdatedEvent, getFirstArgOfLastCall } from '../../util'
+import {
+  experimentsUpdatedEvent,
+  getFirstArgOfLastCall,
+  spyOnPrivateMethod,
+  stubPrivatePrototypeMethod
+} from '../../util'
 import { dvcDemoPath } from '../../../util'
 import {
   RegisteredCliCommands,
@@ -28,7 +33,11 @@ import expShowFixture from '../../../fixtures/expShow/output'
 import { Operator } from '../../../../experiments/model/filterBy'
 import { buildMetricOrParamPath } from '../../../../experiments/columns/paths'
 import { ExperimentsTree } from '../../../../experiments/model/tree'
-import { buildExperiments, buildSingleRepoExperiments } from '../util'
+import {
+  buildExperiments,
+  buildSingleRepoExperiments,
+  stubWorkspaceExperimentsGetters
+} from '../util'
 import { ResourceLocator } from '../../../../resourceLocator'
 import { WEBVIEW_TEST_TIMEOUT } from '../../timeouts'
 import {
@@ -444,9 +453,8 @@ suite('Experiments Tree Test Suite', () => {
 
       const description = '[exp-1234]'
 
-      const setExpandedSpy = spy(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        experimentsTree as any,
+      const setExpandedSpy = spyOnPrivateMethod(
+        experimentsTree,
         'setExperimentExpanded'
       )
 
@@ -480,9 +488,8 @@ suite('Experiments Tree Test Suite', () => {
         'experimentRemove'
       ).resolves('')
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (ExperimentsTree as any).prototype,
+      stubPrivatePrototypeMethod(
+        ExperimentsTree,
         'getSelectedExperimentItems'
       ).returns([mockExperiment])
 
@@ -505,9 +512,8 @@ suite('Experiments Tree Test Suite', () => {
         'experimentRemove'
       ).resolves('')
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (ExperimentsTree as any).prototype,
+      stubPrivatePrototypeMethod(
+        ExperimentsTree,
         'getSelectedExperimentItems'
       ).returns([])
 
@@ -535,9 +541,8 @@ suite('Experiments Tree Test Suite', () => {
         'experimentRemove'
       ).resolves('')
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (ExperimentsTree as any).prototype,
+      stubPrivatePrototypeMethod(
+        ExperimentsTree,
         'getSelectedExperimentItems'
       ).returns([
         dvcDemoPath,
@@ -671,12 +676,10 @@ suite('Experiments Tree Test Suite', () => {
         'experimentRunQueue'
       ).resolves('true')
 
-      const mockGetOnlyOrPickProject = stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
+      const [mockGetOnlyOrPickProject] = stubWorkspaceExperimentsGetters(
+        '',
+        experiments
       )
-      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
 
       const getParamsSpy = spy(experimentsModel, 'getExperimentParams')
 
@@ -735,12 +738,10 @@ suite('Experiments Tree Test Suite', () => {
         undefined
       )
 
-      const mockGetOnlyOrPickProject = stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
+      const [mockGetOnlyOrPickProject] = stubWorkspaceExperimentsGetters(
+        '',
+        experiments
       )
-      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
 
       const getParamsSpy = spy(experimentsModel, 'getExperimentParams')
 
@@ -797,12 +798,10 @@ suite('Experiments Tree Test Suite', () => {
         'runExperimentReset'
       ).resolves(undefined)
 
-      const mockGetOnlyOrPickProject = stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
+      const [mockGetOnlyOrPickProject] = stubWorkspaceExperimentsGetters(
+        '',
+        experiments
       )
-      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
 
       const getParamsSpy = spy(experimentsModel, 'getExperimentParams')
 

--- a/extension/src/test/suite/experiments/util.ts
+++ b/extension/src/test/suite/experiments/util.ts
@@ -171,3 +171,22 @@ export const buildExperimentsData = (disposer: Disposer) => {
 
   return { data, mockCreateFileSystemWatcher, mockExperimentShow }
 }
+
+export const stubWorkspaceExperimentsGetters = (
+  dvcRoot: string,
+  experiments?: Experiments
+) => {
+  const mockGetOnlyOrPickProject = stub(
+    WorkspaceExperiments.prototype,
+    'getOnlyOrPickProject'
+  ).resolves(dvcRoot)
+  let mockGetRepository
+  if (experiments) {
+    mockGetRepository = stub(
+      WorkspaceExperiments.prototype,
+      'getRepository'
+    ).returns(experiments)
+  }
+
+  return [mockGetOnlyOrPickProject, mockGetRepository]
+}

--- a/extension/src/test/suite/experiments/workspace.test.ts
+++ b/extension/src/test/suite/experiments/workspace.test.ts
@@ -5,10 +5,10 @@ import { window, commands, QuickPickItem, Uri } from 'vscode'
 import {
   buildExperiments,
   buildMultiRepoExperiments,
-  buildSingleRepoExperiments
+  buildSingleRepoExperiments,
+  stubWorkspaceExperimentsGetters
 } from './util'
 import { Disposable } from '../../../extension'
-import { WorkspaceExperiments } from '../../../experiments/workspace'
 import { Experiments } from '../../../experiments'
 import * as QuickPick from '../../../vscode/quickPick'
 import { DvcExecutor } from '../../../cli/dvc/executor'
@@ -148,13 +148,7 @@ suite('Workspace Experiments Test Suite', () => {
         'experimentRunQueue'
       ).resolves('true')
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
-      ).returns(dvcDemoPath)
-
-      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
       const mockShowQuickPick = stub(window, 'showQuickPick') as SinonStub<
         [items: readonly QuickPickItem[], options: QuickPickOptionsWithTitle],
@@ -209,13 +203,7 @@ suite('Workspace Experiments Test Suite', () => {
         'runExperiment'
       ).resolves(undefined)
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
-      ).returns(dvcDemoPath)
-
-      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
       const mockShowQuickPick = stub(window, 'showQuickPick') as SinonStub<
         [items: readonly QuickPickItem[], options: QuickPickOptionsWithTitle],
@@ -273,13 +261,7 @@ suite('Workspace Experiments Test Suite', () => {
         'runExperiment'
       ).resolves(undefined)
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
-      ).returns(dvcDemoPath)
-
-      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
       const mockShowQuickPick = stub(window, 'showQuickPick') as SinonStub<
         [items: readonly QuickPickItem[], options: QuickPickOptionsWithTitle],
@@ -335,11 +317,7 @@ suite('Workspace Experiments Test Suite', () => {
         'experimentRunQueue'
       ).resolves('true')
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
-      ).returns(dvcDemoPath)
+      stubWorkspaceExperimentsGetters(dvcDemoPath)
 
       await commands.executeCommand(RegisteredCliCommands.QUEUE_EXPERIMENT)
 
@@ -352,11 +330,7 @@ suite('Workspace Experiments Test Suite', () => {
 
       const mockSendTelemetryEvent = stub(Telemetry, 'sendTelemetryEvent')
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
-      ).returns(dvcDemoPath)
+      stubWorkspaceExperimentsGetters(dvcDemoPath)
 
       const queueExperiment = commands.executeCommand(
         RegisteredCliCommands.QUEUE_EXPERIMENT
@@ -388,11 +362,7 @@ suite('Workspace Experiments Test Suite', () => {
 
       const mockSendTelemetryEvent = stub(Telemetry, 'sendTelemetryEvent')
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
-      ).returns(dvcDemoPath)
+      stubWorkspaceExperimentsGetters(dvcDemoPath)
 
       await commands.executeCommand(RegisteredCliCommands.QUEUE_EXPERIMENT)
 
@@ -413,11 +383,7 @@ suite('Workspace Experiments Test Suite', () => {
         'runExperiment'
       ).resolves(undefined)
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
-      ).returns(dvcDemoPath)
+      stubWorkspaceExperimentsGetters(dvcDemoPath)
 
       await commands.executeCommand(RegisteredCliCommands.EXPERIMENT_RUN)
 
@@ -433,11 +399,7 @@ suite('Workspace Experiments Test Suite', () => {
         'runExperiment'
       ).resolves(undefined)
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
-      ).returns(dvcDemoPath)
+      stubWorkspaceExperimentsGetters(dvcDemoPath)
 
       await commands.executeCommand(RegisteredCliCommands.EXPERIMENT_RESUME)
 
@@ -453,11 +415,7 @@ suite('Workspace Experiments Test Suite', () => {
         'runExperimentReset'
       ).resolves(undefined)
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
-      ).returns(dvcDemoPath)
+      stubWorkspaceExperimentsGetters(dvcDemoPath)
 
       await commands.executeCommand(
         RegisteredCliCommands.EXPERIMENT_RESET_AND_RUN
@@ -475,11 +433,7 @@ suite('Workspace Experiments Test Suite', () => {
         'runExperimentQueue'
       ).resolves(undefined)
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
-      ).returns(dvcDemoPath)
+      stubWorkspaceExperimentsGetters(dvcDemoPath)
 
       await commands.executeCommand(RegisteredCliCommands.EXPERIMENT_RUN_QUEUED)
 
@@ -496,16 +450,8 @@ suite('Workspace Experiments Test Suite', () => {
 
       await experiments.isReady()
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
-      ).returns(dvcDemoPath)
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getRepository'
-      ).returns(experiments)
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
+
       const mockShowQuickPick = stub(window, 'showQuickPick').resolves({
         value: { id: selectedExperiment, name: selectedExperiment }
       } as QuickPickItemWithValue<{ id: string; name: string }>)
@@ -587,13 +533,7 @@ suite('Workspace Experiments Test Suite', () => {
            git checkout ${mockBranch}`
       )
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
-      ).returns(dvcDemoPath)
-
-      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
       await commands.executeCommand(RegisteredCliCommands.EXPERIMENT_BRANCH)
 
@@ -644,13 +584,7 @@ suite('Workspace Experiments Test Suite', () => {
         })
       )
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
-      ).returns(dvcDemoPath)
-
-      stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
       await commands.executeCommand(
         RegisteredCliCommands.EXPERIMENT_SHARE_AS_BRANCH
@@ -680,16 +614,7 @@ suite('Workspace Experiments Test Suite', () => {
 
       await experiments.isReady()
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
-      ).returns(dvcDemoPath)
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getRepository'
-      ).returns(experiments)
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
       stub(window, 'showQuickPick').resolves({
         value: { id: mockExperiment, name: mockExperiment }
@@ -711,16 +636,7 @@ suite('Workspace Experiments Test Suite', () => {
 
       await experiments.isReady()
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
-      ).returns(dvcDemoPath)
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getRepository'
-      ).returns(experiments)
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
       const mockExperimentRemove = stub(
         DvcExecutor.prototype,
@@ -743,16 +659,7 @@ suite('Workspace Experiments Test Suite', () => {
 
       await experiments.isReady()
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getOnlyOrPickProject'
-      ).returns(dvcDemoPath)
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (WorkspaceExperiments as any).prototype,
-        'getRepository'
-      ).returns(experiments)
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
       stub(window, 'showQuickPick').resolves({
         value: { id: mockExperiment, name: mockExperiment }

--- a/extension/src/test/suite/fileSystem/tree.test.ts
+++ b/extension/src/test/suite/fileSystem/tree.test.ts
@@ -19,7 +19,8 @@ import { DvcExecutor } from '../../../cli/dvc/executor'
 import {
   activeTextEditorChangedEvent,
   closeAllEditors,
-  getActiveTextEditorFilename
+  getActiveTextEditorFilename,
+  stubPrivatePrototypeMethod
 } from '../util'
 import { dvcDemoPath } from '../../util'
 import {
@@ -355,9 +356,8 @@ suite('Tracked Explorer Tree Test Suite', () => {
 
       stub(WorkspaceRepositories.prototype, 'getRepository').returns(repository)
       stub(WorkspaceRepositories.prototype, 'isReady').resolves(undefined)
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (TrackedExplorerTree as any).prototype,
+      stubPrivatePrototypeMethod(
+        TrackedExplorerTree,
         'getSelectedPathItems'
       ).returns([])
       const mockPull = stub(DvcExecutor.prototype, 'pull').resolves(
@@ -387,9 +387,8 @@ suite('Tracked Explorer Tree Test Suite', () => {
       const mockPull = stub(DvcExecutor.prototype, 'pull').resolves(
         'target pulled'
       )
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (TrackedExplorerTree as any).prototype,
+      stubPrivatePrototypeMethod(
+        TrackedExplorerTree,
         'getSelectedPathItems'
       ).returns([getPathItem(relPath)])
 
@@ -418,9 +417,8 @@ suite('Tracked Explorer Tree Test Suite', () => {
         'showWarningMessage'
       ).resolves('Force' as unknown as MessageItem)
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (TrackedExplorerTree as any).prototype,
+      stubPrivatePrototypeMethod(
+        TrackedExplorerTree,
         'getSelectedPathItems'
       ).returns([getPathItem(relPath)])
 
@@ -443,9 +441,8 @@ suite('Tracked Explorer Tree Test Suite', () => {
         'target pushed'
       )
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (TrackedExplorerTree as any).prototype,
+      stubPrivatePrototypeMethod(
+        TrackedExplorerTree,
         'getSelectedPathItems'
       ).returns([getPathItem(relPath)])
 
@@ -473,9 +470,8 @@ suite('Tracked Explorer Tree Test Suite', () => {
         'showWarningMessage'
       ).resolves('Force' as unknown as MessageItem)
 
-      stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (TrackedExplorerTree as any).prototype,
+      stubPrivatePrototypeMethod(
+        TrackedExplorerTree,
         'getSelectedPathItems'
       ).returns([])
 

--- a/extension/src/test/suite/repository/sourceControlManagement.test.ts
+++ b/extension/src/test/suite/repository/sourceControlManagement.test.ts
@@ -5,7 +5,7 @@ import { stub, restore, spy } from 'sinon'
 import { window, commands, Uri, MessageItem } from 'vscode'
 import { Disposable } from '../../../extension'
 import { DvcExecutor } from '../../../cli/dvc/executor'
-import { closeAllEditors } from '../util'
+import { closeAllEditors, stubPrivatePrototypeMethod } from '../util'
 import { dvcDemoPath } from '../../util'
 import {
   RegisteredCliCommands,
@@ -95,8 +95,9 @@ suite('Source Control Management Test Suite', () => {
     it('should not run dvc commit if there are no changes in the repository', async () => {
       const mockCommit = stub(DvcExecutor.prototype, 'commit').resolves('')
       const executeCommandSpy = spy(commands, 'executeCommand')
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      stub(WorkspaceRepositories.prototype as any, 'hasChanges').returns(false)
+      stubPrivatePrototypeMethod(WorkspaceRepositories, 'hasChanges').returns(
+        false
+      )
 
       await commands.executeCommand(RegisteredCliCommands.COMMIT, { rootUri })
 
@@ -107,8 +108,9 @@ suite('Source Control Management Test Suite', () => {
     it('should focus the git commit text input box after running dvc commit', async () => {
       const mockCommit = stub(DvcExecutor.prototype, 'commit').resolves('')
       const executeCommandSpy = spy(commands, 'executeCommand')
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      stub(WorkspaceRepositories.prototype as any, 'hasChanges').returns(true)
+      stubPrivatePrototypeMethod(WorkspaceRepositories, 'hasChanges').returns(
+        true
+      )
 
       await commands.executeCommand(RegisteredCliCommands.COMMIT, { rootUri })
 
@@ -129,8 +131,10 @@ suite('Source Control Management Test Suite', () => {
         window,
         'showWarningMessage'
       ).resolves('Force' as unknown as MessageItem)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      stub(WorkspaceRepositories.prototype as any, 'hasChanges').returns(true)
+
+      stubPrivatePrototypeMethod(WorkspaceRepositories, 'hasChanges').returns(
+        true
+      )
 
       await commands.executeCommand(RegisteredCliCommands.COMMIT, { rootUri })
 
@@ -209,9 +213,8 @@ suite('Source Control Management Test Suite', () => {
         GitCli.prototype,
         'getGitRepositoryRoot'
       ).resolves(gitRoot)
-      const mockExecuteProcess = stub(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        Cli.prototype as any,
+      const mockExecuteProcess = stubPrivatePrototypeMethod(
+        Cli,
         'executeProcess'
       ).resolves('')
 
@@ -229,8 +232,10 @@ suite('Source Control Management Test Suite', () => {
     })
 
     it('should unstage all git tracked files', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const mockExecuteProcess = stub(Cli.prototype as any, 'executeProcess')
+      const mockExecuteProcess = stubPrivatePrototypeMethod(
+        Cli,
+        'executeProcess'
+      )
 
       await commands.executeCommand(RegisteredCliCommands.GIT_UNSTAGE_ALL, {
         rootUri
@@ -246,11 +251,14 @@ suite('Source Control Management Test Suite', () => {
 
     it('should not reset the workspace if the user does not confirm', async () => {
       const mockCheckout = stub(DvcExecutor.prototype, 'checkout').resolves('')
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const mockExecuteProcess = stub(Cli.prototype as any, 'executeProcess')
+      const mockExecuteProcess = stubPrivatePrototypeMethod(
+        Cli,
+        'executeProcess'
+      )
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      stub(WorkspaceRepositories.prototype as any, 'hasChanges').returns(true)
+      stubPrivatePrototypeMethod(WorkspaceRepositories, 'hasChanges').returns(
+        true
+      )
 
       const mockShowWarningMessage = stub(
         window,
@@ -271,11 +279,14 @@ suite('Source Control Management Test Suite', () => {
 
     it('should reset the workspace if the user confirms they want to', async () => {
       const mockCheckout = stub(DvcExecutor.prototype, 'checkout').resolves('')
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const mockExecuteProcess = stub(Cli.prototype as any, 'executeProcess')
+      const mockExecuteProcess = stubPrivatePrototypeMethod(
+        Cli,
+        'executeProcess'
+      )
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      stub(WorkspaceRepositories.prototype as any, 'hasChanges').returns(true)
+      stubPrivatePrototypeMethod(WorkspaceRepositories, 'hasChanges').returns(
+        true
+      )
 
       const mockShowWarningMessage = stub(
         window,
@@ -306,10 +317,14 @@ suite('Source Control Management Test Suite', () => {
 
     it('should not reset the workspace if there is another user initiated command running', async () => {
       const mockCheckout = stub(DvcExecutor.prototype, 'checkout').resolves('')
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const mockExecuteProcess = stub(Cli.prototype as any, 'executeProcess')
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      stub(WorkspaceRepositories.prototype as any, 'hasChanges').returns(true)
+      const mockExecuteProcess = stubPrivatePrototypeMethod(
+        Cli,
+        'executeProcess'
+      )
+
+      stubPrivatePrototypeMethod(WorkspaceRepositories, 'hasChanges').returns(
+        true
+      )
 
       stub(DvcExecutor.prototype, 'isScmCommandRunning').returns(true)
 

--- a/extension/src/test/suite/repository/util.ts
+++ b/extension/src/test/suite/repository/util.ts
@@ -1,10 +1,11 @@
-import { spy, stub } from 'sinon'
+import { stub } from 'sinon'
 import { EventEmitter } from 'vscode'
 import { dvcDemoPath } from '../../util'
 import {
   buildInternalCommands,
   FIRST_TRUTHY_TIME,
-  mockDisposable
+  mockDisposable,
+  spyOnPrivateMemberMethod
 } from '../util'
 import { Disposer } from '../../../extension'
 import { RepositoryData } from '../../../repository/data'
@@ -12,8 +13,6 @@ import * as Time from '../../../util/time'
 import * as Watcher from '../../../fileSystem/watcher'
 import { Repository } from '../../../repository'
 import { InternalCommands } from '../../../commands/internal'
-import { DecorationProvider } from '../../../repository/decorationProvider'
-import { SourceControlManagement } from '../../../repository/sourceControlManagement'
 
 export const buildDependencies = (disposer: Disposer) => {
   const { dvcReader, gitReader, internalCommands } =
@@ -99,14 +98,14 @@ export const buildRepository = async (
     new Repository(dvcRoot, internalCommands, updatesPaused, treeDataChanged)
   )
 
-  const setDecorationStateSpy = spy(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (repository as any).decorationProvider as DecorationProvider,
+  const setDecorationStateSpy = spyOnPrivateMemberMethod(
+    repository,
+    'decorationProvider',
     'setState'
   )
-  const setScmStateSpy = spy(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (repository as any).sourceControlManagement as SourceControlManagement,
+  const setScmStateSpy = spyOnPrivateMemberMethod(
+    repository,
+    'sourceControlManagement',
     'setState'
   )
 

--- a/extension/src/test/suite/util.ts
+++ b/extension/src/test/suite/util.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { resolve } from 'path'
 import { SinonSpy, SinonStub, spy, stub } from 'sinon'
 import {
@@ -197,7 +198,6 @@ export const buildDependencies = (
 
 export const getMessageReceivedEmitter = (
   webview: BaseWebview<PlotsData | TableData>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): EventEmitter<MessageFromWebview> => (webview as any).messageReceived
 
 export const getInputBoxEvent = (mockInputValue: string) => {
@@ -209,3 +209,30 @@ export const getInputBoxEvent = (mockInputValue: string) => {
     })
   )
 }
+
+export const stubPrivateMethod = <T>(
+  classWithPrivateMethod: T,
+  method: string
+) => stub(classWithPrivateMethod as any, method)
+
+export const stubPrivatePrototypeMethod = <T extends { prototype: unknown }>(
+  classWithPrivateMethod: T,
+  method: string
+) => stubPrivateMethod(classWithPrivateMethod.prototype, method)
+
+export const stubPrivateMemberMethod = <T>(
+  classWithPrivateMember: T,
+  memberName: string,
+  method: string
+) => stubPrivateMethod((classWithPrivateMember as any)[memberName], method)
+
+export const spyOnPrivateMethod = <T>(
+  classWithPrivateMember: T,
+  method: string
+) => spy(classWithPrivateMember as any, method)
+
+export const spyOnPrivateMemberMethod = <T>(
+  classWithPrivateMember: T,
+  memberName: string,
+  method: string
+) => spy((classWithPrivateMember as any)[memberName], method)


### PR DESCRIPTION
Follow up from https://github.com/iterative/vscode-dvc/pull/2225#discussion_r951473831.

Removes a lot of test copypasta.