### PR TITLE
Add flexible plots legends to plots tree

### DIFF
--- a/extension/resources/plots/circle.svg
+++ b/extension/resources/plots/circle.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" fill="grey" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="8" cy="8" r="4" stroke="grey"/>  
+</svg>

--- a/extension/resources/plots/diamond.svg
+++ b/extension/resources/plots/diamond.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" fill="grey" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <rect x="7" y="-4" width="8" height="8" stroke="grey" transform="rotate(45)"/>  
+</svg>

--- a/extension/resources/plots/square.svg
+++ b/extension/resources/plots/square.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" fill="grey" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <rect x="4" y="4" width="8" height="8" stroke="grey"/>  
+</svg>

--- a/extension/resources/plots/stroke-dash-1-0.svg
+++ b/extension/resources/plots/stroke-dash-1-0.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" fill="none" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="8" cy="8" r="5" stroke="grey" stroke-width="1.5"/>  
+</svg>

--- a/extension/resources/plots/stroke-dash-1-1.svg
+++ b/extension/resources/plots/stroke-dash-1-1.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" fill="none" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="8" cy="8" r="5" stroke="grey" stroke-dasharray="1 1" stroke-width="1.5"/>  
+</svg>

--- a/extension/resources/plots/stroke-dash-2-1.svg
+++ b/extension/resources/plots/stroke-dash-2-1.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" fill="none" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="8" cy="8" r="5" stroke="grey" stroke-dasharray="2 1" stroke-width="1.5"/>  
+</svg>

--- a/extension/resources/plots/stroke-dash-4-2.svg
+++ b/extension/resources/plots/stroke-dash-4-2.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" fill="none" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="8" cy="8" r="5" stroke="grey" stroke-dasharray="4 2" stroke-width="1.5"/>  
+</svg>

--- a/extension/resources/plots/stroke-dash-4-4.svg
+++ b/extension/resources/plots/stroke-dash-4-4.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" fill="none" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="8" cy="8" r="5" stroke="grey" stroke-dasharray="4 4" stroke-width="1.5"/>  
+</svg>

--- a/extension/resources/plots/stroke-dash-8-4.svg
+++ b/extension/resources/plots/stroke-dash-8-4.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" fill="none" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="8" cy="8" r="5" stroke="grey" stroke-dasharray="8 4" stroke-width="1.5"/>  
+</svg>

--- a/extension/resources/plots/stroke-dash-8-8.svg
+++ b/extension/resources/plots/stroke-dash-8-8.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" fill="none" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="8" cy="8" r="5" stroke="grey" stroke-dasharray="8 8" stroke-width="1.5"/>  
+</svg>

--- a/extension/resources/plots/triangle.svg
+++ b/extension/resources/plots/triangle.svg
@@ -1,3 +1,3 @@
 <svg width="16" height="16" fill="grey" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-  <polygon points="8 5.4, 13 13, 3 13" stroke="grey"/>  
+  <polygon points="8 4.2, 13 11.8, 3 11.8" stroke="grey"/>  
 </svg>

--- a/extension/resources/plots/triangle.svg
+++ b/extension/resources/plots/triangle.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" fill="grey" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <polygon points="8 5.4, 13 13, 3 13" stroke="grey"/>  
+</svg>

--- a/extension/src/cli/dvc/constants.ts
+++ b/extension/src/cli/dvc/constants.ts
@@ -1,4 +1,4 @@
-export const MIN_CLI_VERSION = '2.24.0'
+export const MIN_CLI_VERSION = '2.0.0'
 export const LATEST_TESTED_CLI_VERSION = '2.27.2'
 export const MAX_CLI_VERSION = '3'
 

--- a/extension/src/cli/dvc/constants.ts
+++ b/extension/src/cli/dvc/constants.ts
@@ -1,4 +1,4 @@
-export const MIN_CLI_VERSION = '2.0.0'
+export const MIN_CLI_VERSION = '2.24.0'
 export const LATEST_TESTED_CLI_VERSION = '2.27.2'
 export const MAX_CLI_VERSION = '3'
 

--- a/extension/src/experiments/columns/model.ts
+++ b/extension/src/experiments/columns/model.ts
@@ -63,7 +63,22 @@ export class ColumnsModel extends PathSelectionModel<Column> {
     )
   }
 
