### PR TITLE
Ensure table indicators do not overlap with experiment column title

### DIFF
--- a/webview/src/experiments/components/Experiments.tsx
+++ b/webview/src/experiments/components/Experiments.tsx
@@ -23,6 +23,7 @@ import { WebviewWrapper } from '../../shared/components/webviewWrapper/WebviewWr
 import { GetStarted } from '../../shared/components/getStarted/GetStarted'
 import { EmptyState } from '../../shared/components/emptyState/EmptyState'
 import { ExperimentsState } from '../store'
+import { EXPERIMENT_COLUMN_ID } from '../util/columns'
 
 const DEFAULT_COLUMN_WIDTH = 90
 const MINIMUM_COLUMN_WIDTH = 90
@@ -86,8 +87,8 @@ const getDefaultColumnWithIndicatorsPlaceHolder = () => {
       )
     },
     Header: ExperimentHeader,
-    accessor: 'id',
-    id: 'id',
+    accessor: EXPERIMENT_COLUMN_ID,
+    id: EXPERIMENT_COLUMN_ID,
     minWidth: 250,
     width: 250
   }

--- a/webview/src/experiments/components/Experiments.tsx
+++ b/webview/src/experiments/components/Experiments.tsx
@@ -67,35 +67,45 @@ const DateCellContents: React.FC<{ value: string }> = ({ value }) => {
   )
 }
 
