### PR TITLE
Move experiment table context menus to right-start

### DIFF
--- a/webview/src/shared/components/contextMenu/ContextMenu.tsx
+++ b/webview/src/shared/components/contextMenu/ContextMenu.tsx
@@ -56,7 +56,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
   <Tooltip
     trigger={trigger}
     delay={[100, 200]}
-    placement={'bottom'}
+    placement={'right-start'}
     interactive
     isContextMenu={true}
     onTrigger={positionContextMenuAndDisableEvents}


### PR DESCRIPTION
Addresses the following point from https://github.com/iterative/vscode-dvc/issues/2241

>  - [ ] All context menus need to appear on the right side of the target point.
The context menu is usually placed on the right/bottom side of the mouse click unless it is close to the right age of the screen, then it will appear on the left side. However, in VSCode it seems like always on the right side, but we can do it correctly I think.

### Demo

https://user-images.githubusercontent.com/37993418/189559146-9b12a998-6009-459b-8b5d-1436256104e7.mov

