### PR TITLE
Use webpack's development mode to build webview for testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "cover:merge": "nyc merge ./coverage/combined coverage/coverage-final.json",
     "cover:mkdir": "mkdir -p ./coverage/combined",
     "cover:report:integration": "nyc report --reporter=lcov --temp-dir=./extension/coverage/integration",
-    "cover": "yarn turbo run cover-vscode-run --filter=dvc && yarn run-s cover:report:integration cover:mkdir && yarn run-p cover:merge:* && yarn run-s cover:merge cover:report cover:clean",
+    "cover": "yarn turbo run cover-vscode-run && yarn run-s cover:report:integration cover:mkdir && yarn run-p cover:merge:* && yarn run-s cover:merge cover:report cover:clean",
     "cover:report": "nyc report --reporter=lcov --reporter=text --reporter=text-summary --temp-dir=./coverage --lines=95 --check-coverage",
     "build": "yarn turbo run package",
     "install-frozen-lockfile": "./scripts/install-frozen-lockfile.sh",

--- a/turbo.json
+++ b/turbo.json
@@ -22,22 +22,18 @@
       "outputs": ["coverage/jest/**"]
     },
     "cover-vscode-run": {
-      "dependsOn": [
-        "dvc#test-build",
-        "dvc#test",
-        "dvc-vscode-webview#build",
-        "dvc-vscode-webview#test"
-      ],
+      "dependsOn": ["test", "test-build"],
       "outputs": ["coverage/integration/**"]
     },
     "test-build": {
+      "dependsOn": ["^test-build"],
       "outputs": ["dist/**"]
     },
     "test-vscode": {
-      "dependsOn": ["dvc-vscode-webview#build", "dvc#test-build"]
+      "dependsOn": ["test-build"]
     },
     "test-e2e": {
-      "dependsOn": ["dvc-vscode-webview#build", "dvc#test-build"]
+      "dependsOn": ["test-build"]
     },
     "format": {
       "dependsOn": ["^format"],

--- a/webview/.storybook/main.ts
+++ b/webview/.storybook/main.ts
@@ -30,7 +30,8 @@ export default {
   webpackFinal: (config: webpack.Configuration) => {
     return {
       ...config,
-      module: webpackConfig.module
+      module: webpackConfig.module,
+      mode: 'development'
     }
   }
 }

--- a/webview/package.json
+++ b/webview/package.json
@@ -11,6 +11,7 @@
     "dev": "webpack watch --mode development",
     "build": "webpack --mode production",
     "test": "jest --collect-coverage",
+    "test-build": "webpack --mode development",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "chromatic": "npx chromatic --project-token fexq6zfy6",


### PR DESCRIPTION
Shave some time from testing by dropping Webpack production bundling optimizations from the webview build.