### PR TITLE
Stabilize e2e tests

### DIFF
--- a/extension/src/test/e2e/extension.test.ts
+++ b/extension/src/test/e2e/extension.test.ts
@@ -17,6 +17,9 @@ suite('DVC Extension For Visual Studio Code', () => {
   before('should finish loading the extension', async function () {
     this.timeout(240000)
     await waitForViewContainerToLoad()
+    const workbench = await browser.getWorkbench()
+    await workbench.executeCommand('DVC: Garbage Collect Experiments')
+    await browser.keys('Enter')
     return dismissAllNotifications()
   })
 

--- a/extension/src/test/e2e/wdio.conf.ts
+++ b/extension/src/test/e2e/wdio.conf.ts
@@ -33,7 +33,7 @@ export const config: Options.Testrunner = {
   capabilities: [
     {
       browserName: 'vscode',
-      browserVersion: 'insiders',
+      browserVersion: 'stable',
       'wdio:vscodeOptions': {
         extensionPath,
         userSettings: {


### PR DESCRIPTION
This PR stabilises our e2e test suite.

Note: We may be kicking the can down the road as insiders will become the stable version shortly. 