### PR TITLE
[WIP]: flexible plots support

### DIFF
--- a/extension/src/plots/model/collect.ts
+++ b/extension/src/plots/model/collect.ts
@@ -354,7 +354,7 @@ const collectDatapoints = (
   values: Record<string, unknown>[] = []
 ) => {
   for (const value of values) {
-    ;(acc[rev][path] as unknown[]).push({ ...value, rev })
+    ;(acc[rev][path] as unknown[]).push({ ...value })
   }
 }
 

--- a/extension/src/plots/model/index.ts
+++ b/extension/src/plots/model/index.ts
@@ -416,7 +416,7 @@ export class PlotsModel extends ModelWithPersistence {
       selectedRevisions,
       this.templates,
       this.revisionData,
-      undefined
+      this.getRevisionColors()
     )
   }
 }

--- a/extension/src/plots/model/index.ts
+++ b/extension/src/plots/model/index.ts
@@ -416,7 +416,7 @@ export class PlotsModel extends ModelWithPersistence {
       selectedRevisions,
       this.templates,
       this.revisionData,
-      this.getRevisionColors()
+      undefined
     )
   }
 }

--- a/extension/src/plots/webview/contract.ts
+++ b/extension/src/plots/webview/contract.ts
@@ -77,9 +77,20 @@ export enum PlotsType {
 export const isVegaPlot = (plot: Plot): plot is TemplatePlot =>
   plot.type === PlotsType.VEGA
 
+export type DatapointVersionInfo = {
+  revision: string
+  filename: string
+  field: string
+}
+
+export type Datapoint = {
+  dvc_data_version_info: DatapointVersionInfo
+  [key: string]: string | DatapointVersionInfo
+}
+
 export type TemplatePlot = {
   content: VisualizationSpec
-  datapoints?: { [revision: string]: Record<string, unknown>[] }
+  datapoints?: { [revision: string]: Datapoint[] }
   revisions?: string[]
   type: PlotsType
   multiView?: boolean


### PR DESCRIPTION
Creating as draft, 

Current implementation details:
- currently we do will `rev` for complex plots on DVC side, and don't fill `rev` for simple plots - this was done as POC, and I think it cannot stay this way in final implementation. We cannot fill all `rev` on DVC side as vscode might fill `rev` with different value than DVC does (for example vscode fills with `main` string instead of exact commit SHA, which dvc does).

I am currently working on how to resolve this problem.
Related #1757 