### PR TITLE
Fix zoomed in plot overflow

### DIFF
--- a/webview/src/plots/components/styles.module.scss
+++ b/webview/src/plots/components/styles.module.scss
@@ -347,9 +347,15 @@ $gap: 20px;
   width: 80vw;
   height: calc(80vh - 100px);
 
+  :global(.chart-wrapper) {
+    width: 100%;
+    height: 100%;
+  }
+
   svg {
     background-color: transparent !important;
-    max-width: 100%;
+    width: 100%;
+    height: 100%;
   }
 }
 


### PR DESCRIPTION
Part of #2340 

https://user-images.githubusercontent.com/3683420/189382638-397bd74f-b43a-4771-b446-62e249764bca.mov


https://user-images.githubusercontent.com/3683420/189382789-2c4a9e20-4b18-480d-be54-9fe2efe0600d.mov

We lose the ratio of the plot, but I would argue that it's nice to have it really zoomed in and decide on its size. It's possible to have it keep the ratio also, it was just easy to do it this way. (Will change if people feel better in keeping the ratio)