### PR TITLE
Bump min version of DVC to 2.21.0 (data status)

### DIFF
--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,3 +1,3 @@
-dvc[s3]==2.20.1
+dvc[s3]==2.21.1
 torch==1.12.0
 torchvision==0.13.0

--- a/extension/src/cli/dvc/constants.ts
+++ b/extension/src/cli/dvc/constants.ts
@@ -1,5 +1,5 @@
-export const MIN_CLI_VERSION = '2.11.0'
-export const LATEST_TESTED_CLI_VERSION = '2.20.1'
+export const MIN_CLI_VERSION = '2.21.0'
+export const LATEST_TESTED_CLI_VERSION = '2.21.1'
 export const MAX_CLI_VERSION = '3'
 
 export const UNEXPECTED_ERROR_CODE = 255


### PR DESCRIPTION
# 3/5 `main` <- #2091 <- #2151 <- this <- #2267 <- #2299

This PR bumps the min version of the CLI so that we can release all of the code associated with the new data status command.

DVC release page for `2.21.0` is here: https://github.com/iterative/dvc/releases/tag/2.21.0