### PR TITLE
Check for global install of CLI after python install not found

### DIFF
--- a/extension/src/cli/dvc/executor.test.ts
+++ b/extension/src/cli/dvc/executor.test.ts
@@ -46,7 +46,7 @@ describe('CliExecutor', () => {
   const dvcExecutor = new DvcExecutor(
     {
       getCliPath: () => undefined,
-      pythonBinPath: undefined
+      getPythonBinPath: () => undefined
     } as unknown as Config,
     {
       processCompleted: {

--- a/extension/src/cli/dvc/index.test.ts
+++ b/extension/src/cli/dvc/index.test.ts
@@ -66,7 +66,7 @@ describe('executeDvcProcess', () => {
     const cli = new DvcCli(
       {
         getCliPath: () => undefined,
-        pythonBinPath: undefined
+        getPythonBinPath: () => undefined
       } as unknown as Config,
       {
         processCompleted: {
@@ -105,7 +105,7 @@ describe('executeDvcProcess', () => {
     const cli = new DvcCli(
       {
         getCliPath: () => '/some/path/to/dvc',
-        pythonBinPath
+        getPythonBinPath: () => pythonBinPath
       } as unknown as Config,
       {
         processCompleted: {

--- a/extension/src/cli/dvc/index.ts
+++ b/extension/src/cli/dvc/index.ts
@@ -23,7 +23,7 @@ export class DvcCli extends Cli {
 
   public executeDvcProcess(cwd: string, ...args: Args): Promise<string> {
     const options = getOptions(
-      this.config.pythonBinPath,
+      this.config.getPythonBinPath(),
       this.config.getCliPath(),
       cwd,
       ...args

--- a/extension/src/cli/dvc/reader.test.ts
+++ b/extension/src/cli/dvc/reader.test.ts
@@ -48,7 +48,7 @@ describe('CliReader', () => {
   const dvcReader = new DvcReader(
     {
       getCliPath: () => undefined,
-      pythonBinPath: undefined
+      getPythonBinPath: () => undefined
     } as unknown as Config,
     {
       processCompleted: {

--- a/extension/src/cli/dvc/reader.ts
+++ b/extension/src/cli/dvc/reader.ts
@@ -168,12 +168,13 @@ export class DvcReader extends DvcCli {
     } catch {}
   }
 
-  public version(
-    cwd: string,
-    pythonBinPath = this.config.getPythonBinPath(),
-    cliPath = this.config.getCliPath()
-  ): Promise<string> {
-    const options = getOptions(pythonBinPath, cliPath, cwd, Flag.VERSION)
+  public version(cwd: string, isCliGlobal?: true): Promise<string> {
+    const options = getOptions(
+      isCliGlobal ? undefined : this.config.getPythonBinPath(),
+      this.config.getCliPath(),
+      cwd,
+      Flag.VERSION
+    )
 
     return this.executeProcess(options)
   }

--- a/extension/src/cli/dvc/reader.ts
+++ b/extension/src/cli/dvc/reader.ts
@@ -2,6 +2,7 @@ import { join } from 'path'
 import isEmpty from 'lodash.isempty'
 import { DvcCli } from '.'
 import { Args, Command, ExperimentFlag, Flag, SubCommand } from './constants'
+import { getOptions } from './options'
 import { typeCheckCommands } from '..'
 import { MaybeConsoleError } from '../error'
 import { Plot } from '../../plots/webview/contract'
@@ -167,8 +168,14 @@ export class DvcReader extends DvcCli {
     } catch {}
   }
 
-  public version(cwd: string): Promise<string> {
-    return this.executeDvcProcess(cwd, Flag.VERSION)
+  public version(
+    cwd: string,
+    pythonBinPath = this.config.getPythonBinPath(),
+    cliPath = this.config.getCliPath()
+  ): Promise<string> {
+    const options = getOptions(pythonBinPath, cliPath, cwd, Flag.VERSION)
+
+    return this.executeProcess(options)
   }
 
   private readProcessJson<T extends DataStatusOutput | PlotsOutput>(

--- a/extension/src/cli/dvc/runner.ts
+++ b/extension/src/cli/dvc/runner.ts
@@ -196,7 +196,7 @@ export class DvcRunner extends Disposable implements ICli {
 
   private getOptions(cwd: string, args: Args) {
     return getOptions(
-      this.config.pythonBinPath,
+      this.config.getPythonBinPath(),
       this.getOverrideOrCliPath(),
       cwd,
       ...args

--- a/extension/src/config.ts
+++ b/extension/src/config.ts
@@ -11,7 +11,7 @@ import { getOnDidChangeExtensions } from './vscode/extensions'
 export class Config extends DeferredDisposable {
   public readonly onDidChangeExecutionDetails: Event<void>
 
-  public pythonBinPath: string | undefined
+  private pythonBinPath: string | undefined
 
   private dvcPath = this.getCliPath()
 
@@ -39,16 +39,20 @@ export class Config extends DeferredDisposable {
     return getConfigValue(ConfigKey.DVC_PATH)
   }
 
+  public getPythonBinPath() {
+    return this.pythonBinPath
+  }
+
   public isPythonExtensionUsed() {
     return !getConfigValue(ConfigKey.PYTHON_PATH) && !!this.pythonBinPath
   }
 
-  private async getPythonBinPath() {
+  private async getConfigOrExtensionPythonBinPath() {
     return getConfigValue(ConfigKey.PYTHON_PATH) || (await getPythonBinPath())
   }
 
   private async setPythonBinPath() {
-    this.pythonBinPath = await this.getPythonBinPath()
+    this.pythonBinPath = await this.getConfigOrExtensionPythonBinPath()
     return this.deferred.resolve()
   }
 
@@ -89,7 +93,7 @@ export class Config extends DeferredDisposable {
 
   private async setPythonAndNotifyIfChanged() {
     const oldPath = this.pythonBinPath
-    this.pythonBinPath = await this.getPythonBinPath()
+    this.pythonBinPath = await this.getConfigOrExtensionPythonBinPath()
     this.notifyIfChanged(oldPath, this.pythonBinPath)
   }
 

--- a/extension/src/config.ts
+++ b/extension/src/config.ts
@@ -43,6 +43,10 @@ export class Config extends DeferredDisposable {
     return this.pythonBinPath
   }
 
+  public unsetPythonBinPath() {
+    this.pythonBinPath = undefined
+  }
+
   public isPythonExtensionUsed() {
     return !getConfigValue(ConfigKey.PYTHON_PATH) && !!this.pythonBinPath
   }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -303,7 +303,7 @@ export class Extension extends Disposable implements IExtension {
     const stopWatch = new StopWatch()
     try {
       const previousCliPath = this.config.getCliPath()
-      const previousPythonPath = this.config.pythonBinPath
+      const previousPythonPath = this.config.getPythonBinPath()
 
       const completed = await setupWorkspace()
       sendTelemetryEvent(
@@ -316,7 +316,7 @@ export class Extension extends Disposable implements IExtension {
 
       const executionDetailsUnchanged =
         this.config.getCliPath() === previousPythonPath &&
-        this.config.pythonBinPath === previousCliPath
+        this.config.getPythonBinPath() === previousCliPath
 
       if (completed && !this.cliAccessible && executionDetailsUnchanged) {
         this.workspaceChanged.fire()
@@ -428,7 +428,7 @@ export class Extension extends Disposable implements IExtension {
       dvcRootCount: this.dvcRoots.length,
       msPythonInstalled: isPythonExtensionInstalled(),
       msPythonUsed: this.config.isPythonExtensionUsed(),
-      pythonPathUsed: !!this.config.pythonBinPath,
+      pythonPathUsed: !!this.config.getPythonBinPath(),
       workspaceFolderCount: getWorkspaceFolderCount()
     }
   }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -329,9 +329,9 @@ export class Extension extends Disposable implements IExtension {
     }
   }
 
-  public async isPythonExtensionUsed() {
+  public async isDvcPythonModule() {
     await this.config.isReady()
-    return this.config.isPythonExtensionUsed()
+    return !!this.config.getPythonBinPath()
   }
 
   public async canRunCli(cwd: string, tryGlobalCli?: true) {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -332,11 +332,14 @@ export class Extension extends Disposable implements IExtension {
     }
   }
 
-  public async canRunCli(cwd: string) {
+  public async canRunCli(cwd: string, tryGlobalCli?: true) {
     await this.config.isReady()
     setContextValue('dvc.cli.incompatible', undefined)
-    const version = await this.dvcReader.version(cwd)
+    const version = await this.dvcReader.version(cwd, tryGlobalCli)
     const compatible = isVersionCompatible(version)
+    if (compatible && tryGlobalCli) {
+      this.config.unsetPythonBinPath()
+    }
     this.cliCompatible = compatible
     setContextValue('dvc.cli.incompatible', !compatible)
     return this.setAvailable(compatible)

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -329,6 +329,11 @@ export class Extension extends Disposable implements IExtension {
     }
   }
 
+  public async isPythonExtensionUsed() {
+    await this.config.isReady()
+    return this.config.isPythonExtensionUsed()
+  }
+
   public async canRunCli(cwd: string, tryGlobalCli?: true) {
     await this.config.isReady()
     setContextValue('dvc.cli.incompatible', undefined)

--- a/extension/src/interfaces.ts
+++ b/extension/src/interfaces.ts
@@ -1,6 +1,7 @@
 export interface IExtension {
   canRunCli: (cwd: string, isCliGlobal?: true) => Promise<boolean>
   hasRoots: () => boolean
+  isPythonExtensionUsed: () => Promise<boolean>
 
   setupWorkspace: () => void
 

--- a/extension/src/interfaces.ts
+++ b/extension/src/interfaces.ts
@@ -1,5 +1,5 @@
 export interface IExtension {
-  canRunCli: (cwd: string) => Promise<boolean>
+  canRunCli: (cwd: string, isCliGlobal?: true) => Promise<boolean>
   hasRoots: () => boolean
 
   setupWorkspace: () => void

--- a/extension/src/interfaces.ts
+++ b/extension/src/interfaces.ts
@@ -1,7 +1,7 @@
 export interface IExtension {
   canRunCli: (cwd: string, isCliGlobal?: true) => Promise<boolean>
   hasRoots: () => boolean
-  isPythonExtensionUsed: () => Promise<boolean>
+  isDvcPythonModule: () => Promise<boolean>
 
   setupWorkspace: () => void
 

--- a/extension/src/setup.test.ts
+++ b/extension/src/setup.test.ts
@@ -59,7 +59,7 @@ const mockedHasRoots = jest.fn()
 const mockedGetFirstWorkspaceFolder = jest.mocked(getFirstWorkspaceFolder)
 const mockedCwd = __dirname
 const mockedInitialize = jest.fn()
-const mockedIsPythonExtensionUsed = jest.fn()
+const mockedIsDvcPythonModule = jest.fn()
 const mockedResetMembers = jest.fn()
 const mockedSetAvailable = jest.fn()
 const mockedSetRoots = jest.fn()
@@ -251,7 +251,7 @@ describe('setup', () => {
     canRunCli: mockedCanRunCli,
     hasRoots: mockedHasRoots,
     initialize: mockedInitialize,
-    isPythonExtensionUsed: mockedIsPythonExtensionUsed,
+    isDvcPythonModule: mockedIsDvcPythonModule,
     resetMembers: mockedResetMembers,
     setAvailable: mockedSetAvailable,
     setRoots: mockedSetRoots,
@@ -269,7 +269,7 @@ describe('setup', () => {
 
   it('should set the DVC roots even if the cli cannot be used', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
-    mockedIsPythonExtensionUsed.mockResolvedValueOnce(false)
+    mockedIsDvcPythonModule.mockResolvedValueOnce(false)
     mockedCanRunCli.mockResolvedValueOnce(false)
 
     await setup(extension)
@@ -280,7 +280,7 @@ describe('setup', () => {
   it('should not alert the user if the workspace has no DVC project and the cli cannot be found', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
     mockedHasRoots.mockReturnValueOnce(false)
-    mockedIsPythonExtensionUsed.mockResolvedValueOnce(false)
+    mockedIsDvcPythonModule.mockResolvedValueOnce(false)
     mockedCanRunCli.mockRejectedValueOnce(new Error('command not found: dvc'))
 
     await setup(extension)
@@ -296,7 +296,7 @@ describe('setup', () => {
   it('should not alert the user if the workspace contains a DVC project, the cli cannot be found and the do not show option is set', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
     mockedHasRoots.mockReturnValueOnce(true)
-    mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
+    mockedIsDvcPythonModule.mockResolvedValueOnce(true)
     mockedCanRunCli
       .mockRejectedValueOnce(new Error('command not found: dvc'))
       .mockRejectedValueOnce(new Error('command not found: dvc'))
@@ -315,7 +315,7 @@ describe('setup', () => {
   it('should alert the user if the workspace contains a DVC project and the cli cannot be found', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
     mockedHasRoots.mockReturnValueOnce(true)
-    mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
+    mockedIsDvcPythonModule.mockResolvedValueOnce(true)
     mockedCanRunCli
       .mockRejectedValueOnce(new Error('command not found: dvc'))
       .mockRejectedValueOnce(new Error('command not found: dvc'))
@@ -338,7 +338,7 @@ describe('setup', () => {
   it('should try to setup the workspace if the workspace contains a DVC project, the cli cannot be found and the user selects setup the workspace', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
     mockedHasRoots.mockReturnValueOnce(true)
-    mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
+    mockedIsDvcPythonModule.mockResolvedValueOnce(true)
     mockedCanRunCli
       .mockRejectedValueOnce(new Error('command not found: dvc'))
       .mockRejectedValueOnce(new Error('command not found: dvc'))
@@ -364,7 +364,7 @@ describe('setup', () => {
   it('should try to select the python interpreter if the workspace contains a DVC project, the cli cannot be found and the user decides to select the python interpreter', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
     mockedHasRoots.mockReturnValueOnce(true)
-    mockedIsPythonExtensionUsed.mockResolvedValueOnce(false)
+    mockedIsDvcPythonModule.mockResolvedValueOnce(false)
     mockedCanRunCli.mockRejectedValueOnce(new Error('command not found: dvc'))
     mockedWarnWithOptions.mockResolvedValueOnce(Response.SELECT_INTERPRETER)
     mockedExecuteProcess.mockImplementation(({ executable }) =>
@@ -388,7 +388,7 @@ describe('setup', () => {
   it('should set a user config option if the workspace contains a DVC project, the cli cannot be found and the user selects never', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
     mockedHasRoots.mockReturnValueOnce(true)
-    mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
+    mockedIsDvcPythonModule.mockResolvedValueOnce(true)
     mockedCanRunCli
       .mockRejectedValueOnce(new Error('command not found: dvc'))
       .mockRejectedValueOnce(new Error('command not found: dvc'))
@@ -414,7 +414,7 @@ describe('setup', () => {
   it('should not send telemetry or set the cli as unavailable or run initialization if roots have not been found but the cli can be run', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
     mockedHasRoots.mockReturnValueOnce(false)
-    mockedIsPythonExtensionUsed.mockResolvedValueOnce(false)
+    mockedIsDvcPythonModule.mockResolvedValueOnce(false)
     mockedCanRunCli.mockResolvedValueOnce(true)
 
     await setup(extension)
@@ -427,7 +427,7 @@ describe('setup', () => {
   it('should run initialization if roots have been found and the cli can be run', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
     mockedHasRoots.mockReturnValueOnce(true)
-    mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
+    mockedIsDvcPythonModule.mockResolvedValueOnce(true)
     mockedCanRunCli.mockResolvedValueOnce(true)
 
     await setup(extension)
@@ -438,7 +438,7 @@ describe('setup', () => {
   it('should call the cli to see if it is available from path if it fails on the first call', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
     mockedHasRoots.mockReturnValueOnce(true)
-    mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
+    mockedIsDvcPythonModule.mockResolvedValueOnce(true)
     mockedCanRunCli
       .mockRejectedValueOnce(new Error('command not found: dvc'))
       .mockResolvedValueOnce(true)
@@ -452,7 +452,7 @@ describe('setup', () => {
   it('should only call the cli once if the python extension is not used', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
     mockedHasRoots.mockReturnValueOnce(true)
-    mockedIsPythonExtensionUsed.mockResolvedValueOnce(false)
+    mockedIsDvcPythonModule.mockResolvedValueOnce(false)
     mockedCanRunCli.mockResolvedValueOnce(false)
 
     await setup(extension)
@@ -461,7 +461,7 @@ describe('setup', () => {
 
   it('should run reset if the cli cannot be run and there is a workspace folder open', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
-    mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
+    mockedIsDvcPythonModule.mockResolvedValueOnce(true)
     mockedHasRoots.mockReturnValueOnce(true)
     mockedCanRunCli.mockResolvedValueOnce(false)
 

--- a/extension/src/setup.test.ts
+++ b/extension/src/setup.test.ts
@@ -292,7 +292,9 @@ describe('setup', () => {
   it('should not alert the user if the workspace contains a DVC project, the cli cannot be found and the do not show option is set', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
     mockedHasRoots.mockReturnValueOnce(true)
-    mockedCanRunCli.mockRejectedValueOnce(new Error('command not found: dvc'))
+    mockedCanRunCli
+      .mockRejectedValueOnce(new Error('command not found: dvc'))
+      .mockRejectedValueOnce(new Error('command not found: dvc'))
     mockedGetConfigValue.mockReturnValueOnce(true)
 
     await setup(extension)
@@ -308,7 +310,9 @@ describe('setup', () => {
   it('should alert the user if the workspace contains a DVC project and the cli cannot be found', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
     mockedHasRoots.mockReturnValueOnce(true)
-    mockedCanRunCli.mockRejectedValueOnce(new Error('command not found: dvc'))
+    mockedCanRunCli
+      .mockRejectedValueOnce(new Error('command not found: dvc'))
+      .mockRejectedValueOnce(new Error('command not found: dvc'))
     mockedWarnWithOptions.mockResolvedValueOnce(undefined)
     mockedExecuteProcess.mockImplementation(({ executable }) =>
       Promise.resolve(executable)
@@ -328,7 +332,9 @@ describe('setup', () => {
   it('should try to setup the workspace if the workspace contains a DVC project, the cli cannot be found and the user selects setup the workspace', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
     mockedHasRoots.mockReturnValueOnce(true)
-    mockedCanRunCli.mockRejectedValueOnce(new Error('command not found: dvc'))
+    mockedCanRunCli
+      .mockRejectedValueOnce(new Error('command not found: dvc'))
+      .mockRejectedValueOnce(new Error('command not found: dvc'))
     mockedWarnWithOptions.mockResolvedValueOnce(Response.SETUP_WORKSPACE)
     mockedExecuteProcess.mockImplementation(({ executable }) =>
       Promise.resolve(executable)
@@ -351,7 +357,9 @@ describe('setup', () => {
   it('should try to select the python interpreter if the workspace contains a DVC project, the cli cannot be found and the user decides to select the python interpreter', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
     mockedHasRoots.mockReturnValueOnce(true)
-    mockedCanRunCli.mockRejectedValueOnce(new Error('command not found: dvc'))
+    mockedCanRunCli
+      .mockRejectedValueOnce(new Error('command not found: dvc'))
+      .mockRejectedValueOnce(new Error('command not found: dvc'))
     mockedWarnWithOptions.mockResolvedValueOnce(Response.SELECT_INTERPRETER)
     mockedExecuteProcess.mockImplementation(({ executable }) =>
       Promise.resolve(executable)
@@ -374,7 +382,9 @@ describe('setup', () => {
   it('should set a user config option if the workspace contains a DVC project, the cli cannot be found and the user selects never', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
     mockedHasRoots.mockReturnValueOnce(true)
-    mockedCanRunCli.mockRejectedValueOnce(new Error('command not found: dvc'))
+    mockedCanRunCli
+      .mockRejectedValueOnce(new Error('command not found: dvc'))
+      .mockRejectedValueOnce(new Error('command not found: dvc'))
     mockedWarnWithOptions.mockResolvedValueOnce(Response.NEVER)
     mockedExecuteProcess.mockImplementation(({ executable }) =>
       Promise.resolve(executable)

--- a/extension/src/setup.ts
+++ b/extension/src/setup.ts
@@ -211,7 +211,7 @@ const warnUserCLIInaccessible = async (
 
 const extensionCanRunPythonCli = async (extension: IExtension, cwd: string) => {
   let canRunCli = false
-  if (await extension.isPythonExtensionUsed()) {
+  if (await extension.isDvcPythonModule()) {
     try {
       canRunCli = await extension.canRunCli(cwd)
     } catch {}

--- a/extension/src/setup.ts
+++ b/extension/src/setup.ts
@@ -209,6 +209,18 @@ const warnUserCLIInaccessible = async (
   }
 }
 
+const extensionCanRunGlobalCli = async (extension: IExtension, cwd: string) => {
+  let canRunCli = false
+  try {
+    canRunCli = await extension.canRunCli(cwd, true)
+  } catch {
+    if (extension.hasRoots()) {
+      warnUserCLIInaccessible(extension)
+    }
+  }
+  return canRunCli
+}
+
 const extensionCanRunCli = async (
   extension: IExtension,
   cwd: string
@@ -216,10 +228,9 @@ const extensionCanRunCli = async (
   let canRunCli = false
   try {
     canRunCli = await extension.canRunCli(cwd)
-  } catch {
-    if (extension.hasRoots()) {
-      warnUserCLIInaccessible(extension)
-    }
+  } catch {}
+  if (!canRunCli) {
+    canRunCli = await extensionCanRunGlobalCli(extension, cwd)
   }
   return canRunCli
 }

--- a/extension/src/setup.ts
+++ b/extension/src/setup.ts
@@ -209,6 +209,16 @@ const warnUserCLIInaccessible = async (
   }
 }
 
+const extensionCanRunPythonCli = async (extension: IExtension, cwd: string) => {
+  let canRunCli = false
+  if (await extension.isPythonExtensionUsed()) {
+    try {
+      canRunCli = await extension.canRunCli(cwd)
+    } catch {}
+  }
+  return canRunCli
+}
+
 const extensionCanRunGlobalCli = async (extension: IExtension, cwd: string) => {
   let canRunCli = false
   try {
@@ -225,10 +235,8 @@ const extensionCanRunCli = async (
   extension: IExtension,
   cwd: string
 ): Promise<boolean> => {
-  let canRunCli = false
-  try {
-    canRunCli = await extension.canRunCli(cwd)
-  } catch {}
+  let canRunCli = await extensionCanRunPythonCli(extension, cwd)
+
   if (!canRunCli) {
     canRunCli = await extensionCanRunGlobalCli(extension, cwd)
   }

--- a/extension/src/test/cli/util.ts
+++ b/extension/src/test/cli/util.ts
@@ -9,7 +9,7 @@ import { dvcDemoPath } from '../util'
 
 const config = {
   getCliPath: () => '',
-  pythonBinPath: getVenvBinPath(TEMP_DIR, ENV_DIR, 'python')
+  getPythonBinPath: () => getVenvBinPath(TEMP_DIR, ENV_DIR, 'python')
 } as Config
 
 export const dvcReader = new DvcReader(config)

--- a/extension/src/test/suite/cli/dvc/runner.test.ts
+++ b/extension/src/test/suite/cli/dvc/runner.test.ts
@@ -24,7 +24,8 @@ suite('DVC Runner Test Suite', () => {
 
   describe('DvcRunner', () => {
     it('should only be able to run a single command at a time', async () => {
-      const dvcRunner = disposable.track(new DvcRunner({} as Config, 'sleep'))
+      const mockConfig = { getPythonBinPath: () => undefined } as Config
+      const dvcRunner = disposable.track(new DvcRunner(mockConfig, 'sleep'))
 
       const windowErrorMessageSpy = spy(window, 'showErrorMessage')
       const cwd = __dirname
@@ -36,7 +37,8 @@ suite('DVC Runner Test Suite', () => {
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should be able to stop a started command', async () => {
-      const dvcRunner = disposable.track(new DvcRunner({} as Config, 'sleep'))
+      const mockConfig = { getPythonBinPath: () => undefined } as Config
+      const dvcRunner = disposable.track(new DvcRunner(mockConfig, 'sleep'))
       const cwd = __dirname
 
       const onDidCompleteProcess = (): Promise<void> =>
@@ -107,8 +109,9 @@ suite('DVC Runner Test Suite', () => {
 
       const cwd = __dirname
 
+      const mockConfig = { getPythonBinPath: () => undefined } as Config
       const dvcRunner = disposable.track(
-        new DvcRunner({} as Config, 'echo', {
+        new DvcRunner(mockConfig, 'echo', {
           processCompleted,
           processOutput,
           processStarted
@@ -126,7 +129,8 @@ suite('DVC Runner Test Suite', () => {
     it('should send an error event if the command fails with an exit code and stderr', async () => {
       const mockSendTelemetryEvent = stub(Telemetry, 'sendErrorTelemetryEvent')
 
-      const dvcRunner = disposable.track(new DvcRunner({} as Config, 'sleep'))
+      const mockConfig = { getPythonBinPath: () => undefined } as Config
+      const dvcRunner = disposable.track(new DvcRunner(mockConfig, 'sleep'))
 
       const cwd = __dirname
 

--- a/extension/src/test/suite/config.test.ts
+++ b/extension/src/test/suite/config.test.ts
@@ -29,7 +29,7 @@ suite('Config Test Suite', () => {
 
       const config = disposable.track(new Config(extensionsChanged.event))
       expect(mockGetExtensionAPI).to.be.calledTwice
-      expect(config.pythonBinPath).to.be.undefined
+      expect(config.getPythonBinPath()).to.be.undefined
 
       const pythonBinPath = join('some', 'magic', 'python', 'path')
 
@@ -45,7 +45,7 @@ suite('Config Test Suite', () => {
       extensionsChanged.fire()
 
       await executionDetailsUpdated
-      expect(config.pythonBinPath).to.equal(pythonBinPath)
+      expect(config.getPythonBinPath()).to.equal(pythonBinPath)
     })
   })
 })

--- a/extension/src/test/suite/extension.test.ts
+++ b/extension/src/test/suite/extension.test.ts
@@ -468,7 +468,8 @@ suite('Extension Test Suite', () => {
         RegisteredCommands.EXTENSION_CHECK_CLI_COMPATIBLE
       )
 
-      expect(mockVersion).to.be.calledOnce
+      expect(mockVersion).to.be.calledTwice
+      mockVersion.resetHistory()
       expect(
         executeCommandSpy,
         'should set dvc.cli.incompatible to true if the version is incompatible'
@@ -480,6 +481,7 @@ suite('Extension Test Suite', () => {
       )
 
       expect(mockVersion).to.be.calledTwice
+      mockVersion.resetHistory()
       expect(
         executeCommandSpy,
         'should set dvc.cli.incompatible to false if the version is compatible'
@@ -494,7 +496,7 @@ suite('Extension Test Suite', () => {
         RegisteredCommands.EXTENSION_CHECK_CLI_COMPATIBLE
       )
 
-      expect(mockVersion).to.be.calledThrice
+      expect(mockVersion).to.be.calledTwice
       expect(
         executeCommandSpy,
         'should unset dvc.cli.incompatible if the CLI throws an error'

--- a/extension/src/test/suite/extension.test.ts
+++ b/extension/src/test/suite/extension.test.ts
@@ -32,6 +32,7 @@ import { MIN_CLI_VERSION } from '../../cli/dvc/constants'
 import * as WorkspaceFolders from '../../vscode/workspaceFolders'
 import { DvcExecutor } from '../../cli/dvc/executor'
 import { GitReader } from '../../cli/git/reader'
+import { Config } from '../../config'
 
 suite('Extension Test Suite', () => {
   const dvcPathOption = 'dvc.dvcPath'
@@ -454,6 +455,7 @@ suite('Extension Test Suite', () => {
       stub(DvcReader.prototype, 'plotsDiff').resolves({})
       stub(GitReader.prototype, 'hasChanges').resolves(false)
       stub(GitReader.prototype, 'listUntracked').resolves(new Set())
+      stub(Config.prototype, 'isPythonExtensionUsed').resolves(true)
 
       const mockVersion = stub(DvcReader.prototype, 'version')
         .onFirstCall()

--- a/extension/src/test/suite/extension.test.ts
+++ b/extension/src/test/suite/extension.test.ts
@@ -455,7 +455,7 @@ suite('Extension Test Suite', () => {
       stub(DvcReader.prototype, 'plotsDiff').resolves({})
       stub(GitReader.prototype, 'hasChanges').resolves(false)
       stub(GitReader.prototype, 'listUntracked').resolves(new Set())
-      stub(Config.prototype, 'isPythonExtensionUsed').resolves(true)
+      stub(Config.prototype, 'getPythonBinPath').resolves(join('python'))
 
       const mockVersion = stub(DvcReader.prototype, 'version')
         .onFirstCall()


### PR DESCRIPTION
Closes https://github.com/iterative/vscode-dvc/issues/2449.

The extension will now first check that to see if DVC can be found with the help of the Python extension and if it cannot find the cli then it will try to use a global install of DVC.

### Demo

https://user-images.githubusercontent.com/37993418/192173253-e925a826-80e9-4ceb-a1b3-5b62857c63b0.mov

