### PR TITLE
Move DVC Tracked tree into repository directory structure

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -10,7 +10,7 @@ import { WorkspaceExperiments } from './experiments/workspace'
 import { registerExperimentCommands } from './experiments/commands/register'
 import { registerPlotsCommands } from './plots/commands/register'
 import { findAbsoluteDvcRootPath, findDvcRootPaths } from './fileSystem'
-import { TrackedExplorerTree } from './fileSystem/tree'
+import { RepositoriesTree } from './repository/model/tree'
 import { IExtension } from './interfaces'
 import { registerRepositoryCommands } from './repository/commands/register'
 import { ResourceLocator } from './resourceLocator'
@@ -61,7 +61,7 @@ export class Extension extends Disposable implements IExtension {
   private readonly repositories: WorkspaceRepositories
   private readonly experiments: WorkspaceExperiments
   private readonly plots: WorkspacePlots
-  private readonly trackedExplorerTree: TrackedExplorerTree
+  private readonly repositoriesTree: RepositoriesTree
   private readonly dvcExecutor: DvcExecutor
   private readonly dvcReader: DvcReader
   private readonly dvcRunner: DvcRunner
@@ -177,8 +177,8 @@ export class Extension extends Disposable implements IExtension {
       )
     )
 
-    this.trackedExplorerTree = this.dispose.track(
-      new TrackedExplorerTree(this.internalCommands, this.repositories)
+    this.repositoriesTree = this.dispose.track(
+      new RepositoriesTree(this.internalCommands, this.repositories)
     )
 
     setup(this)
@@ -355,7 +355,7 @@ export class Extension extends Disposable implements IExtension {
 
     await Promise.all([
       this.repositories.create(this.dvcRoots, this.updatesPaused),
-      this.trackedExplorerTree.initialize(this.dvcRoots),
+      this.repositoriesTree.initialize(this.dvcRoots),
       this.experiments.create(
         this.dvcRoots,
         this.updatesPaused,
@@ -379,7 +379,7 @@ export class Extension extends Disposable implements IExtension {
 
   public resetMembers() {
     this.repositories.reset()
-    this.trackedExplorerTree.initialize([])
+    this.repositoriesTree.initialize([])
     this.experiments.reset()
     this.plots.reset()
   }

--- a/extension/src/repository/model/tree.test.ts
+++ b/extension/src/repository/model/tree.test.ts
@@ -8,18 +8,18 @@ import {
   window
 } from 'vscode'
 import { Disposable, Disposer } from '@hediet/std/disposable'
-import { exists, isDirectory } from '.'
-import { TrackedExplorerTree } from './tree'
-import { getWorkspaceFolders } from '../vscode/workspaceFolders'
-import { InternalCommands } from '../commands/internal'
-import { RegisteredCommands } from '../commands/external'
-import { OutputChannel } from '../vscode/outputChannel'
-import { WorkspaceRepositories } from '../repository/workspace'
-import { Repository } from '../repository'
-import { dvcDemoPath } from '../test/util'
-import { getDecoratableUri, DecoratableTreeItemScheme } from '../tree'
-import { getMarkdownString } from '../vscode/markdownString'
-import { PathItem } from '../repository/model/collect'
+import { PathItem } from './collect'
+import { RepositoriesTree } from './tree'
+import { Repository } from '..'
+import { WorkspaceRepositories } from '../workspace'
+import { exists, isDirectory } from '../../fileSystem'
+import { getWorkspaceFolders } from '../../vscode/workspaceFolders'
+import { InternalCommands } from '../../commands/internal'
+import { RegisteredCommands } from '../../commands/external'
+import { OutputChannel } from '../../vscode/outputChannel'
+import { dvcDemoPath } from '../../test/util'
+import { getDecoratableUri, DecoratableTreeItemScheme } from '../../tree'
+import { getMarkdownString } from '../../vscode/markdownString'
 
 const mockedTreeDataChanged = jest.mocked(new EventEmitter<void>())
 const mockedTreeDataChangedFire = jest.fn()
@@ -61,10 +61,10 @@ const mockedGetMarkdownString = jest.mocked(getMarkdownString)
 
 jest.mock('vscode')
 jest.mock('@hediet/std/disposable')
-jest.mock('.')
-jest.mock('../cli/dvc/reader')
-jest.mock('../vscode/workspaceFolders')
-jest.mock('../vscode/markdownString')
+jest.mock('../../fileSystem')
+jest.mock('../../cli/dvc/reader')
+jest.mock('../../vscode/workspaceFolders')
+jest.mock('../../vscode/markdownString')
 
 beforeEach(() => {
   jest.resetAllMocks()
@@ -75,10 +75,10 @@ beforeEach(() => {
   } as unknown as Repository)
 })
 
-describe('TrackedTreeView', () => {
+describe('RepositoriesTree', () => {
   describe('initialize', () => {
     it('should fire the event emitter to reset the data in the view', () => {
-      const trackedTreeView = new TrackedExplorerTree(
+      const trackedTreeView = new RepositoriesTree(
         mockedInternalCommands,
         mockedRepositories
       )
@@ -93,7 +93,7 @@ describe('TrackedTreeView', () => {
       const mockedOtherRoot = join('some', 'other', 'root')
       const mockedDvcRoots = [dvcDemoPath, mockedOtherRoot]
 
-      const trackedTreeView = new TrackedExplorerTree(
+      const trackedTreeView = new RepositoriesTree(
         mockedInternalCommands,
         mockedRepositories
       )
@@ -125,7 +125,7 @@ describe('TrackedTreeView', () => {
         resolve(dvcDemoPath, '..')
       ])
 
-      const trackedTreeView = new TrackedExplorerTree(
+      const trackedTreeView = new RepositoriesTree(
         mockedInternalCommands,
         mockedRepositories
       )
@@ -147,7 +147,7 @@ describe('TrackedTreeView', () => {
       const mockedDvcRoots = [dvcDemoPath]
       mockedGetWorkspaceFolders.mockReturnValueOnce(mockedDvcRoots)
 
-      const trackedTreeView = new TrackedExplorerTree(
+      const trackedTreeView = new RepositoriesTree(
         mockedInternalCommands,
         mockedRepositories
       )
@@ -194,7 +194,7 @@ describe('TrackedTreeView', () => {
       const data = Uri.file(join(dvcDemoPath, 'data'))
       mockedGetWorkspaceFolders.mockReturnValueOnce([dvcDemoPath])
 
-      const trackedTreeView = new TrackedExplorerTree(
+      const trackedTreeView = new RepositoriesTree(
         mockedInternalCommands,
         mockedRepositories
       )
@@ -264,7 +264,7 @@ describe('TrackedTreeView', () => {
       })
       mockedExists.mockReturnValueOnce(false)
 
-      const trackedTreeView = new TrackedExplorerTree(
+      const trackedTreeView = new RepositoriesTree(
         mockedInternalCommands,
         mockedRepositories
       )
@@ -292,7 +292,7 @@ describe('TrackedTreeView', () => {
         return mockedItem
       })
 
-      const trackedTreeView = new TrackedExplorerTree(
+      const trackedTreeView = new RepositoriesTree(
         mockedInternalCommands,
         mockedRepositories
       )
@@ -319,7 +319,7 @@ describe('TrackedTreeView', () => {
         return mockedItem
       })
 
-      const trackedTreeView = new TrackedExplorerTree(
+      const trackedTreeView = new RepositoriesTree(
         mockedInternalCommands,
         mockedRepositories
       )
@@ -351,7 +351,7 @@ describe('TrackedTreeView', () => {
         return mockedItem
       })
 
-      const trackedTreeView = new TrackedExplorerTree(
+      const trackedTreeView = new RepositoriesTree(
         mockedInternalCommands,
         mockedRepositories
       )
@@ -395,7 +395,7 @@ describe('TrackedTreeView', () => {
         return mockedItem
       })
 
-      const trackedTreeView = new TrackedExplorerTree(
+      const trackedTreeView = new RepositoriesTree(
         mockedInternalCommands,
         mockedRepositories
       )

--- a/extension/src/repository/model/tree.ts
+++ b/extension/src/repository/model/tree.ts
@@ -8,43 +8,46 @@ import {
   TreeView,
   Uri
 } from 'vscode'
-import { exists, relativeWithUri } from '.'
-import { standardizePath } from './path'
-import { fireWatcher } from './watcher'
-import { deleteTarget, moveTargets } from './workspace'
-import { definedAndNonEmpty, sameContents, uniqueValues } from '../util/array'
+import { collectSelected, collectTrackedPaths, PathItem } from './collect'
+import { ErrorItem, pathItemHasError } from './error'
+import { Resource } from '../commands'
+import { WorkspaceRepositories } from '../workspace'
+import { exists, relativeWithUri } from '../../fileSystem'
+import { standardizePath } from '../../fileSystem/path'
+import { fireWatcher } from '../../fileSystem/watcher'
+import { deleteTarget, moveTargets } from '../../fileSystem/workspace'
+import {
+  definedAndNonEmpty,
+  sameContents,
+  uniqueValues
+} from '../../util/array'
 import {
   AvailableCommands,
   CommandId,
   InternalCommands
-} from '../commands/internal'
-import { tryThenMaybeForce } from '../cli/dvc/actions'
-import { RegisteredCliCommands, RegisteredCommands } from '../commands/external'
-import { sendViewOpenedTelemetryEvent } from '../telemetry'
-import { EventName } from '../telemetry/constants'
-import { getInput } from '../vscode/inputBox'
-import { pickResources } from '../vscode/resourcePicker'
-import { warnOfConsequences } from '../vscode/modal'
-import { Response } from '../vscode/response'
-import { Resource } from '../repository/commands'
-import { WorkspaceRepositories } from '../repository/workspace'
+} from '../../commands/internal'
+import { tryThenMaybeForce } from '../../cli/dvc/actions'
 import {
-  collectSelected,
-  collectTrackedPaths,
-  PathItem
-} from '../repository/model/collect'
-import { ErrorItem, pathItemHasError } from '../repository/model/error'
-import { Title } from '../vscode/title'
-import { Disposable } from '../class/dispose'
+  RegisteredCliCommands,
+  RegisteredCommands
+} from '../../commands/external'
+import { sendViewOpenedTelemetryEvent } from '../../telemetry'
+import { EventName } from '../../telemetry/constants'
+import { getInput } from '../../vscode/inputBox'
+import { pickResources } from '../../vscode/resourcePicker'
+import { warnOfConsequences } from '../../vscode/modal'
+import { Response } from '../../vscode/response'
+import { Title } from '../../vscode/title'
+import { Disposable } from '../../class/dispose'
 import {
   createTreeView,
   DecoratableTreeItemScheme,
   getDecoratableTreeItem,
   getErrorTooltip
-} from '../tree'
-import { getWorkspaceFolders } from '../vscode/workspaceFolders'
+} from '../../tree'
+import { getWorkspaceFolders } from '../../vscode/workspaceFolders'
 
-export class TrackedExplorerTree
+export class RepositoriesTree
   extends Disposable
   implements TreeDataProvider<PathItem>
 {

--- a/extension/src/test/suite/repository/model/tree.test.ts
+++ b/extension/src/test/suite/repository/model/tree.test.ts
@@ -13,28 +13,28 @@ import {
   WorkspaceEdit,
   workspace
 } from 'vscode'
-import { Disposable } from '../../../extension'
-import * as Workspace from '../../../fileSystem/workspace'
-import { DvcExecutor } from '../../../cli/dvc/executor'
+import { Disposable } from '../../../../extension'
+import * as Workspace from '../../../../fileSystem/workspace'
+import { DvcExecutor } from '../../../../cli/dvc/executor'
 import {
   activeTextEditorChangedEvent,
   buildDependencies,
   closeAllEditors,
   getActiveTextEditorFilename,
   stubPrivatePrototypeMethod
-} from '../util'
-import { dvcDemoPath } from '../../util'
+} from '../../util'
+import { dvcDemoPath } from '../../../util'
 import {
   RegisteredCliCommands,
   RegisteredCommands
-} from '../../../commands/external'
-import { WEBVIEW_TEST_TIMEOUT } from '../timeouts'
-import { Title } from '../../../vscode/title'
-import { Repository } from '../../../repository'
-import { WorkspaceRepositories } from '../../../repository/workspace'
-import { TrackedExplorerTree } from '../../../fileSystem/tree'
+} from '../../../../commands/external'
+import { WEBVIEW_TEST_TIMEOUT } from '../../timeouts'
+import { Title } from '../../../../vscode/title'
+import { Repository } from '../../../../repository'
+import { WorkspaceRepositories } from '../../../../repository/workspace'
+import { RepositoriesTree } from '../../../../repository/model/tree'
 
-suite('Tracked Explorer Tree Test Suite', () => {
+suite('Repositories Tree Test Suite', () => {
   const { join } = path
 
   const getPathItem = (relPath: string, isTracked = true) => ({
@@ -54,7 +54,7 @@ suite('Tracked Explorer Tree Test Suite', () => {
     return closeAllEditors()
   })
 
-  describe('TrackedExplorerTree', () => {
+  describe('RepositoriesTree', () => {
     it('should appear in the UI', async () => {
       await expect(
         commands.executeCommand('dvc.views.trackedExplorerTree.focus')
@@ -314,7 +314,7 @@ suite('Tracked Explorer Tree Test Suite', () => {
       stub(WorkspaceRepositories.prototype, 'getRepository').returns(repository)
       stub(WorkspaceRepositories.prototype, 'isReady').resolves(undefined)
       stubPrivatePrototypeMethod(
-        TrackedExplorerTree,
+        RepositoriesTree,
         'getSelectedPathItems'
       ).returns([])
       const mockPull = stub(DvcExecutor.prototype, 'pull').resolves(
@@ -345,7 +345,7 @@ suite('Tracked Explorer Tree Test Suite', () => {
         'target pulled'
       )
       stubPrivatePrototypeMethod(
-        TrackedExplorerTree,
+        RepositoriesTree,
         'getSelectedPathItems'
       ).returns([getPathItem(relPath)])
 
@@ -375,7 +375,7 @@ suite('Tracked Explorer Tree Test Suite', () => {
       ).resolves('Force' as unknown as MessageItem)
 
       stubPrivatePrototypeMethod(
-        TrackedExplorerTree,
+        RepositoriesTree,
         'getSelectedPathItems'
       ).returns([getPathItem(relPath)])
 
@@ -399,7 +399,7 @@ suite('Tracked Explorer Tree Test Suite', () => {
       )
 
       stubPrivatePrototypeMethod(
-        TrackedExplorerTree,
+        RepositoriesTree,
         'getSelectedPathItems'
       ).returns([getPathItem(relPath)])
 
@@ -428,7 +428,7 @@ suite('Tracked Explorer Tree Test Suite', () => {
       ).resolves('Force' as unknown as MessageItem)
 
       stubPrivatePrototypeMethod(
-        TrackedExplorerTree,
+        RepositoriesTree,
         'getSelectedPathItems'
       ).returns([])
 


### PR DESCRIPTION
# 2/3 `main` <- #2330 <- this <- #2332

As mentioned [here](https://github.com/iterative/vscode-dvc/pull/2330/files#r962425655).