### PR TITLE
Ensure welcome screen is not shown when only one column is provided

### DIFF
--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -136,6 +136,18 @@ describe('App', () => {
     expect(noColumnsState).toBeInTheDocument()
   })
 
+  it('should not show the no columns selected empty state when only the timestamp column is provided', () => {
+    renderTable({
+      ...tableDataFixture,
+      columns: tableDataFixture.columns.filter(
+        ({ label }) => label === 'Created'
+      )
+    })
+
+    const noColumnsState = screen.queryByText('No Columns Selected.')
+    expect(noColumnsState).not.toBeInTheDocument()
+  })
+
   it('should show the no experiments empty state when only the workspace is provided', () => {
     renderTableWithWorkspaceRowOnly()
 

--- a/webview/src/experiments/components/Experiments.tsx
+++ b/webview/src/experiments/components/Experiments.tsx
@@ -205,7 +205,7 @@ export const ExperimentsTable: React.FC = () => {
     toggleAllRowsExpanded()
   }, [toggleAllRowsExpanded])
 
-  const hasOnlyDefaultColumns = columns.length <= 2
+  const hasOnlyDefaultColumns = columns.length <= 1
   const hasOnlyWorkspace = data.length <= 1
   if (hasOnlyDefaultColumns || hasOnlyWorkspace) {
     return (


### PR DESCRIPTION
The initial problem of the table not being shown has been fixed. However, the indicators are mashed in with the experiments header name if the shown columns have a depth of 1:

### Demo

https://user-images.githubusercontent.com/37993418/189264864-ae724051-757b-4047-b795-9fd5c582028a.mov

I spent a good chunk of time looking at this. Can someone point me in the right direction to fix it?