### PR TITLE
Add commit and share experiment command to the palette

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -364,6 +364,12 @@
         "icon": "$(repo-push)"
       },
       {
+        "title": "%command.shareExperimentAsCommit%",
+        "command": "dvc.shareExperimentAsCommit",
+        "category": "DVC",
+        "icon": "$(repo-push)"
+      },
+      {
         "title": "%command.showCommands",
         "command": "dvc.showCommands",
         "category": "DVC"
@@ -755,6 +761,10 @@
         },
         {
           "command": "dvc.shareExperimentAsBranch",
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running"
+        },
+        {
+          "command": "dvc.shareExperimentAsCommit",
           "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running"
         },
         {

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -49,6 +49,7 @@
   "command.selectForCompare": "Select for Compare",
   "command.setupWorkspace": "Setup The Workspace",
   "command.shareExperimentAsBranch": "Share Experiment as Branch",
+  "command.shareExperimentAsCommit": "Commit and Share Experiment",
   "command.showCommands": "Show Commands",
   "command.showExperiments": "Show Experiments",
   "command.showOutput": "Show DVC Output",

--- a/extension/src/commands/external.ts
+++ b/extension/src/commands/external.ts
@@ -10,6 +10,7 @@ export enum RegisteredCliCommands {
   EXPERIMENT_RUN_QUEUED = 'dvc.startExperimentsQueue',
   EXPERIMENT_RESET_AND_RUN = 'dvc.resetAndRunCheckpointExperiment',
   EXPERIMENT_SHARE_AS_BRANCH = 'dvc.shareExperimentAsBranch',
+  EXPERIMENT_SHARE_AS_COMMIT = 'dvc.shareExperimentAsCommit',
   QUEUE_EXPERIMENT = 'dvc.queueExperiment',
 
   EXPERIMENT_VIEW_APPLY = 'dvc.views.experiments.applyExperiment',

--- a/extension/src/experiments/commands/register.ts
+++ b/extension/src/experiments/commands/register.ts
@@ -195,6 +195,15 @@ const registerExperimentInputCommands = (
   )
 
   internalCommands.registerExternalCliCommand(
+    RegisteredCliCommands.EXPERIMENT_SHARE_AS_COMMIT,
+    () =>
+      experiments.getCwdExpNameAndInputThenRun(
+        getShareExperimentAsCommitCommand(internalCommands),
+        Title.ENTER_COMMIT_MESSAGE
+      )
+  )
+
+  internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.EXPERIMENT_VIEW_SHARE_AS_COMMIT,
     ({ dvcRoot, id }: ExperimentDetails) =>
       experiments.getExpNameAndInputThenRun(

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -127,6 +127,7 @@ export interface IEventNamePropertyMapping {
   [EventName.EXPERIMENT_RESET_AND_RUN]: undefined
   [EventName.EXPERIMENT_SELECT]: undefined
   [EventName.EXPERIMENT_SHARE_AS_BRANCH]: undefined
+  [EventName.EXPERIMENT_SHARE_AS_COMMIT]: undefined
   [EventName.EXPERIMENT_SHOW]: undefined
   [EventName.EXPERIMENT_SORT_ADD]: undefined
   [EventName.EXPERIMENT_SORT_ADD_STARRED]: undefined

--- a/extension/src/test/suite/experiments/workspace.test.ts
+++ b/extension/src/test/suite/experiments/workspace.test.ts
@@ -606,6 +606,61 @@ suite('Workspace Experiments Test Suite', () => {
     })
   })
 
+  describe('dvc.shareExperimentAsCommit', () => {
+    it('should be able to share an experiment as a commit', async () => {
+      const { experiments } = buildExperiments(disposable)
+      await experiments.isReady()
+
+      const testExperiment = 'exp-83425'
+      const mockCommit = 'this is the best experiment ever!'
+      const inputEvent = getInputBoxEvent(mockCommit)
+
+      stub(window, 'showQuickPick').resolves({
+        value: { id: testExperiment, name: testExperiment }
+      } as QuickPickItemWithValue<{ id: string; name: string }>)
+
+      const mockExperimentApply = stub(
+        DvcExecutor.prototype,
+        'experimentApply'
+      ).resolves(
+        `Changes for experiment '${testExperiment}' have been applied to your current workspace.`
+      )
+      const mockPush = stub(DvcExecutor.prototype, 'push').resolves(
+        '191232423 files updated.'
+      )
+      const mockStageAndCommit = stub(
+        GitExecutor.prototype,
+        'stageAndCommit'
+      ).resolves('')
+      const mockGitPush = stub(GitExecutor.prototype, 'pushBranch')
+      const branchPushedToRemote = new Promise(resolve =>
+        mockGitPush.callsFake(() => {
+          resolve(undefined)
+          return Promise.resolve(`${mockCommit} pushed to remote`)
+        })
+      )
+
+      stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
+
+      await commands.executeCommand(
+        RegisteredCliCommands.EXPERIMENT_SHARE_AS_COMMIT
+      )
+
+      await inputEvent
+      await branchPushedToRemote
+      expect(mockExperimentApply).to.be.calledWithExactly(
+        dvcDemoPath,
+        testExperiment
+      )
+      expect(mockStageAndCommit).to.be.calledWithExactly(
+        dvcDemoPath,
+        mockCommit
+      )
+      expect(mockPush).to.be.calledWithExactly(dvcDemoPath)
+      expect(mockGitPush).to.be.calledWithExactly(dvcDemoPath)
+    })
+  })
+
   describe('dvc.removeExperiment', () => {
     it('should ask the user to pick an experiment and then remove that experiment from the workspace', async () => {
       const mockExperiment = 'exp-to-remove'


### PR DESCRIPTION
Follow up from #2237. This PR adds the ability to commit and share an experiment from the command palette.

### Demo

https://user-images.githubusercontent.com/37993418/186547904-9848bb52-422c-4556-ae05-0d11d1d4e118.mov


