### PR TITLE
Remove extra background color from the table view

### DIFF
--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -287,7 +287,6 @@ $workspace-row-edge-margin: $edge-padding - $cell-padding;
   .tableContainer {
     overflow: auto;
     flex: 1;
-    background-color: $experiments-view-bg-color;
   }
   .table {
     display: inline-block;

--- a/webview/src/shared/variables.scss
+++ b/webview/src/shared/variables.scss
@@ -10,7 +10,6 @@ $deps-color: var(--vscode-dvc-deps);
 $changed-color: var(--vscode-dvc-workspaceChanged);
 $error-color: var(--vscode-errorForeground);
 
-$experiments-view-bg-color: var(--vscode-menu-background);
 $row-bg-color: $bg-color;
 $header-fg-color: $fg-color;
 $row-bg-alt-color: var(--vscode-sideBar-background);


### PR DESCRIPTION
**Motivation:**

- make it more VS Code style (editors don't have an extra delimiter). It feels like there are two open tabs, and even in that case it's not right since background is from menu, not from editors, panels
- make less visually noisy

**Before:**

https://user-images.githubusercontent.com/3659196/190882762-7cf94bd2-2b8c-44de-88c5-b0ea7a84cc2d.mov

**After:**

https://user-images.githubusercontent.com/3659196/190882770-947cb980-11ec-49ed-b292-245e0fd03fb6.mov



