### PR TITLE
Turn off language server again

### DIFF
--- a/demo/dvc.yaml
+++ b/demo/dvc.yaml
@@ -2,21 +2,21 @@ stages:
   train:
     cmd: python train.py
     deps:
-    - data/MNIST
-    - train.py
+      - data/MNIST
+      - train.py
     params:
-    - params.yaml:
+      - params.yaml:
     outs:
-    - model.pt:
-        checkpoint: true
+      - model.pt:
+          checkpoint: true
     metrics:
       - training_metrics.json:
           persist: true
           cache: false
     plots:
-    - training_metrics
-    - misclassified.jpg
-    - predictions.json:
-        template: confusion
-        x: actual
-        y: predicted
+      - training_metrics
+      - misclassified.jpg
+      - predictions.json:
+          template: confusion
+          x: actual
+          y: predicted

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -51,7 +51,6 @@ import { collectWorkspaceScale } from './telemetry/collect'
 import { createFileSystemWatcher } from './fileSystem/watcher'
 import { GitExecutor } from './cli/git/executor'
 import { GitReader } from './cli/git/reader'
-import { LanguageClientWrapper } from './lspClient/languageClient'
 
 export class Extension extends Disposable implements IExtension {
   protected readonly internalCommands: InternalCommands
@@ -92,8 +91,6 @@ export class Extension extends Disposable implements IExtension {
 
     this.setCommandsAvailability(false)
     this.setProjectAvailability()
-
-    this.dispose.track(new LanguageClientWrapper())
 
     this.resourceLocator = this.dispose.track(
       new ResourceLocator(context.extensionUri)


### PR DESCRIPTION
Based on 

<img width="877" alt="image" src="https://user-images.githubusercontent.com/37993418/193142246-53a90919-5112-42b4-8329-c2ca1836d75d.png">

Possible cause of #2501

We should turn off and ship an update to see if this fixes the issue.

If the issue was only for `0.4.9` then I would guess that it is an issue with flexible plots. See as the crash was introduced in `0.4.8` this is (IMO) the most likely cause.