### PR TITLE
Cleanup after drag and drop

### DIFF
--- a/webview/src/shared/components/dragDrop/DragDropContainer.tsx
+++ b/webview/src/shared/components/dragDrop/DragDropContainer.tsx
@@ -113,12 +113,14 @@ export const DragDropContainer: React.FC<DragDropContainerProps> = ({
   const dispatch = useDispatch()
 
   const cleanup = useCallback(() => {
-    immediateDragLeave()
-    setDraggedOverId('')
-    setDraggedId('')
-    setDirection(defaultDragEnterDirection)
-    pickedUp.current = false
-    dispatch(changeRef(undefined))
+    if (pickedUp.current) {
+      immediateDragLeave()
+      setDraggedOverId('')
+      setDraggedId('')
+      setDirection(defaultDragEnterDirection)
+      pickedUp.current = false
+      dispatch(changeRef(undefined))
+    }
   }, [
     setDraggedOverId,
     setDirection,


### PR DESCRIPTION
Closes #2423 


https://user-images.githubusercontent.com/3683420/192616319-6fbf955d-df67-47f9-bb9e-72575b0c12ae.mov

Since `onDragEnd` is being called only half the time, there is now a failsafe on mouse move. If the mouse moves with no mouse button pressed and the drag and drop state is not clean, it'll call the cleanup function to reset the state.