### PR TITLE
Display failed experiments

### DIFF
--- a/extension/src/cli/dvc/contract.ts
+++ b/extension/src/cli/dvc/contract.ts
@@ -1,6 +1,8 @@
 import { Plot } from '../../plots/webview/contract'
 
-export type DvcError = { error: { type: string; msg: string } }
+type ErrorContents = { type: string; msg: string }
+
+export type DvcError = { error: ErrorContents }
 
 export type Changes = {
   added?: string[]
@@ -22,7 +24,7 @@ export type Value = SingleValue | SingleValue[]
 
 export interface ValueTreeOrError {
   data?: ValueTree
-  error?: { type: string; msg: string }
+  error?: ErrorContents
 }
 
 type RelPathObject<T> = {
@@ -63,11 +65,12 @@ export interface ExperimentFields extends BaseExperimentFields {
   metrics?: ValueTreeRoot
   deps?: Deps
   outs?: RelPathObject<Out>
+  error?: ErrorContents
 }
 
 export interface ExperimentFieldsOrError {
   data?: ExperimentFields
-  error?: { type: string; msg: string }
+  error?: ErrorContents
 }
 
 export interface ExperimentsBranchOutput {

--- a/extension/src/experiments/model/collect.ts
+++ b/extension/src/experiments/model/collect.ts
@@ -148,6 +148,11 @@ const transformColumns = (
   }
 }
 
+const mergeErrors = (
+  experimentFieldsOrError: ExperimentFieldsOrError
+): string | undefined =>
+  experimentFieldsOrError.error?.msg || experimentFieldsOrError.data?.error?.msg
+
 const transformExperimentData = (
   id: string,
   experimentFieldsOrError: ExperimentFieldsOrError,
@@ -159,7 +164,7 @@ const transformExperimentData = (
 ): Experiment => {
   const data = experimentFieldsOrError.data || {}
 
-  const error = experimentFieldsOrError.error
+  const error = mergeErrors(experimentFieldsOrError)
 
   const experiment = {
     id,
@@ -180,7 +185,7 @@ const transformExperimentData = (
   }
 
   if (error) {
-    experiment.error = error.msg
+    experiment.error = error
   }
 
   transformColumns(experiment, data, branch)

--- a/extension/src/test/fixtures/expShow/output.ts
+++ b/extension/src/test/fixtures/expShow/output.ts
@@ -3,7 +3,8 @@ import { ExperimentsOutput, ExperimentStatus } from '../../../cli/dvc/contract'
 
 export const errorShas = [
   '489fd8bdaa709f7330aac342e051a9431c625481',
-  'f0f918662b4f8c47819ca154a23029bf9b47d4f3'
+  'f0f918662b4f8c47819ca154a23029bf9b47d4f3',
+  '55d492c9c633912685351b32df91bfe1f9ecefb9'
 ]
 
 const data: ExperimentsOutput = {

--- a/extension/src/test/fixtures/expShow/output.ts
+++ b/extension/src/test/fixtures/expShow/output.ts
@@ -1743,6 +1743,77 @@ const data: ExperimentsOutput = {
         status: ExperimentStatus.QUEUED,
         timestamp: '2020-12-29T15:25:27'
       }
+    },
+    '55d492c9c633912685351b32df91bfe1f9ecefb9': {
+      data: {
+        deps: {
+          [join('data', 'data.xml')]: {
+            hash: '22a1a2931c8370d3aeedd7183606fd7f',
+            size: 14445097,
+            nfiles: null
+          },
+          [join('src', 'prepare.py')]: {
+            hash: 'f09ea0c15980b43010257ccb9f0055e2',
+            size: 1576,
+            nfiles: null
+          },
+          [join('data', 'prepared')]: {
+            hash: '153aad06d376b6595932470e459ef42a.dir',
+            size: 8437363,
+            nfiles: 2
+          },
+          [join('src', 'featurization.py')]: {
+            hash: 'e0265fc22f056a4b86d85c3056bc2894',
+            size: 2490,
+            nfiles: null
+          },
+          [join('data', 'features')]: {
+            hash: 'f35d4cc2c552ac959ae602162b8543f3.dir',
+            size: 2232588,
+            nfiles: 2
+          },
+          [join('src', 'train.py')]: {
+            hash: 'c3961d777cfbd7727f9fde4851896006',
+            size: 967,
+            nfiles: null
+          },
+          'model.pkl': {
+            hash: '46865edbf3d62fc5c039dd9d2b0567a4',
+            size: 1763725,
+            nfiles: null
+          },
+          [join('src', 'evaluate.py')]: {
+            hash: '44e714021a65edf881b1716e791d7f59',
+            size: 2346,
+            nfiles: null
+          }
+        },
+        error: {
+          msg: 'Experiment run failed.',
+          type: 'Queue failure'
+        },
+        outs: {},
+        params: {
+          'params.yaml': {
+            data: {
+              code_names: [0, 2],
+              epochs: 5,
+              learning_rate: 2.1e-7,
+              dvc_logs_dir: 'dvc_logs',
+              log_file: 'logs.csv',
+              dropout: 0.125,
+              process: { threshold: 0.85 }
+            }
+          },
+          [join('nested', 'params.yaml')]: {
+            data: {
+              test: true
+            }
+          }
+        },
+        status: ExperimentStatus.FAILED,
+        timestamp: '2020-12-29T15:25:27'
+      }
     }
   }
 }

--- a/extension/src/test/fixtures/expShow/rows.ts
+++ b/extension/src/test/fixtures/expShow/rows.ts
@@ -1465,6 +1465,56 @@ const data: Row[] = [
         sha: '90aea7f2482117a55dfcadcdb901aaa6610fbbc9',
         starred: false,
         Created: '2020-12-29T15:25:27'
+      },
+      {
+        displayColor: undefined,
+        deps: {
+          [join('data', 'data.xml')]: valueWithNoChanges(
+            '22a1a2931c8370d3aeedd7183606fd7f'
+          ),
+          [join('data', 'features')]: valueWithNoChanges(
+            'f35d4cc2c552ac959ae602162b8543f3.dir'
+          ),
+          [join('data', 'prepared')]: valueWithNoChanges(
+            '153aad06d376b6595932470e459ef42a.dir'
+          ),
+          'model.pkl': valueWithNoChanges('46865edbf3d62fc5c039dd9d2b0567a4'),
+          [join('src', 'evaluate.py')]: valueWithNoChanges(
+            '44e714021a65edf881b1716e791d7f59'
+          ),
+          [join('src', 'featurization.py')]: valueWithNoChanges(
+            'e0265fc22f056a4b86d85c3056bc2894'
+          ),
+          [join('src', 'prepare.py')]: valueWithNoChanges(
+            'f09ea0c15980b43010257ccb9f0055e2'
+          ),
+          [join('src', 'train.py')]: valueWithNoChanges(
+            'c3961d777cfbd7727f9fde4851896006'
+          )
+        },
+        error: 'Experiment run failed.',
+        id: '55d492c9c633912685351b32df91bfe1f9ecefb9',
+        label: '55d492c',
+        outs: {},
+        params: {
+          'params.yaml': {
+            code_names: [0, 2],
+            epochs: 5,
+            learning_rate: 2.1e-7,
+            dvc_logs_dir: 'dvc_logs',
+            log_file: 'logs.csv',
+            dropout: 0.125,
+            process: { threshold: 0.85 }
+          },
+          [join('nested', 'params.yaml')]: {
+            test: true
+          }
+        },
+        selected: false,
+        status: ExperimentStatus.FAILED,
+        sha: '55d492c9c633912685351b32df91bfe1f9ecefb9',
+        starred: false,
+        Created: '2020-12-29T15:25:27'
       }
     ],
     Created: '2020-11-21T19:58:22'

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -1286,6 +1286,7 @@ suite('Experiments Test Suite', () => {
         '22e40e1fa3c916ac567f69b85969e3066a91dda4': 0,
         '23250b33e3d6dd0e136262d1d26a2face031cb03': 0,
         '489fd8bdaa709f7330aac342e051a9431c625481': colors[5],
+        '55d492c9c633912685351b32df91bfe1f9ecefb9': 0,
         '91116c1eae4b79cb1f5ab0312dfd9b3e43608e15': 0,
         '9523bde67538cf31230efaff2dbc47d38a944ab5': 0,
         c658f8b14ac819ac2a5ea0449da6c15dbe8eb880: 0,
@@ -1385,6 +1386,7 @@ suite('Experiments Test Suite', () => {
         '22e40e1fa3c916ac567f69b85969e3066a91dda4': 0,
         '23250b33e3d6dd0e136262d1d26a2face031cb03': 0,
         '489fd8bdaa709f7330aac342e051a9431c625481': colors[5],
+        '55d492c9c633912685351b32df91bfe1f9ecefb9': 0,
         '91116c1eae4b79cb1f5ab0312dfd9b3e43608e15': 0,
         '9523bde67538cf31230efaff2dbc47d38a944ab5': 0,
         c658f8b14ac819ac2a5ea0449da6c15dbe8eb880: 0,
@@ -1406,6 +1408,7 @@ suite('Experiments Test Suite', () => {
         'experimentsSortBy:test': sortDefinitions,
         'experimentsStatus:test': {
           '489fd8bdaa709f7330aac342e051a9431c625481': 0,
+          '55d492c9c633912685351b32df91bfe1f9ecefb9': 0,
           'exp-83425': colors[0],
           'exp-e7a67': 0,
           'exp-f13bca': 0,

--- a/extension/src/test/suite/experiments/model/filterBy/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/filterBy/tree.test.ts
@@ -479,7 +479,7 @@ suite('Experiments Filter By Tree Test Suite', () => {
         columnOrder: [],
         columnWidths: {},
         columns: columnsFixture,
-        filteredCounts: { checkpoints: 9, experiments: 5 },
+        filteredCounts: { checkpoints: 9, experiments: 6 },
         filters: ['starred'],
         hasCheckpoints: true,
         hasColumns: true,

--- a/extension/src/test/suite/experiments/workspace.test.ts
+++ b/extension/src/test/suite/experiments/workspace.test.ts
@@ -501,6 +501,14 @@ suite('Workspace Experiments Test Suite', () => {
             description: '[exp-f13bca]',
             label: 'f0f9186',
             value: { id: 'exp-f13bca', name: 'exp-f13bca' }
+          },
+          {
+            description: undefined,
+            label: '55d492c',
+            value: {
+              id: '55d492c9c633912685351b32df91bfe1f9ecefb9',
+              name: '55d492c'
+            }
           }
         ],
         {


### PR DESCRIPTION
# 3/3 `main` <- #2520 <- #2521 <- this

Relates to https://github.com/iterative/dvc/pull/8318

This PR adds code to display failed experiments as experiments with errors. Failed experiments will be displayed in the exact same way as other experiments with errors.

### Screenshot

<img width="1728" alt="Screen Shot 2022-10-06 at 1 36 38 pm" src="https://user-images.githubusercontent.com/37993418/194206787-eef2c376-a0d8-4c7d-aac6-11cd3421108a.png">


Steps to recreate state: 
1. Using `git+https://github.com/karajan1001/dvc.git@fix7986` (update min value of DVC)
2. Queue several experiments
3. `dvc queue start -j 3`

**Note**: I have added a new record to the base test fixture which relates to this situation.