### PR TITLE
[WIP] Add tests for the server stability

### DIFF
--- a/languageServer/src/test/definitions.test.ts
+++ b/languageServer/src/test/definitions.test.ts
@@ -122,4 +122,28 @@ describe('textDocument/definitions', () => {
       uri: 'file:///moreParams/otherParams.json'
     })
   })
+
+  it('should send responses for a big number of files', async () => {
+    const multipleDocuments = [
+      {
+        languageId: 'yaml',
+        mockContents: file_path_dvc_yaml,
+        mockPath: 'dvc.yaml'
+      }
+    ]
+
+    for (let i = 0; i < 10000; i++) {
+      multipleDocuments.push({
+        languageId: 'yaml',
+        mockContents: file_path_dvc_yaml,
+        mockPath: 'dvc.yaml'
+      })
+    }
+
+    const [dvcYaml] = await openTheseFilesAndNotifyServer(multipleDocuments)
+
+    const response = await requestDefinitions(dvcYaml, 'params.json')
+
+    expect(response).toBeTruthy()
+  })
 })

--- a/languageServer/src/test/definitions.test.ts
+++ b/languageServer/src/test/definitions.test.ts
@@ -177,4 +177,22 @@ describe('textDocument/definitions', () => {
 
     expect(response).toBeTruthy()
   })
+
+  it('should send responses for a big number of requests to the same file', async () => {
+    const multipleDocuments = [
+      {
+        languageId: 'yaml',
+        mockContents: file_path_dvc_yaml,
+        mockPath: 'dvc.yaml'
+      }
+    ]
+
+    for (let i = 0; i < 1000; i++) {
+      const [dvcYaml] = await openTheseFilesAndNotifyServer(multipleDocuments)
+
+      const response = await requestDefinitions(dvcYaml, 'params.json')
+
+      expect(response).toBeTruthy()
+    }
+  })
 })

--- a/languageServer/src/test/definitions.test.ts
+++ b/languageServer/src/test/definitions.test.ts
@@ -132,7 +132,7 @@ describe('textDocument/definitions', () => {
       }
     ]
 
-    for (let i = 0; i < 10000; i++) {
+    for (let i = 0; i < 100; i++) {
       multipleDocuments.push({
         languageId: 'yaml',
         mockContents: file_path_dvc_yaml,
@@ -156,7 +156,7 @@ describe('textDocument/definitions', () => {
       }
     ]
 
-    for (let i = 0; i < 1000; i++) {
+    for (let i = 0; i < 100; i++) {
       multipleDocuments.push(
         {
           languageId: 'yaml',
@@ -187,7 +187,7 @@ describe('textDocument/definitions', () => {
       }
     ]
 
-    for (let i = 0; i < 1000; i++) {
+    for (let i = 0; i < 100; i++) {
       const [dvcYaml] = await openTheseFilesAndNotifyServer(multipleDocuments)
 
       const response = await requestDefinitions(dvcYaml, 'params.json')

--- a/languageServer/src/test/definitions.test.ts
+++ b/languageServer/src/test/definitions.test.ts
@@ -6,7 +6,7 @@ import {
   foreach_dvc_yaml,
   params_dvc_yaml
 } from './fixtures/examples/valid'
-import { params } from './fixtures/params'
+import { params, paramsJson } from './fixtures/params'
 import { requestDefinitions } from './utils/requestDefinitions'
 import { openTheseFilesAndNotifyServer } from './utils/openTheseFilesAndNotifyServer'
 import {
@@ -123,7 +123,7 @@ describe('textDocument/definitions', () => {
     })
   })
 
-  it('should send responses for a big number of files', async () => {
+  it('should send responses for a big number of the same file', async () => {
     const multipleDocuments = [
       {
         languageId: 'yaml',
@@ -138,6 +138,37 @@ describe('textDocument/definitions', () => {
         mockContents: file_path_dvc_yaml,
         mockPath: 'dvc.yaml'
       })
+    }
+
+    const [dvcYaml] = await openTheseFilesAndNotifyServer(multipleDocuments)
+
+    const response = await requestDefinitions(dvcYaml, 'params.json')
+
+    expect(response).toBeTruthy()
+  })
+
+  it('should send responses for a big number of different files', async () => {
+    const multipleDocuments = [
+      {
+        languageId: 'yaml',
+        mockContents: file_path_dvc_yaml,
+        mockPath: 'dvc.yaml'
+      }
+    ]
+
+    for (let i = 0; i < 1000; i++) {
+      multipleDocuments.push(
+        {
+          languageId: 'yaml',
+          mockContents: file_path_dvc_yaml.repeat(i),
+          mockPath: 'dvc.yaml'
+        },
+        {
+          languageId: 'json',
+          mockContents: paramsJson.repeat(i),
+          mockPath: 'params.json'
+        }
+      )
     }
 
     const [dvcYaml] = await openTheseFilesAndNotifyServer(multipleDocuments)

--- a/languageServer/src/test/fixtures/params/index.ts
+++ b/languageServer/src/test/fixtures/params/index.ts
@@ -5,3 +5,10 @@ epochs: 15
 auc: 0.9
 loss: 0.2
 `.trim()
+
+export const paramsJson = `
+{
+  "lr": 0.003,
+  "epochs": 15
+}
+`


### PR DESCRIPTION
https://github.com/iterative/vscode-dvc/issues/2529

Will try a permutation of big changes and files to test that the server side is stable.

- [x] Lots of copies of the same file
- [x] Lots of different file types
- [x] Lots of requests for a single open file
- [ ] Lots of requests for a lot of documents open
- [ ] Lots of workspace changes (delete,move,rename,create)

Then add an e2e smoke test.

Tests are failing, so I'll gradually remove the iterations until we have a baseline for the CI

Then we can have a target to improve, if it's too small

Current Baseline for the tests so far: 100 iterations

I'll add the workspace changes tests and then try again
