### PR TITLE
Keep cursor on `col-resize` on table column resize

### DIFF
--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -814,4 +814,8 @@ $badge-size: 0.85rem;
 .isColumnResizing {
   @extend .noSelect;
   cursor: col-resize;
+
+  * {
+    cursor: col-resize;
+  }
 }


### PR DESCRIPTION
* stops cursor from changing when user hovers over draggable cells on column resize

## Demo

https://user-images.githubusercontent.com/43496356/189118009-ddb0bc97-b1a9-496e-89c7-7281efd41f02.mov

Followup to [#2305 comment ](https://github.com/iterative/vscode-dvc/pull/2305#issuecomment-1240068875)