### PR TITLE
Cache yaml Documents based on TextDocument versions (3/3)

### DIFF
--- a/languageServer/src/LanguageServer.ts
+++ b/languageServer/src/LanguageServer.ts
@@ -20,6 +20,7 @@ import { TextDocumentWrapper } from './TextDocumentWrapper'
 export class LanguageServer {
   private documentsKnownToEditor!: TextDocuments<TextDocument>
   private documentsFromDvcClient: TextDocumentWrapper[] = []
+  private documentsCache: Record<string, TextDocumentWrapper> = {}
 
   public listen(connection: _Connection) {
     this.documentsKnownToEditor = new TextDocuments(TextDocument)
@@ -91,7 +92,11 @@ export class LanguageServer {
   }
 
   private wrap(doc: TextDocument) {
-    return new TextDocumentWrapper(doc)
+    if (!this.documentsCache[doc.uri]) {
+      this.documentsCache[doc.uri] = new TextDocumentWrapper(doc)
+    }
+
+    return this.documentsCache[doc.uri]
   }
 
   private getFilePathLocations(

--- a/languageServer/src/TextDocumentWrapper.ts
+++ b/languageServer/src/TextDocumentWrapper.ts
@@ -14,7 +14,8 @@ import {
   Node,
   Scalar,
   Pair,
-  isPair
+  isPair,
+  Document
 } from 'yaml'
 import { alphadecimalWords, variableTemplates } from './regexes'
 import { ITextDocumentWrapper } from './ITextDocumentWrapper'
@@ -23,10 +24,14 @@ export class TextDocumentWrapper implements ITextDocumentWrapper {
   uri: string
 
   private textDocument: TextDocument
+  private yamlDocument: Document
+  private lastParsedVersion!: number
 
   constructor(textDocument: TextDocument) {
     this.textDocument = textDocument
     this.uri = this.textDocument.uri
+    this.lastParsedVersion = this.textDocument.version
+    this.yamlDocument = parseDocument(this.textDocument.getText())
   }
 
   public offsetAt(position: Position) {
@@ -42,7 +47,11 @@ export class TextDocumentWrapper implements ITextDocumentWrapper {
   }
 
   public getYamlDocument() {
-    return parseDocument(this.getText())
+    if (this.lastParsedVersion !== this.textDocument.version) {
+      this.yamlDocument = parseDocument(this.getText())
+    }
+
+    return this.yamlDocument
   }
 
   public findLocationsFor(aSymbol: DocumentSymbol) {


### PR DESCRIPTION
The team raised some valid concerns around a potential performance hit when multiple/big yamls are constantly being parsed by the server.

This PR is attempt to address them by caching the parsed yaml trees based on the current TextDocument version number. It will only attempt to parse the contents again if the version changed.

In this context the TextDocument.version changes when the user edits the document and a request is sent to the server. The document doesn't need to be saved for it to be incremented.