### PR TITLE
Improve table column resizing styles

### DIFF
--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -1085,7 +1085,7 @@ describe('App', () => {
   it('should disable text selection while resizing', async () => {
     renderTable()
 
-    expect(document.body).not.toHaveClass(styles.noSelect)
+    expect(document.body).not.toHaveClass(styles.isColumnResizing)
 
     const [experimentColumnResizeHandle] = await screen.findAllByRole(
       'separator'
@@ -1093,10 +1093,10 @@ describe('App', () => {
 
     fireEvent.mouseDown(experimentColumnResizeHandle)
 
-    expect(document.body).toHaveClass(styles.noSelect)
+    expect(document.body).toHaveClass(styles.isColumnResizing)
 
     fireEvent.mouseUp(experimentColumnResizeHandle)
 
-    expect(document.body).not.toHaveClass(styles.noSelect)
+    expect(document.body).not.toHaveClass(styles.isColumnResizing)
   })
 })

--- a/webview/src/experiments/components/Experiments.tsx
+++ b/webview/src/experiments/components/Experiments.tsx
@@ -175,11 +175,11 @@ export const ExperimentsTable: React.FC = () => {
     hooks => {
       hooks.stateReducers.push((state, action) => {
         if (action.type === 'columnStartResizing') {
-          document.body.classList.add(styles.noSelect)
+          document.body.classList.add(styles.isColumnResizing)
         }
         if (action.type === 'columnDoneResizing') {
           reportResizedColumn(state)
-          document.body.classList.remove(styles.noSelect)
+          document.body.classList.remove(styles.isColumnResizing)
         }
         return state
       })

--- a/webview/src/experiments/components/table/TableHeaderCell.tsx
+++ b/webview/src/experiments/components/table/TableHeaderCell.tsx
@@ -23,7 +23,7 @@ const calcResizerHeight = (
   const nbUpperLevels = isPlaceholder
     ? 0
     : countUpperLevels(orderedColumns, column, columns, 0)
-  return 100 + nbUpperLevels * 92 + '%'
+  return 100 + nbUpperLevels * 105 + '%'
 }
 
 const getHeaderPropsArgs = (

--- a/webview/src/experiments/components/table/TableHeaderCellContents.tsx
+++ b/webview/src/experiments/components/table/TableHeaderCellContents.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import cx from 'classnames'
 import { Experiment } from 'dvc/src/experiments/webview/contract'
 import { HeaderGroup } from 'react-table'
@@ -89,6 +89,12 @@ export const TableHeaderCellContents: React.FC<{
   setMenuSuppressed,
   resizerHeight
 }) => {
+  const [isResizing, setIsResizing] = useState(false)
+
+  useEffect(() => {
+    setIsResizing(column.isResizing)
+  }, [column.isResizing])
+
   return (
     <>
       <div className={styles.iconMenu}>
@@ -106,7 +112,7 @@ export const TableHeaderCellContents: React.FC<{
           {...column.getResizerProps()}
           onMouseEnter={() => setMenuSuppressed(true)}
           onMouseLeave={() => setMenuSuppressed(false)}
-          className={styles.columnResizer}
+          className={cx(styles.columnResizer, isResizing && styles.isResizing)}
           style={{ height: resizerHeight }}
         />
       )}

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -620,7 +620,7 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
   touch-action: none;
   cursor: col-resize;
 
-  &:hover::after {
+  &::after {
     content: '';
     position: absolute;
     bottom: 0;
@@ -628,6 +628,12 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
     width: 2px;
     height: 100%;
     background-color: $header-resizer-color;
+    display: none;
+  }
+
+  &:hover::after,
+  &.isResizing::after {
+    display: block;
   }
 }
 
@@ -809,4 +815,9 @@ $badge-size: 0.85rem;
 
 .noSelect {
   user-select: none;
+}
+
+.isColumnResizing {
+  @extend .noSelect;
+  cursor: col-resize;
 }


### PR DESCRIPTION
* show `columnResizer` bar active styles on hover and when the column is being resized
* keep the resizer bar the same height of the cell(s)

## Demo


https://user-images.githubusercontent.com/43496356/187734504-a6f9e544-02fe-48e2-a7fa-fc6a1630f9e8.mov

Part of #2241 