-  public filterChildren(path?: string) {
+  public getChildren(path: string | undefined) {
+    return this.filterChildren(path).map(element => {
+      return {
+        ...element,
+        descendantStatuses: this.getTerminalNodeStatuses(element.path),
+        label: element.label,
+        status: this.status[element.path]
+      }
+    })
+  }
+
+  public hasNonDefaultColumns() {
+    return this.data.length > 1
+  }
+
+  private filterChildren(path?: string) {
     return this.data.filter(element =>
       path
         ? element.parentPath === path
@@ -71,10 +86,6 @@ export class ColumnsModel extends PathSelectionModel<Column> {
             element.parentPath || element.type
           )
     )
-  }
-
-  public hasNonDefaultColumns() {
-    return this.data.length > 1
   }
 
   private async transformAndSetColumns(data: ExperimentsOutput) {

--- a/extension/src/experiments/columns/tree.ts
+++ b/extension/src/experiments/columns/tree.ts
@@ -31,7 +31,10 @@ export class ExperimentsColumnsTree extends BasePathSelectionTree<WorkspaceExper
   }
 
   public getRepositoryChildren(dvcRoot: string, path: string) {
-    return this.workspace.getRepository(dvcRoot).getChildColumns(path)
+    return this.workspace
+      .getRepository(dvcRoot)
+      .getChildColumns(path)
+      .map(element => this.transformElement({ ...element, dvcRoot }))
   }
 
   public getRepositoryStatuses(dvcRoot: string) {

--- a/extension/src/path/selection/model.ts
+++ b/extension/src/path/selection/model.ts
@@ -44,17 +44,6 @@ export abstract class PathSelectionModel<
       .map(element => ({ ...element, selected: !!this.status[element.path] }))
   }
 
-  public getChildren(path: string | undefined) {
-    return this.filterChildren(path).map(element => {
-      return {
-        ...element,
-        descendantStatuses: this.getTerminalNodeStatuses(element.path),
-        label: element.label,
-        status: this.status[element.path]
-      }
-    })
-  }
-
   public toggleStatus(path: string) {
     const status = this.getNextStatus(path)
     this.status[path] = status
@@ -153,5 +142,7 @@ export abstract class PathSelectionModel<
     return this.persist(this.statusKey, this.status)
   }
 
-  abstract filterChildren(path?: string): T[]
+  abstract getChildren(
+    ...args: unknown[]
+  ): (T & { descendantStatuses: Status[]; label: string; status: Status })[]
 }

--- a/extension/src/plots/index.ts
+++ b/extension/src/plots/index.ts
@@ -4,7 +4,7 @@ import { PlotsData as TPlotsData } from './webview/contract'
 import { WebviewMessages } from './webview/messages'
 import { PlotsData } from './data'
 import { PlotsModel } from './model'
-import { collectElementsFromEncoding, collectScale } from './paths/collect'
+import { collectEncodingElements, collectScale } from './paths/collect'
 import { PathsModel } from './paths/model'
 import { BaseWebview } from '../webview'
 import { ViewKey } from '../webview/constants'
