### PR TITLE
Truncate axis titles

### DIFF
--- a/webview/src/plots/components/ZoomablePlot.tsx
+++ b/webview/src/plots/components/ZoomablePlot.tsx
@@ -24,6 +24,47 @@ const TitleLimit = {
   [PlotSize.SMALL]: 30
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, sonarjs/cognitive-complexity
+const layersWithTruncatedTitles = (layer: any, size: number) => {
+  if (layer.length === 0) {
+    return layer
+  }
+
+  const layerEncoding = layer[0].encoding
+
+  return [
+    {
+      ...layer[0],
+      encoding: layerEncoding
+        ? {
+            ...layerEncoding,
+            x: layerEncoding.x
+              ? {
+                  ...layerEncoding.x,
+                  title: truncateTitle(layerEncoding.x.title, size)
+                }
+              : {},
+            y: layerEncoding.y
+              ? {
+                  ...layerEncoding.y,
+                  title: truncateTitle(layerEncoding.y.title, size * 0.75)
+                }
+              : {}
+          }
+        : {}
+    },
+    ...layer.slice(1)
+  ]
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const withOrWithoutlayer = (spec: any, size: number) =>
+  spec.layer
+    ? {
+        layer: layersWithTruncatedTitles(spec.layer, size)
+      }
+    : {}
+
 export const ZoomablePlot: React.FC<ZoomablePlotProps> = ({
   spec,
   data,
@@ -44,6 +85,7 @@ export const ZoomablePlot: React.FC<ZoomablePlotProps> = ({
     renderer: 'svg' as unknown as Renderers,
     spec: {
       ...spec,
+      ...withOrWithoutlayer(spec, TitleLimit[size]),
       title: truncateTitle(spec.title, TitleLimit[size])
     }
   } as VegaLiteProps


### PR DESCRIPTION
Part of #2340 
<img width="405" alt="Screen Shot 2022-09-08 at 10 30 11 AM" src="https://user-images.githubusercontent.com/3683420/189155551-7e2dd154-f175-4311-96a9-36c2c852154f.png">

This technically works, but I'm not really happy about this because I previously got it to work by changing the titles on `spec.encoding.x` and `spec.encoding.y` and I feel like these could be found pretty much anywhere in the object structure.  I'm going to make a util that finds axes anywhere in the spec instead.