+const getDefaultColumnWithIndicatorsPlaceHolder = () => {
+  const experimentColumn = {
+    Cell: ({
+      row: {
+        original: { label, displayNameOrParent }
+      }
+    }: Cell<Row>) => {
+      return (
+        <div className={styles.experimentCellContents}>
+          <span className={styles.experimentCellPrimaryName}>{label}</span>
+          {displayNameOrParent && (
+            <span className={styles.experimentCellSecondaryName}>
+              {displayNameOrParent}
+            </span>
+          )}
+        </div>
+      )
+    },
+    Header: ExperimentHeader,
+    accessor: 'id',
+    id: 'id',
+    minWidth: 250,
+    width: 250
+  }
+  return {
+    Header: '',
+    columns: [experimentColumn],
+    id: 'id_placeholder',
+    placeholderOf: experimentColumn
+  }
+}
+
 const getColumns = (columns: Column[]): TableColumn<Row>[] => {
   const includeTimestamp = columns.some(
     ({ type }) => type === ColumnType.TIMESTAMP
   )
 
   const builtColumns = [
-    {
-      Cell: ({
-        row: {
-          original: { label, displayNameOrParent }
-        }
-      }: Cell<Row>) => {
-        return (
-          <div className={styles.experimentCellContents}>
-            <span className={styles.experimentCellPrimaryName}>{label}</span>
-            {displayNameOrParent && (
-              <span className={styles.experimentCellSecondaryName}>
-                {displayNameOrParent}
-              </span>
-            )}
-          </div>
-        )
-      },
-      Header: ExperimentHeader,
-      accessor: 'id',
-      id: 'id',
-      minWidth: 250,
-      width: 250
-    },
+    getDefaultColumnWithIndicatorsPlaceHolder(),
     ...buildDynamicColumns(columns, ColumnType.METRICS),
     ...buildDynamicColumns(columns, ColumnType.PARAMS),
     ...buildDynamicColumns(columns, ColumnType.DEPS)

--- a/webview/src/experiments/components/table/MergeHeaderGroups.tsx
+++ b/webview/src/experiments/components/table/MergeHeaderGroups.tsx
@@ -13,7 +13,6 @@ export const MergedHeaderGroups: React.FC<{
   onDragUpdate: DragFunction
   onDragStart: DragFunction
   onDragEnd: DragFunction
-  firstExpColumnCellId: string
   setExpColumnNeedsShadow: (needsShadow: boolean) => void
   root: HTMLElement | null
 }> = ({
@@ -24,7 +23,6 @@ export const MergedHeaderGroups: React.FC<{
   onDragEnd,
   onDragStart,
   root,
-  firstExpColumnCellId,
   setExpColumnNeedsShadow
 }) => {
   return (
@@ -35,7 +33,6 @@ export const MergedHeaderGroups: React.FC<{
     >
       {headerGroup.headers.map((column: HeaderGroup<Experiment>) => (
         <TableHeader
-          firstExpColumnCellId={firstExpColumnCellId}
           setExpColumnNeedsShadow={setExpColumnNeedsShadow}
           key={column.id}
           orderedColumns={orderedColumns}

--- a/webview/src/experiments/components/table/TableHead.tsx
+++ b/webview/src/experiments/components/table/TableHead.tsx
@@ -97,8 +97,6 @@ export const TableHead = ({
 
   const selectedForPlotsCount = getSelectedForPlotsCount(rows)
 
-  const firstExpColumnCellId = headerGroups[0].headers[0].id
-
   return (
     <div className={styles.thead} ref={wrapper}>
       <Indicators selectedForPlotsCount={selectedForPlotsCount} />
@@ -113,7 +111,6 @@ export const TableHead = ({
           onDragUpdate={onDragUpdate}
           onDragEnd={onDragEnd}
           root={root}
-          firstExpColumnCellId={firstExpColumnCellId}
           setExpColumnNeedsShadow={setExpColumnNeedsShadow}
         />
       ))}

--- a/webview/src/experiments/components/table/TableHeader.tsx
+++ b/webview/src/experiments/components/table/TableHeader.tsx
@@ -33,7 +33,6 @@ interface TableHeaderProps {
   onDragEnter: DragFunction
   onDragStart: DragFunction
   onDrop: DragFunction
-  firstExpColumnCellId: string
   setExpColumnNeedsShadow: (needsShadow: boolean) => void
   root: HTMLElement | null
 }
@@ -46,7 +45,6 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
   onDragStart,
   onDrop,
   root,
-  firstExpColumnCellId,
   setExpColumnNeedsShadow
 }) => {
   const { filters, sorts } = useSelector(
@@ -99,7 +97,6 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
       onDrop={onDrop}
       menuDisabled={!isSortable && column.group !== ColumnType.PARAMS}
       root={root}
-      firstExpColumnCellId={firstExpColumnCellId}
       setExpColumnNeedsShadow={setExpColumnNeedsShadow}
       menuContent={
         <div>

--- a/webview/src/experiments/components/table/TableHeaderCell.tsx
+++ b/webview/src/experiments/components/table/TableHeaderCell.tsx
@@ -10,7 +10,11 @@ import { useInView } from 'react-intersection-observer'
 import styles from './styles.module.scss'
 import { SortOrder } from './TableHeader'
 import { TableHeaderCellContents } from './TableHeaderCellContents'
-import { countUpperLevels, isFirstLevelHeader } from '../../util/columns'
+import {
+  countUpperLevels,
+  isExperimentColumn,
+  isFirstLevelHeader
+} from '../../util/columns'
 import { ContextMenu } from '../../../shared/components/contextMenu/ContextMenu'
 import { DragFunction } from '../../../shared/components/dragDrop/Draggable'
 
@@ -84,7 +88,6 @@ export const TableHeaderCell: React.FC<{
   onDragEnter: DragFunction
   onDragStart: DragFunction
   onDrop: DragFunction
-  firstExpColumnCellId: string
   setExpColumnNeedsShadow: (needsShadow: boolean) => void
   root: HTMLElement | null
 }> = ({
@@ -100,7 +103,6 @@ export const TableHeaderCell: React.FC<{
   onDragStart,
   onDrop,
   root,
-  firstExpColumnCellId,
   setExpColumnNeedsShadow
 }) => {
   const [menuSuppressed, setMenuSuppressed] = React.useState<boolean>(false)
@@ -147,7 +149,7 @@ export const TableHeaderCell: React.FC<{
         role="columnheader"
         tabIndex={0}
       >
-        {firstExpColumnCellId === column.id ? (
+        {isExperimentColumn(column.id) ? (
           <WithExpColumnNeedsShadowUpdates
             setExpColumnNeedsShadow={setExpColumnNeedsShadow}
             root={root}

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -586,6 +586,7 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
   .placeholderHeaderCell {
     background-color: $header-bg-color;
     border-left: 1px solid $header-border-color;
+    padding: 0.31rem $cell-padding;
 
     &:first-child {
       border-left: none;
@@ -597,7 +598,6 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
     color: $header-fg-color;
     text-align: center;
     border-bottom: 1px solid $header-border-color;
-    padding: 0.31rem $cell-padding;
 
     &.leafHeader {
       border-bottom: none;

--- a/webview/src/experiments/util/columns.ts
+++ b/webview/src/experiments/util/columns.ts
@@ -114,3 +114,8 @@ export const leafColumnIds: (
 
   return [column.id]
 }
+
+export const EXPERIMENT_COLUMN_ID = 'id'
+
+export const isExperimentColumn = (id: string): boolean =>
+  id === EXPERIMENT_COLUMN_ID

--- a/webview/src/stories/Table.stories.tsx
+++ b/webview/src/stories/Table.stories.tsx
@@ -7,6 +7,7 @@ import columnsFixture from 'dvc/src/test/fixtures/expShow/columns'
 import workspaceChangesFixture from 'dvc/src/test/fixtures/expShow/workspaceChanges'
 import deeplyNestedTableData from 'dvc/src/test/fixtures/expShow/deeplyNested'
 import { dataTypesTableData } from 'dvc/src/test/fixtures/expShow/dataTypes'
+import { timestampColumn } from 'dvc/src/experiments/columns/constants'
 import {
   within,
   userEvent,
@@ -197,6 +198,11 @@ WithNoExperiments.args = {
 export const WithNoColumns = Template.bind({})
 WithNoColumns.args = {
   tableData: { ...tableData, columns: [] }
+}
+
+export const WithOnlyTimestamp = Template.bind({})
+WithOnlyTimestamp.args = {
+  tableData: { ...tableData, columns: [timestampColumn] }
 }
 
 export const WithNoSortsOrFilters = Template.bind({})

--- a/webview/src/test/sort.ts
+++ b/webview/src/test/sort.ts
@@ -54,8 +54,12 @@ export const tableData: TableData = {
 }
 
 export const getHeaders = async () => {
-  const renderedHeaders = await screen.findAllByTestId('rendered-header')
-  return renderedHeaders.map(header => header.textContent)
+  const renderedHeadersAndPlaceholders = await screen.findAllByTestId(
+    'rendered-header'
+  )
+  return renderedHeadersAndPlaceholders
+    .map(header => header.textContent?.trim())
+    .filter(Boolean)
 }
 
 export const expectHeaders = async (expectedHeaderNames: string[]) => {


### PR DESCRIPTION
This PR follows on from https://github.com/iterative/vscode-dvc/pull/2363 by making sure that the table indicators never overlap with the experiments column text.

The approach taken is to add a placeholder to the experiments column. This means that the table header will never be < 2 rows high.

### Demo

https://user-images.githubusercontent.com/37993418/189558361-344576b1-8203-4a7f-93e3-3020e0b88b13.mov