@@ -131,7 +131,7 @@ export class Plots extends BaseRepository<TPlotsData> {
     const multiSourceEncoding = this.plots?.getMultiSourceData() || {}
 
     if (path && multiSourceEncoding[path]) {
-      return collectElementsFromEncoding(path, multiSourceEncoding)
+      return collectEncodingElements(path, multiSourceEncoding)
     }
 
     return this.paths?.getChildren(path, multiSourceEncoding) || []

--- a/extension/src/plots/index.ts
+++ b/extension/src/plots/index.ts
@@ -4,7 +4,7 @@ import { PlotsData as TPlotsData } from './webview/contract'
 import { WebviewMessages } from './webview/messages'
 import { PlotsData } from './data'
 import { PlotsModel } from './model'
-import { collectScale } from './paths/collect'
+import { collectElementsFromEncoding, collectScale } from './paths/collect'
 import { PathsModel } from './paths/model'
 import { BaseWebview } from '../webview'
 import { ViewKey } from '../webview/constants'
@@ -127,8 +127,14 @@ export class Plots extends BaseRepository<TPlotsData> {
     this.data.managedUpdate()
   }
 
-  public getChildPaths(path: string) {
-    return this.paths?.getChildren(path) || []
+  public getChildPaths(path: string | undefined) {
+    const multiSourceEncoding = this.plots?.getMultiSourceData() || {}
+
+    if (path && multiSourceEncoding[path]) {
+      return collectElementsFromEncoding(path, multiSourceEncoding)
+    }
+
+    return this.paths?.getChildren(path, multiSourceEncoding) || []
   }
 
   public getPathStatuses() {

--- a/extension/src/plots/model/index.ts
+++ b/extension/src/plots/model/index.ts
@@ -306,6 +306,10 @@ export class PlotsModel extends ModelWithPersistence {
     return this.sectionCollapsed
   }
 
+  public getMultiSourceData() {
+    return this.multiSourceEncoding
+  }
+
   private removeStaleData() {
     return Promise.all([
       this.removeStaleBranches(),

--- a/extension/src/plots/multiSource/constants.ts
+++ b/extension/src/plots/multiSource/constants.ts
@@ -9,13 +9,7 @@ export const StrokeDash = [
 ] as const
 export type StrokeDashValue = typeof StrokeDash[number]
 
-export const Shape = [
-  'square',
-  'circle',
-  'triangle',
-  'diamond',
-  'cross'
-] as const
+export const Shape = ['square', 'circle', 'triangle', 'diamond'] as const
 export type ShapeValue = typeof Shape[number]
 
 export type Scale<T extends StrokeDashValue | ShapeValue> = {

--- a/extension/src/plots/paths/collect.test.ts
+++ b/extension/src/plots/paths/collect.test.ts
@@ -1,8 +1,14 @@
 import { join } from 'path'
 import { VisualizationSpec } from 'react-vega'
-import { collectPaths, collectTemplateOrder } from './collect'
+import {
+  collectEncodingElements,
+  collectPaths,
+  collectTemplateOrder,
+  EncodingType
+} from './collect'
 import { TemplatePlotGroup, PlotsType } from '../webview/contract'
 import plotsDiffFixture from '../../test/fixtures/plotsDiff/output'
+import { Shape, StrokeDash } from '../multiSource/constants'
 
 describe('collectPath', () => {
   it('should return the expected data from the test fixture', () => {
@@ -377,6 +383,58 @@ describe('collectTemplateOrder', () => {
 
     expect(plotSections).toStrictEqual([
       { group: TemplatePlotGroup.MULTI_VIEW, paths: multiViewOrder }
+    ])
+  })
+})
+
+describe('collectEncodingElements', () => {
+  it('should return an empty array if there is no multi source encoding for a path', () => {
+    const elements = collectEncodingElements(__filename, {})
+    expect(elements).toStrictEqual([])
+  })
+
+  it('should collect encoding elements from multi source encoding', () => {
+    const elements = collectEncodingElements(__filename, {
+      [__filename]: {
+        shape: {
+          field: 'filename',
+          scale: { domain: ['X', 'Y'], range: [Shape[0], Shape[1]] }
+        },
+        strokeDash: {
+          field: 'field',
+          scale: {
+            domain: ['A', 'B', 'C'],
+            range: [StrokeDash[0], StrokeDash[1], StrokeDash[2]]
+          }
+        }
+      }
+    })
+    expect(elements).toStrictEqual([
+      {
+        label: 'A',
+        type: EncodingType.STROKE_DASH,
+        value: StrokeDash[0]
+      },
+      {
+        label: 'B',
+        type: EncodingType.STROKE_DASH,
+        value: StrokeDash[1]
+      },
+      {
+        label: 'C',
+        type: EncodingType.STROKE_DASH,
+        value: StrokeDash[2]
+      },
+      {
+        label: 'X',
+        type: EncodingType.SHAPE,
+        value: Shape[0]
+      },
+      {
+        label: 'Y',
+        type: EncodingType.SHAPE,
+        value: Shape[1]
+      }
     ])
   })
 })

--- a/extension/src/plots/paths/collect.ts
+++ b/extension/src/plots/paths/collect.ts
@@ -287,11 +287,16 @@ export const isEncodingElement = (
   element: unknown
 ): element is EncodingElement => !!(element as EncodingElement)?.value
 
-export const collectElementsFromEncoding = (
+export const collectEncodingElements = (
   path: string,
   multiSourceEncoding: MultiSourceEncoding
 ): EncodingElement[] => {
   const encoding = multiSourceEncoding[path]
+
+  if (!encoding) {
+    return []
+  }
+
   const { strokeDash } = encoding
   const elements: EncodingElement[] = []
   const { domain, range } = strokeDash.scale

--- a/extension/src/plots/paths/collect.ts
+++ b/extension/src/plots/paths/collect.ts
@@ -4,6 +4,8 @@ import { getParent, getPath, getPathArray } from '../../fileSystem/util'
 import { splitMatchedOrdered, definedAndNonEmpty } from '../../util/array'
 import { isMultiViewPlot } from '../vega/util'
 import { createTypedAccumulator } from '../../util/object'
+import { StrokeDashValue } from '../multiSource/constants'
+import { MultiSourceEncoding } from '../multiSource/collect'
 
 export enum PathType {
   COMPARISON = 'comparison',
@@ -262,4 +264,37 @@ export const collectScale = (paths: PlotPath[] = []) => {
     addToScale(acc, type)
   }
   return acc
+}
+
+export type EncodingElement = {
+  type: string
+  value: StrokeDashValue
+  label: string
+}
+
+export const isEncodingElement = (
+  element: unknown
+): element is EncodingElement => !!(element as EncodingElement)?.value
+
+export const collectElementsFromEncoding = (
+  path: string,
+  multiSourceEncoding: MultiSourceEncoding
+): EncodingElement[] => {
+  const encoding = multiSourceEncoding[path]
+  const { strokeDash } = encoding
+  const elements: {
+    type: string
+    value: StrokeDashValue
+    label: string
+  }[] = []
+  const { domain, range } = strokeDash.scale
+  for (const [i, element] of domain.entries()) {
+    const child = {
+      label: element,
+      type: 'strokeDash',
+      value: range[i]
+    }
+    elements.push(child)
+  }
+  return elements
 }

--- a/extension/src/plots/paths/tree.test.ts
+++ b/extension/src/plots/paths/tree.test.ts
@@ -1,0 +1,83 @@
+import { Uri } from 'vscode'
+import { Disposable, Disposer } from '@hediet/std/disposable'
+import { EncodingType } from './collect'
+import { PlotsPathsTree } from './tree'
+import { WorkspacePlots } from '../workspace'
+import { ResourceLocator } from '../../resourceLocator'
+import { InternalCommands } from '../../commands/internal'
+import { Plots } from '..'
+import { buildMockedEventEmitter } from '../../test/util/jest'
+import { Shape, StrokeDash } from '../multiSource/constants'
+import { join } from '../../test/util/path'
+
+const mockedDisposable = jest.mocked(Disposable)
+const mockedGetChildPaths = jest.fn()
+
+jest.mock('vscode')
+jest.mock('@hediet/std/disposable')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  mockedDisposable.fn.mockReturnValue({
+    track: function <T>(disposable: T): T {
+      return disposable
+    }
+  } as unknown as (() => void) & Disposer)
+})
+
+describe('PlotsPathsTree', () => {
+  it('should return the correct children for multi source plots (encoding elements)', () => {
+    const mockedWorkspacePlots = {
+      getRepository: () =>
+        ({ getChildPaths: mockedGetChildPaths } as unknown as Plots),
+      pathsChanged: buildMockedEventEmitter()
+    } as unknown as WorkspacePlots
+    const mockedInternalCommands = {
+      registerExternalCommand: jest.fn()
+    } as unknown as InternalCommands
+    const resourceLocator = new ResourceLocator(Uri.file(__filename))
+
+    const plotsPathTree = new PlotsPathsTree(
+      mockedWorkspacePlots,
+      mockedInternalCommands,
+      resourceLocator
+    )
+
+    mockedGetChildPaths.mockReturnValueOnce([
+      {
+        label: 'A',
+        type: EncodingType.STROKE_DASH,
+        value: StrokeDash[0]
+      },
+      {
+        label: 'Y',
+        type: EncodingType.SHAPE,
+        value: Shape[1]
+      }
+    ])
+
+    const children = plotsPathTree.getRepositoryChildren(__dirname, undefined)
+    expect(children).toStrictEqual([
+      {
+        collapsibleState: 0,
+        description: undefined,
+        dvcRoot: __dirname,
+        iconPath: Uri.file(
+          join(__filename, 'resources', 'plots', 'stroke-dash-1-0.svg')
+        ),
+        label: 'A',
+        path: 'A'
+      },
+      {
+        collapsibleState: 0,
+        description: undefined,
+        dvcRoot: __dirname,
+        iconPath: Uri.file(
+          join(__filename, 'resources', 'plots', 'circle.svg')
+        ),
+        label: 'Y',
+        path: 'Y'
+      }
+    ])
+  })
+})

--- a/extension/src/plots/paths/tree.ts
+++ b/extension/src/plots/paths/tree.ts
@@ -1,5 +1,5 @@
 import { TreeItemCollapsibleState } from 'vscode'
-import { isEncodingElement } from './collect'
+import { EncodingType, isEncodingElement } from './collect'
 import {
   BasePathSelectionTree,
   PathSelectionItem
@@ -38,12 +38,15 @@ export class PlotsPathsTree extends BasePathSelectionTree<WorkspacePlots> {
       .getChildPaths(path)
       .map(element => {
         if (isEncodingElement(element)) {
-          const { label, value } = element
+          const { label, type, value } = element
           return {
             collapsibleState: TreeItemCollapsibleState.None,
             description: undefined,
             dvcRoot,
-            iconPath: this.resourceLocator.getPlotsStrokeDashResource(value),
+            iconPath:
+              type === EncodingType.STROKE_DASH
+                ? this.resourceLocator.getPlotsStrokeDashResource(value)
+                : this.resourceLocator.getPlotsShapeResource(value),
             label,
             path: label
           }

--- a/extension/src/plots/paths/tree.ts
+++ b/extension/src/plots/paths/tree.ts
@@ -1,3 +1,5 @@
+import { TreeItemCollapsibleState } from 'vscode'
+import { isEncodingElement } from './collect'
 import {
   BasePathSelectionTree,
   PathSelectionItem
@@ -30,8 +32,25 @@ export class PlotsPathsTree extends BasePathSelectionTree<WorkspacePlots> {
     )
   }
 
-  public getRepositoryChildren(dvcRoot: string, path: string) {
-    return this.workspace.getRepository(dvcRoot).getChildPaths(path)
+  public getRepositoryChildren(dvcRoot: string, path: string | undefined) {
+    return this.workspace
+      .getRepository(dvcRoot)
+      .getChildPaths(path)
+      .map(element => {
+        if (isEncodingElement(element)) {
+          const { label, value } = element
+          return {
+            collapsibleState: TreeItemCollapsibleState.None,
+            description: undefined,
+            dvcRoot,
+            iconPath: this.resourceLocator.getPlotsStrokeDashResource(value),
+            label,
+            path: label
+          }
+        }
+
+        return this.transformElement({ ...element, dvcRoot })
+      })
   }
 
   public getRepositoryStatuses(dvcRoot: string) {

--- a/extension/src/plots/vega/util.test.ts
+++ b/extension/src/plots/vega/util.test.ts
@@ -282,14 +282,17 @@ describe('reverseOfLegendSuppressionUpdate', () => {
       shape: {
         field: 'shape-field',
         legend: {
-          disable: true
+          disable: true,
+          symbolFillColor: 'blue'
         },
         scale: { domain: [], range: [] }
       },
       strokeDash: {
         field: 'strokeDash-field',
         legend: {
-          disable: true
+          disable: true,
+          symbolFillColor: 'blue',
+          symbolStrokeColor: 'red'
         },
         scale: { domain: [], range: [] }
       }

--- a/extension/src/plots/vega/util.ts
+++ b/extension/src/plots/vega/util.ts
@@ -103,11 +103,14 @@ export type Encoding = {
   strokeDash?: StrokeDashEncoding & {
     legend: {
       disable: boolean
+      symbolFillColor: string
+      symbolStrokeColor: string
     }
   }
   shape?: ShapeEncoding & {
     legend: {
       disable: boolean
+      symbolFillColor: string
     }
   }
   detail?: {
@@ -145,13 +148,21 @@ export const getSpecEncodingUpdate = ({
   if (strokeDash) {
     encoding.strokeDash = {
       ...strokeDash,
-      legend: { disable: true }
+      legend: {
+        disable: true,
+        symbolFillColor: 'transparent',
+        symbolStrokeColor: 'grey'
+      }
     }
   }
+
   if (shape) {
     encoding.shape = {
       ...shape,
-      legend: { disable: true }
+      legend: {
+        disable: true,
+        symbolFillColor: 'grey'
+      }
     }
     encoding.detail = shape
   }
@@ -299,15 +310,7 @@ export const reverseOfLegendSuppressionUpdate = () => ({
       },
       strokeDash: {
         legend: {
-          disable: false,
-          encode: {
-            symbols: {
-              update: {
-                fill: { value: 'transparent' },
-                stroke: { value: 'grey' }
-              }
-            }
-          }
+          disable: false
         }
       }
     }

--- a/extension/src/plots/vega/util.ts
+++ b/extension/src/plots/vega/util.ts
@@ -153,7 +153,7 @@ export const getSpecEncodingUpdate = ({
       ...shape,
       legend: { disable: true }
     }
-    encoding.detail = { field: shape.field }
+    encoding.detail = shape
   }
 
   return {
@@ -292,8 +292,24 @@ export const reverseOfLegendSuppressionUpdate = () => ({
   spec: {
     encoding: {
       color: { legend: { disable: false } },
-      shape: { legend: { disable: false } },
-      strokeDash: { legend: { disable: false } }
+      shape: {
+        legend: {
+          disable: false
+        }
+      },
+      strokeDash: {
+        legend: {
+          disable: false,
+          encode: {
+            symbols: {
+              update: {
+                fill: { value: 'transparent' },
+                stroke: { value: 'grey' }
+              }
+            }
+          }
+        }
+      }
     }
   }
 })

--- a/extension/src/resourceLocator.ts
+++ b/extension/src/resourceLocator.ts
@@ -1,12 +1,14 @@
 import { Uri } from 'vscode'
 import { Disposable } from './class/dispose'
+import { StrokeDashValue } from './plots/multiSource/constants'
 
 export type Resource = { dark: Uri; light: Uri }
 
 export enum IconName {
   CIRCLE_FILLED = 'circle-filled',
   CIRCLE_OUTLINE = 'circle-outline',
-  LOADING_SPIN = 'loading-spin'
+  LOADING_SPIN = 'loading-spin',
+  STROKE_DASH = 'stroke-dash'
 }
 
 export class ResourceLocator extends Disposable {
@@ -42,6 +44,15 @@ export class ResourceLocator extends Disposable {
       'resources',
       'experiments',
       `${name}-${color}.svg`
+    )
+  }
+
+  public getPlotsStrokeDashResource(strokeDash: StrokeDashValue): Uri {
+    return Uri.joinPath(
+      this.extensionUri,
+      'resources',
+      'plots',
+      `stroke-dash-${strokeDash.join('-')}.svg`
     )
   }
 

--- a/extension/src/resourceLocator.ts
+++ b/extension/src/resourceLocator.ts
@@ -1,6 +1,6 @@
 import { Uri } from 'vscode'
 import { Disposable } from './class/dispose'
-import { StrokeDashValue } from './plots/multiSource/constants'
+import { ShapeValue, StrokeDashValue } from './plots/multiSource/constants'
 
 export type Resource = { dark: Uri; light: Uri }
 
@@ -54,6 +54,10 @@ export class ResourceLocator extends Disposable {
       'plots',
       `stroke-dash-${strokeDash.join('-')}.svg`
     )
+  }
+
+  public getPlotsShapeResource(shape: ShapeValue): Uri {
+    return Uri.joinPath(this.extensionUri, 'resources', 'plots', `${shape}.svg`)
   }
 
   private getResourceLocations(...path: string[]): { dark: Uri; light: Uri } {


### PR DESCRIPTION
# 2/2 `main` <- #2403 <- this

Related to #1757

This PR adds shape and stroke dash information into the plots tree.

### Screenshots

<img width="1728" alt="Screen Shot 2022-09-23 at 4 07 41 pm" src="https://user-images.githubusercontent.com/37993418/191902087-4466f7b0-e26b-43d8-b5a9-c638054f6b3a.png">

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/37993418/192403431-b88686af-dfa0-4976-9b2a-14605269f79f.png">


**Note:** The hacky way that we add shape + detail to the plot template causes the on-hover behaviour to break. I will change the approach in the next PR.

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/37993418/192403536-4ef67e79-382f-4fb2-848c-f6ac69792c02.png">
