### PR TITLE
Dispatch publish extension action on merge of update version and CHANGELOG for release PR

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -59,7 +59,8 @@ jobs:
 
             Please close and reopen this PR to run the required workflows (Required statuses must pass before merging).
 
-            **This needs to be approved and merged before we run the `publish` workflow.**
-          commit-message: 'update version and changelog for release'
+            **The `publish` workflow will run automatically when this PR is merged.**
+          commit-message: 'Update version and CHANGELOG for release'
           title: 'Update version and CHANGELOG for release'
           token: ${{ secrets.GITHUB_TOKEN }}
+          labels: make release go now

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,15 @@
 name: Publish Extension
 
-on: workflow_dispatch
+on:
+  pull_request:
+    types: [closed]
 
 jobs:
   deploy:
+    if: |
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'make release go now') && 
+      github.event.pull_request.title == 'Update version and CHANGELOG for release'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 CHANGELOG.md
+.github/workflows/publish.yml


### PR DESCRIPTION
Follow up on an action item from the retro.

A release should now be triggered whenever a PR with the title `Update version and CHANGELOG for release` and label `make release go now` is merged. 