### PR TITLE
Move remaining data update watchers to RelativePatterns

### DIFF
--- a/extension/src/data/index.ts
+++ b/extension/src/data/index.ts
@@ -1,7 +1,10 @@
 import { join } from 'path'
 import { EventEmitter, Event } from 'vscode'
 import { Disposable } from '@hediet/std/disposable'
-import { createFileSystemWatcher } from '../fileSystem/watcher'
+import {
+  createFileSystemWatcher,
+  getRelativePattern
+} from '../fileSystem/watcher'
 import { ProcessManager } from '../processManager'
 import { InternalCommands } from '../commands/internal'
 import { ExperimentsOutput, PlotsOutput } from '../cli/dvc/reader'
@@ -94,7 +97,7 @@ export abstract class BaseData<
 
     return this.dispose.track(
       createFileSystemWatcher(
-        join(this.dvcRoot, '**', `{${files.join(',')}}`),
+        getRelativePattern(this.dvcRoot, join('**', `{${files.join(',')}}`)),
         path => {
           if (!path) {
             return

--- a/extension/src/fileSystem/data/index.ts
+++ b/extension/src/fileSystem/data/index.ts
@@ -2,7 +2,7 @@ import { join } from 'path'
 import { Event, EventEmitter } from 'vscode'
 import { isSameOrChild, loadYaml, PartialDvcYaml } from '..'
 import { findFiles } from '../workspace'
-import { createFileSystemWatcher } from '../watcher'
+import { createFileSystemWatcher, getRelativePattern } from '../watcher'
 import { DeferredDisposable } from '../../class/deferred'
 
 export class FileSystemData extends DeferredDisposable {
@@ -40,15 +40,18 @@ export class FileSystemData extends DeferredDisposable {
 
   private watchDvcYaml() {
     this.dispose.track(
-      createFileSystemWatcher(join(this.dvcRoot, '**', 'dvc.yaml'), path => {
-        if (!path) {
-          return
+      createFileSystemWatcher(
+        getRelativePattern(this.dvcRoot, join('**', 'dvc.yaml')),
+        path => {
+          if (!path) {
+            return
+          }
+          const yaml = loadYaml<PartialDvcYaml>(path)
+          if (yaml) {
+            this.updated.fire({ path, yaml })
+          }
         }
-        const yaml = loadYaml<PartialDvcYaml>(path)
-        if (yaml) {
-          this.updated.fire({ path, yaml })
-        }
-      })
+      )
     )
   }
 }

--- a/extension/src/test/suite/experiments/data/index.test.ts
+++ b/extension/src/test/suite/experiments/data/index.test.ts
@@ -1,6 +1,6 @@
 import { join, resolve, sep } from 'path'
 import { afterEach, beforeEach, describe, it, suite } from 'mocha'
-import { EventEmitter, FileSystemWatcher } from 'vscode'
+import { EventEmitter, FileSystemWatcher, RelativePattern, Uri } from 'vscode'
 import { expect } from 'chai'
 import { stub, restore, spy } from 'sinon'
 import { Disposable } from '../../../../extension'
@@ -63,11 +63,13 @@ suite('Experiments Data Test Suite', () => {
       expect(mockExperimentShow).to.be.calledOnce
       expect(mockCreateFileSystemWatcher).to.be.calledOnce
 
-      expect(getFirstArgOfCall(mockCreateFileSystemWatcher, 0)).to.equal(
-        join(
-          dvcDemoPath,
-          '**',
-          `{dvc.lock,dvc.yaml,params.yaml,*.dvc,nested${sep}params.yaml,summary.json}`
+      expect(getFirstArgOfCall(mockCreateFileSystemWatcher, 0)).to.deep.equal(
+        new RelativePattern(
+          Uri.file(dvcDemoPath),
+          join(
+            '**',
+            `{dvc.lock,dvc.yaml,params.yaml,*.dvc,nested${sep}params.yaml,summary.json}`
+          )
         )
       )
     })
@@ -135,18 +137,22 @@ suite('Experiments Data Test Suite', () => {
 
       expect(mockCreateFileSystemWatcher).to.be.calledTwice
       expect(mockDispose).to.be.calledOnce
-      expect(getFirstArgOfCall(mockCreateFileSystemWatcher, 0)).to.equal(
-        join(
-          dvcDemoPath,
-          '**',
-          `{dvc.lock,dvc.yaml,params.yaml,*.dvc,nested${sep}params.yaml,summary.json}`
+      expect(getFirstArgOfCall(mockCreateFileSystemWatcher, 0)).to.deep.equal(
+        new RelativePattern(
+          Uri.file(dvcDemoPath),
+          join(
+            '**',
+            `{dvc.lock,dvc.yaml,params.yaml,*.dvc,nested${sep}params.yaml,summary.json}`
+          )
         )
       )
-      expect(getFirstArgOfCall(mockCreateFileSystemWatcher, 1)).to.equal(
-        join(
-          dvcDemoPath,
-          '**',
-          `{dvc.lock,dvc.yaml,params.yaml,*.dvc,nested${sep}params.yaml,new_params.yml,new_summary.json,summary.json}`
+      expect(getFirstArgOfCall(mockCreateFileSystemWatcher, 1)).to.deep.equal(
+        new RelativePattern(
+          Uri.file(dvcDemoPath),
+          join(
+            '**',
+            `{dvc.lock,dvc.yaml,params.yaml,*.dvc,nested${sep}params.yaml,new_params.yml,new_summary.json,summary.json}`
+          )
         )
       )
     })

--- a/extension/src/test/suite/fileSystem/data/index.test.ts
+++ b/extension/src/test/suite/fileSystem/data/index.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, it, suite } from 'mocha'
 import { stub, restore } from 'sinon'
 import { expect } from 'chai'
+import { RelativePattern, Uri } from 'vscode'
 import { Disposable } from '../../../../extension'
 import { FileSystemData } from '../../../../fileSystem/data'
 import { dvcDemoPath } from '../../../util'
@@ -46,8 +47,8 @@ suite('File System Data Test Suite', () => {
       const data = disposable.track(new FileSystemData(dvcDemoPath))
 
       expect(mockCreateFileSystemWatcher).to.be.calledOnce
-      expect(getFirstArgOfCall(mockCreateFileSystemWatcher, 0)).to.equal(
-        join(dvcDemoPath, '**', 'dvc.yaml')
+      expect(getFirstArgOfCall(mockCreateFileSystemWatcher, 0)).to.deep.equal(
+        new RelativePattern(Uri.file(dvcDemoPath), join('**', 'dvc.yaml'))
       )
 
       await data.isReady()


### PR DESCRIPTION
(Unlikely but) possible cause of live updates not working for plots on Codespaces.

Follows on from https://github.com/iterative/vscode-dvc/pull/1905