### PR TITLE
Bump min version of DVC to 2.23.0 (--with-dirs removed from data status)

### DIFF
--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,3 +1,3 @@
-dvc[s3]==2.21.1
+dvc[s3]==2.23.0
 torch==1.12.0
 torchvision==0.13.0

--- a/extension/src/cli/dvc/constants.ts
+++ b/extension/src/cli/dvc/constants.ts
@@ -1,5 +1,5 @@
-export const MIN_CLI_VERSION = '2.21.0'
-export const LATEST_TESTED_CLI_VERSION = '2.21.1'
+export const MIN_CLI_VERSION = '2.23.0'
+export const LATEST_TESTED_CLI_VERSION = '2.23.0'
 export const MAX_CLI_VERSION = '3'
 
 export const UNEXPECTED_ERROR_CODE = 255
@@ -36,8 +36,7 @@ export enum Flag {
   SET_PARAM = '-S',
   SPLIT = '--split',
   UNCHANGED = '--unchanged',
-  VERSION = '--version',
-  WITH_DIRS = '--with-dirs'
+  VERSION = '--version'
 }
 
 export enum ExperimentSubCommand {

--- a/extension/src/cli/dvc/reader.test.ts
+++ b/extension/src/cli/dvc/reader.test.ts
@@ -138,14 +138,7 @@ describe('CliReader', () => {
       expect(statusOutput).toStrictEqual(cliOutput)
 
       expect(mockedCreateProcess).toBeCalledWith({
-        args: [
-          'data',
-          'status',
-          '--with-dirs',
-          '--granular',
-          '--unchanged',
-          JSON_FLAG
-        ],
+        args: ['data', 'status', '--granular', '--unchanged', JSON_FLAG],
         cwd,
         env: mockedEnv,
         executable: 'dvc'

--- a/extension/src/cli/dvc/reader.ts
+++ b/extension/src/cli/dvc/reader.ts
@@ -107,7 +107,6 @@ export class DvcReader extends DvcCli {
       cwd,
       Command.DATA,
       SubCommand.STATUS,
-      Flag.WITH_DIRS,
       Flag.GRANULAR,
       Flag.UNCHANGED,
       ...args


### PR DESCRIPTION
# 5/5 `main` <- #2091 <- #2151 <- #2266 <- #2267 <- this

This PR removes the use of a `--with-dirs` from our call to `data status`. The flag was removed in `2.23.0` in favour of having that as the default behaviour.