### PR TITLE
Send initial YAML and JSON files right after language client starts (2/3)

### DIFF
--- a/extension/src/lspClient/languageClient.ts
+++ b/extension/src/lspClient/languageClient.ts
@@ -42,7 +42,7 @@ export class LanguageClientWrapper extends Disposable {
   async start() {
     await this.client.start()
 
-    const files = await findFiles('**/*.{yaml,json}', '.??*')
+    const files = await findFiles('**/*.{yaml,json,py,toml}', '.??*')
 
     const textDocuments = files.map(filePath => {
       const uri = Uri.file(filePath).toString()

--- a/languageServer/src/test/definitions.test.ts
+++ b/languageServer/src/test/definitions.test.ts
@@ -11,6 +11,7 @@ import {
   disposeTestConnections,
   setupTestConnections
 } from './utils/setup-test-connections'
+import { sendTheseFilesToServer } from './utils/sendTheseFilesToServer'
 
 describe('textDocument/definitions', () => {
   beforeEach(() => {
@@ -75,7 +76,7 @@ describe('textDocument/definitions', () => {
   })
 
   it('should provide a single location that points to the top of the file path symbol', async () => {
-    const [dvcYaml] = await openTheseFilesAndNotifyServer([
+    const [dvcYaml] = await sendTheseFilesToServer([
       {
         languageId: 'yaml',
         mockContents: vars_dvc_yaml,

--- a/languageServer/src/test/utils/sendTheseFilesToServer.ts
+++ b/languageServer/src/test/utils/sendTheseFilesToServer.ts
@@ -1,0 +1,27 @@
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import { URI } from 'vscode-uri'
+import { client } from './setup-test-connections'
+
+export const sendTheseFilesToServer = async (
+  files: Array<{ mockPath: string; mockContents: string; languageId: string }>
+) => {
+  const filesToReturn: TextDocument[] = []
+
+  for (const { mockPath, mockContents, languageId } of files) {
+    const uri = URI.file(mockPath).toString()
+    const textDocument = TextDocument.create(uri, languageId, 1, mockContents)
+    filesToReturn.push(textDocument)
+  }
+  await client.sendRequest('initialTextDocuments', {
+    textDocuments: filesToReturn.map(textDocument => {
+      return {
+        languageId: 'yaml',
+        text: textDocument.getText(),
+        uri: textDocument.uri,
+        version: textDocument.version
+      }
+    })
+  })
+
+  return filesToReturn
+}


### PR DESCRIPTION
The standard documents manager provided by the VSCode SDK is only aware of text documents that the user has already opened in the editor area.

This is annoying because we would expect a feature like Go to Definitions to be immediately aware of the params.yaml file for example.

To solve this problem this PR will create a custom request from the Client to the Server with an initial batch of interesting documents. For now they are any yaml or json files that are not inside a hidden folder.