### PR TITLE
Account for exp show returning extra data in CLI output tests

### DIFF
--- a/extension/src/test/cli/expShow.test.ts
+++ b/extension/src/test/cli/expShow.test.ts
@@ -16,7 +16,10 @@ suite('exp show --show-json', () => {
       expect(output.workspace, 'should have a workspace key').not.to.be
         .undefined
 
-      expect(Object.keys(output), 'should have two entries').to.have.lengthOf(2)
+      expect(
+        Object.keys(output),
+        'should have at least two entries'
+      ).to.have.lengthOf.greaterThanOrEqual(2)
 
       // each entry under output
       for (const [key, obj] of Object.entries(output)) {
@@ -81,7 +84,7 @@ suite('exp show --show-json', () => {
       expect(
         Object.keys(output),
         'should have at least two entries'
-      ).to.have.lengthOf(2)
+      ).to.have.lengthOf.greaterThanOrEqual(2)
 
       const { workspace } = output
 


### PR DESCRIPTION
The addition of extra commits into the exp show data broken 2 of the scheduled CLI output tests. This update fixes them.