### PR TITLE
Bump min version of DVC to 2.24.0 (patch windows paths in data status)

### DIFF
--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,3 +1,3 @@
-dvc[s3]==2.23.0
+dvc[s3]==2.24.0
 torch==1.12.0
 torchvision==0.13.0

--- a/extension/src/cli/dvc/constants.ts
+++ b/extension/src/cli/dvc/constants.ts
@@ -1,5 +1,5 @@
-export const MIN_CLI_VERSION = '2.23.0'
-export const LATEST_TESTED_CLI_VERSION = '2.23.0'
+export const MIN_CLI_VERSION = '2.24.0'
+export const LATEST_TESTED_CLI_VERSION = '2.24.0'
 export const MAX_CLI_VERSION = '3'
 
 export const UNEXPECTED_ERROR_CODE = 255


### PR DESCRIPTION
Unblocks `0.4.0`.

See [here](https://iterativeai.slack.com/archives/C01RB7BTG4C/p1661985291488089) for details.