### PR TITLE
Fix UX of extension using fallback global CLI when Python extension is active

### DIFF
--- a/extension/src/cli/dvc/version.ts
+++ b/extension/src/cli/dvc/version.ts
@@ -14,7 +14,7 @@ export enum CliCompatible {
   YES = 'yes'
 }
 
-export const cliIsCompatible = (
+export const isCliCompatible = (
   cliCompatible: CliCompatible
 ): boolean | undefined => {
   if (cliCompatible === CliCompatible.NO_NOT_FOUND) {
@@ -59,11 +59,25 @@ export const warnAheadOfLatestTested = (): void => {
 		Please upgrade to the most recent version of the extension and reload this window.`)
 }
 
+const cliIsCompatible = (
+  currentMajor: number,
+  currentMinor: number
+): CliCompatible => {
+  const { major: latestTestedMajor, minor: latestTestedMinor } = extractSemver(
+    LATEST_TESTED_CLI_VERSION
+  ) as ParsedSemver
+
+  if (currentMajor === latestTestedMajor && currentMinor > latestTestedMinor) {
+    return CliCompatible.YES_MINOR_VERSION_AHEAD_OF_TESTED
+  }
+
+  return CliCompatible.YES
+}
+
 const checkCLIVersion = (currentSemVer: {
   major: number
   minor: number
   patch: number
-  // eslint-disable-next-line sonarjs/cognitive-complexity
 }): CliCompatible => {
   const {
     major: currentMajor,
@@ -89,15 +103,7 @@ const checkCLIVersion = (currentSemVer: {
     return CliCompatible.NO_BEHIND_MIN_VERSION
   }
 
-  const { major: latestTestedMajor, minor: latestTestedMinor } = extractSemver(
-    LATEST_TESTED_CLI_VERSION
-  ) as ParsedSemver
-
-  if (currentMajor === latestTestedMajor && currentMinor > latestTestedMinor) {
-    return CliCompatible.YES_MINOR_VERSION_AHEAD_OF_TESTED
-  }
-
-  return CliCompatible.YES
+  return cliIsCompatible(currentMajor, currentMinor)
 }
 
 export const isVersionCompatible = (
@@ -111,9 +117,6 @@ export const isVersionCompatible = (
 
   if (
     !currentSemVer ||
-    typeof currentSemVer.major !== 'number' ||
-    typeof currentSemVer.minor !== 'number' ||
-    typeof currentSemVer.patch !== 'number' ||
     Number.isNaN(currentSemVer.major) ||
     Number.isNaN(currentSemVer.minor) ||
     Number.isNaN(currentSemVer.patch)

--- a/extension/src/cli/dvc/version.ts
+++ b/extension/src/cli/dvc/version.ts
@@ -37,21 +37,24 @@ export const extractSemver = (stdout: string): ParsedSemver | undefined => {
   return { major: Number(major), minor: Number(minor), patch: Number(patch) }
 }
 
+export const warnUnableToVerifyVersion = () =>
+  Toast.warnWithOptions(
+    'The extension cannot initialize as we were unable to verify the DVC CLI version.'
+  )
+
 export const warnVersionIncompatible = (
   version: string,
   update: 'CLI' | 'extension'
 ): void => {
   Toast.warnWithOptions(
-    `The extension cannot initialize because you are using version ${version} of the DVC CLI. 
-		The expected version is ${MIN_CLI_VERSION} <= DVC < ${MAX_CLI_VERSION}. 
-		Please upgrade to the most recent version of the ${update} and reload this window.`
+    `The extension cannot initialize because you are using version ${version} of the DVC CLI. The expected version is ${MIN_CLI_VERSION} <= DVC < ${MAX_CLI_VERSION}. Please upgrade to the most recent version of the ${update} and reload this window.`
   )
 }
 
 export const warnAheadOfLatestTested = (): void => {
-  Toast.warnWithOptions(`The located DVC CLI is at least a minor version ahead of the latest version the extension was tested with (${LATEST_TESTED_CLI_VERSION}). 
-		This could lead to unexpected behaviour. 
-		Please upgrade to the most recent version of the extension and reload this window.`)
+  Toast.warnWithOptions(
+    `The located DVC CLI is at least a minor version ahead of the latest version the extension was tested with (${LATEST_TESTED_CLI_VERSION}). This could lead to unexpected behaviour. Please upgrade to the most recent version of the extension and reload this window.`
+  )
 }
 
 const cliIsCompatible = (

--- a/extension/src/cli/dvc/version.ts
+++ b/extension/src/cli/dvc/version.ts
@@ -37,20 +37,15 @@ export const extractSemver = (stdout: string): ParsedSemver | undefined => {
   return { major: Number(major), minor: Number(minor), patch: Number(patch) }
 }
 
-export const EXPECTED_VERSION_TEXT = `The expected version is ${MIN_CLI_VERSION} <= DVC < ${MAX_CLI_VERSION}.`
-
-const getWarningText = (
-  currentVersion: string,
-  update: 'CLI' | 'extension'
-): string => `The extension cannot initialize because you are using version ${currentVersion} of the DVC CLI.
-${EXPECTED_VERSION_TEXT} Please upgrade to the most recent version of the ${update} and reload this window.`
-
-export const getTextAndSend = (
+export const warnVersionIncompatible = (
   version: string,
   update: 'CLI' | 'extension'
 ): void => {
-  const text = getWarningText(version, update)
-  Toast.warnWithOptions(text)
+  Toast.warnWithOptions(
+    `The extension cannot initialize because you are using version ${version} of the DVC CLI. 
+		The expected version is ${MIN_CLI_VERSION} <= DVC < ${MAX_CLI_VERSION}. 
+		Please upgrade to the most recent version of the ${update} and reload this window.`
+  )
 }
 
 export const warnAheadOfLatestTested = (): void => {

--- a/extension/src/cli/dvc/version.ts
+++ b/extension/src/cli/dvc/version.ts
@@ -5,6 +5,27 @@ import {
 } from './constants'
 import { Toast } from '../../vscode/toast'
 
+export enum CliCompatible {
+  NO_BEHIND_MIN_VERSION = 'no-behind-min-version',
+  NO_CANNOT_VERIFY = 'no-cannot-verify',
+  NO_MAJOR_VERSION_AHEAD = 'no-major-version-ahead',
+  NO_NOT_FOUND = 'no-not-found',
+  YES_MINOR_VERSION_AHEAD_OF_TESTED = 'yes-minor-version-ahead-of-tested',
+  YES = 'yes'
+}
+
+export const cliIsCompatible = (
+  cliCompatible: CliCompatible
+): boolean | undefined => {
+  if (cliCompatible === CliCompatible.NO_NOT_FOUND) {
+    return
+  }
+
+  return [
+    CliCompatible.YES,
+    CliCompatible.YES_MINOR_VERSION_AHEAD_OF_TESTED
+  ].includes(cliCompatible)
+}
 export type ParsedSemver = { major: number; minor: number; patch: number }
 
 export const extractSemver = (stdout: string): ParsedSemver | undefined => {
@@ -16,36 +37,34 @@ export const extractSemver = (stdout: string): ParsedSemver | undefined => {
   return { major: Number(major), minor: Number(minor), patch: Number(patch) }
 }
 
+export const EXPECTED_VERSION_TEXT = `The expected version is ${MIN_CLI_VERSION} <= DVC < ${MAX_CLI_VERSION}.`
+
 const getWarningText = (
   currentVersion: string,
   update: 'CLI' | 'extension'
 ): string => `The extension cannot initialize because you are using version ${currentVersion} of the DVC CLI.
-The expected version is ${MIN_CLI_VERSION} <= DVC < ${MAX_CLI_VERSION}. Please upgrade to the most recent version of the ${update} and reload this window.`
+${EXPECTED_VERSION_TEXT} Please upgrade to the most recent version of the ${update} and reload this window.`
 
-const getTextAndSend = (version: string, update: 'CLI' | 'extension'): void => {
+export const getTextAndSend = (
+  version: string,
+  update: 'CLI' | 'extension'
+): void => {
   const text = getWarningText(version, update)
   Toast.warnWithOptions(text)
 }
 
-const warnIfAheadOfLatestTested = (
-  currentMajor: number,
-  currentMinor: number
-) => {
-  const { major: latestTestedMajor, minor: latestTestedMinor } = extractSemver(
-    LATEST_TESTED_CLI_VERSION
-  ) as ParsedSemver
-
-  if (currentMajor === latestTestedMajor && currentMinor > latestTestedMinor) {
-    Toast.warnWithOptions(`The located DVC CLI is at least a minor version ahead of the latest version the extension was tested with (${LATEST_TESTED_CLI_VERSION}). 
+export const warnAheadOfLatestTested = (): void => {
+  Toast.warnWithOptions(`The located DVC CLI is at least a minor version ahead of the latest version the extension was tested with (${LATEST_TESTED_CLI_VERSION}). 
 		This could lead to unexpected behaviour. 
 		Please upgrade to the most recent version of the extension and reload this window.`)
-  }
 }
 
-const checkCLIVersion = (
-  version: string,
-  currentSemVer: { major: number; minor: number; patch: number }
-): boolean => {
+const checkCLIVersion = (currentSemVer: {
+  major: number
+  minor: number
+  patch: number
+  // eslint-disable-next-line sonarjs/cognitive-complexity
+}): CliCompatible => {
   const {
     major: currentMajor,
     minor: currentMinor,
@@ -53,8 +72,7 @@ const checkCLIVersion = (
   } = currentSemVer
 
   if (currentMajor >= Number(MAX_CLI_VERSION)) {
-    getTextAndSend(version, 'extension')
-    return false
+    return CliCompatible.NO_MAJOR_VERSION_AHEAD
   }
 
   const {
@@ -68,28 +86,40 @@ const checkCLIVersion = (
     currentMinor < minMinor ||
     (currentMinor === minMinor && currentPatch < Number(minPatch))
   ) {
-    getTextAndSend(version, 'CLI')
-    return false
+    return CliCompatible.NO_BEHIND_MIN_VERSION
   }
 
-  warnIfAheadOfLatestTested(currentMajor, currentMinor)
+  const { major: latestTestedMajor, minor: latestTestedMinor } = extractSemver(
+    LATEST_TESTED_CLI_VERSION
+  ) as ParsedSemver
 
-  return true
+  if (currentMajor === latestTestedMajor && currentMinor > latestTestedMinor) {
+    return CliCompatible.YES_MINOR_VERSION_AHEAD_OF_TESTED
+  }
+
+  return CliCompatible.YES
 }
 
-export const isVersionCompatible = (version: string): boolean => {
+export const isVersionCompatible = (
+  version: string | undefined
+): CliCompatible => {
+  if (!version) {
+    return CliCompatible.NO_NOT_FOUND
+  }
+
   const currentSemVer = extractSemver(version)
+
   if (
     !currentSemVer ||
+    typeof currentSemVer.major !== 'number' ||
+    typeof currentSemVer.minor !== 'number' ||
+    typeof currentSemVer.patch !== 'number' ||
     Number.isNaN(currentSemVer.major) ||
     Number.isNaN(currentSemVer.minor) ||
     Number.isNaN(currentSemVer.patch)
   ) {
-    Toast.warnWithOptions(
-      'The extension cannot initialize as we were unable to verify the DVC CLI version.'
-    )
-    return false
+    return CliCompatible.NO_CANNOT_VERIFY
   }
 
-  return checkCLIVersion(version, currentSemVer)
+  return checkCLIVersion(currentSemVer)
 }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -328,9 +328,9 @@ export class Extension extends Disposable implements IExtension {
     }
   }
 
-  public async isDvcPythonModule() {
+  public async isPythonExtensionUsed() {
     await this.config.isReady()
-    return !!this.config.getPythonBinPath()
+    return !!this.config.isPythonExtensionUsed()
   }
 
   public async getCliVersion(cwd: string, tryGlobalCli?: true) {

--- a/extension/src/interfaces.ts
+++ b/extension/src/interfaces.ts
@@ -1,5 +1,8 @@
 export interface IExtension {
-  canRunCli: (cwd: string, isCliGlobal?: true) => Promise<boolean>
+  getCliVersion: (
+    cwd: string,
+    isCliGlobal?: true
+  ) => Promise<string | undefined>
   hasRoots: () => boolean
   isDvcPythonModule: () => Promise<boolean>
 
@@ -7,6 +10,9 @@ export interface IExtension {
 
   initialize: () => Promise<void[]>
   resetMembers: () => void
+
   setAvailable: (available: boolean) => void
+  setCliCompatible: (compatible: boolean | undefined) => void
   setRoots: () => Promise<void>
+  unsetPythonBinPath: () => void
 }

--- a/extension/src/interfaces.ts
+++ b/extension/src/interfaces.ts
@@ -4,7 +4,7 @@ export interface IExtension {
     isCliGlobal?: true
   ) => Promise<string | undefined>
   hasRoots: () => boolean
-  isDvcPythonModule: () => Promise<boolean>
+  isPythonExtensionUsed: () => Promise<boolean>
 
   setupWorkspace: () => void
 

--- a/extension/src/setup.test.ts
+++ b/extension/src/setup.test.ts
@@ -481,7 +481,7 @@ describe('setup', () => {
     await flushPromises()
     expect(mockedWarnWithOptions).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).toHaveBeenCalledWith(
-      `The extension is unable to access an appropriate version of the CLI. The CLI was not located using the interpreter provided by the Python extension. ${belowMinVersion} is installed globally. For auto Python environment activation, ensure the correct interpreter is set. Active Python interpreter: ${mockedPythonPath}.`,
+      `The extension is unable to initialize. The CLI was not located using the interpreter provided by the Python extension. ${belowMinVersion} is installed globally. For auto Python environment activation, ensure the correct interpreter is set. Active Python interpreter: ${mockedPythonPath}.`,
       Response.SETUP_WORKSPACE,
       Response.SELECT_INTERPRETER,
       Response.NEVER
@@ -572,7 +572,7 @@ describe('setup', () => {
     await flushPromises()
     expect(mockedWarnWithOptions).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).toHaveBeenCalledWith(
-      `The extension is unable to access an appropriate version of the CLI. The CLI was not located using the interpreter provided by the Python extension. The CLI is also not installed globally. For auto Python environment activation, ensure the correct interpreter is set. Active Python interpreter: ${mockedPythonPath}.`,
+      `The extension is unable to initialize. The CLI was not located using the interpreter provided by the Python extension. The CLI is also not installed globally. For auto Python environment activation, ensure the correct interpreter is set. Active Python interpreter: ${mockedPythonPath}.`,
       Response.SETUP_WORKSPACE,
       Response.SELECT_INTERPRETER,
       Response.NEVER

--- a/extension/src/setup.test.ts
+++ b/extension/src/setup.test.ts
@@ -592,6 +592,18 @@ describe('setup', () => {
     expect(mockedGetCliVersion).toHaveBeenCalledTimes(1)
   })
 
+  it('should not attempt to find the cli globally if the python extension is used and the found version is behind', async () => {
+    const [major] = MIN_CLI_VERSION.split('.')
+    const behind = [major, 0, 0].join('.')
+    mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
+    mockedHasRoots.mockReturnValueOnce(true)
+    mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
+    mockedGetCliVersion.mockResolvedValueOnce(behind)
+
+    await setup(extension)
+    expect(mockedGetCliVersion).toHaveBeenCalledTimes(1)
+  })
+
   it('should run reset if the cli cannot be run and there is a workspace folder open', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)

--- a/extension/src/setup.test.ts
+++ b/extension/src/setup.test.ts
@@ -481,7 +481,7 @@ describe('setup', () => {
     await flushPromises()
     expect(mockedWarnWithOptions).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).toHaveBeenCalledWith(
-      `The extension is unable to access an appropriate version of the CLI. The CLI was not located using the interpreter provided by the Python extension. ${belowMinVersion} is installed globally. For auto Python environment activation ensure the correct interpreter is set. Active Python interpreter: ${mockedPythonPath}.`,
+      `The extension is unable to access an appropriate version of the CLI. The CLI was not located using the interpreter provided by the Python extension. ${belowMinVersion} is installed globally. For auto Python environment activation, ensure the correct interpreter is set. Active Python interpreter: ${mockedPythonPath}.`,
       Response.SETUP_WORKSPACE,
       Response.SELECT_INTERPRETER,
       Response.NEVER
@@ -572,7 +572,7 @@ describe('setup', () => {
     await flushPromises()
     expect(mockedWarnWithOptions).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).toHaveBeenCalledWith(
-      `The extension is unable to access an appropriate version of the CLI. The CLI was not located using the interpreter provided by the Python extension. The CLI is also not installed globally. For auto Python environment activation ensure the correct interpreter is set. Active Python interpreter: ${mockedPythonPath}.`,
+      `The extension is unable to access an appropriate version of the CLI. The CLI was not located using the interpreter provided by the Python extension. The CLI is also not installed globally. For auto Python environment activation, ensure the correct interpreter is set. Active Python interpreter: ${mockedPythonPath}.`,
       Response.SETUP_WORKSPACE,
       Response.SELECT_INTERPRETER,
       Response.NEVER

--- a/extension/src/setup.test.ts
+++ b/extension/src/setup.test.ts
@@ -414,7 +414,7 @@ describe('setup', () => {
     expect(mockedGetConfigValue).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).toHaveBeenCalledTimes(1)
     expect(mockedSetupWorkspace).not.toHaveBeenCalled()
-    expect(mockedExecuteCommand).toHaveBeenCalledTimes(0)
+    expect(mockedExecuteCommand).not.toHaveBeenCalled()
     expect(mockedSetUserConfigValue).toHaveBeenCalledTimes(1)
     expect(mockedResetMembers).toHaveBeenCalledTimes(1)
     expect(mockedInitialize).not.toHaveBeenCalled()
@@ -537,17 +537,19 @@ describe('setup', () => {
   })
 
   it('should send a specific message to the user if the located CLI is a major version ahead', async () => {
-    const majorVersion = '16.0.0'
+    const MajorAhead = MIN_CLI_VERSION.split('.')
+      .map(num => Number(num) + 100)
+      .join('.')
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
     mockedHasRoots.mockReturnValueOnce(true)
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
-    mockedGetCliVersion.mockResolvedValueOnce(majorVersion)
+    mockedGetCliVersion.mockResolvedValueOnce(MajorAhead)
 
     await setup(extension)
     await flushPromises()
     expect(mockedWarnWithOptions).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).toHaveBeenCalledWith(
-      `The extension cannot initialize because you are using version ${majorVersion} of the DVC CLI. The expected version is ${MIN_CLI_VERSION} <= DVC < ${MAX_CLI_VERSION}. Please upgrade to the most recent version of the extension and reload this window.`
+      `The extension cannot initialize because you are using version ${MajorAhead} of the DVC CLI. The expected version is ${MIN_CLI_VERSION} <= DVC < ${MAX_CLI_VERSION}. Please upgrade to the most recent version of the extension and reload this window.`
     )
     expect(mockedGetCliVersion).toHaveBeenCalledTimes(1)
     expect(mockedResetMembers).toHaveBeenCalledTimes(1)

--- a/extension/src/setup.ts
+++ b/extension/src/setup.ts
@@ -244,16 +244,21 @@ const warnUser = (
   }
 }
 
+type CanRunCli = {
+  isAvailable: boolean
+  isCompatible: boolean | undefined
+}
+
 const getVersionDetails = async (
   extension: IExtension,
   cwd: string,
   tryGlobalCli?: true
-): Promise<{
-  cliCompatible: CliCompatible
-  isAvailable: boolean
-  isCompatible: boolean | undefined
-  version: string | undefined
-}> => {
+): Promise<
+  CanRunCli & {
+    cliCompatible: CliCompatible
+    version: string | undefined
+  }
+> => {
   const version = await extension.getCliVersion(cwd, tryGlobalCli)
   const cliCompatible = isVersionCompatible(version)
   const isCompatible = isCliCompatible(cliCompatible)
@@ -266,7 +271,7 @@ const processVersionDetails = (
   version: string | undefined,
   isAvailable: boolean,
   isCompatible: boolean | undefined
-): { isAvailable: boolean; isCompatible: boolean | undefined } => {
+): CanRunCli => {
   warnUser(extension, cliCompatible, version)
   return {
     isAvailable,
@@ -277,7 +282,7 @@ const processVersionDetails = (
 const tryGlobalFallbackVersion = async (
   extension: IExtension,
   cwd: string
-): Promise<{ isAvailable: boolean; isCompatible: boolean | undefined }> => {
+): Promise<CanRunCli> => {
   const tryGlobal = await getVersionDetails(extension, cwd, true)
   const { cliCompatible, isAvailable, isCompatible, version } = tryGlobal
 
@@ -301,7 +306,7 @@ const tryGlobalFallbackVersion = async (
 const extensionCanAutoRunCli = async (
   extension: IExtension,
   cwd: string
-): Promise<{ isAvailable: boolean; isCompatible: boolean | undefined }> => {
+): Promise<CanRunCli> => {
   const {
     cliCompatible: pythonCliCompatible,
     isAvailable: pythonVersionIsAvailable,
@@ -324,7 +329,7 @@ const extensionCanAutoRunCli = async (
 const extensionCanRunCli = async (
   extension: IExtension,
   cwd: string
-): Promise<{ isAvailable: boolean; isCompatible: boolean | undefined }> => {
+): Promise<CanRunCli> => {
   if (await extension.isPythonExtensionUsed()) {
     return extensionCanAutoRunCli(extension, cwd)
   }

--- a/extension/src/setup.ts
+++ b/extension/src/setup.ts
@@ -212,7 +212,7 @@ const warnUserCLIInaccessibleAnywhere = async (
     true,
     `The extension is unable to access an appropriate version of the CLI. The CLI was not located using the interpreter provided by the Python extension. ${
       globalDvcVersion ? globalDvcVersion + ' is' : 'The CLI is also not'
-    } installed globally. For auto Python environment activation ensure the correct interpreter is set. Active Python interpreter: ${binPath}.`
+    } installed globally. For auto Python environment activation, ensure the correct interpreter is set. Active Python interpreter: ${binPath}.`
   )
 }
 

--- a/extension/src/setup.ts
+++ b/extension/src/setup.ts
@@ -210,7 +210,7 @@ const warnUserCLIInaccessibleAnywhere = async (
   return warnUserCLIInaccessible(
     extension,
     true,
-    `The extension is unable to access an appropriate version of the CLI. The CLI was not located using the interpreter provided by the Python extension. ${
+    `The extension is unable to initialize. The CLI was not located using the interpreter provided by the Python extension. ${
       globalDvcVersion ? globalDvcVersion + ' is' : 'The CLI is also not'
     } installed globally. For auto Python environment activation, ensure the correct interpreter is set. Active Python interpreter: ${binPath}.`
   )

--- a/extension/src/test/suite/extension.test.ts
+++ b/extension/src/test/suite/extension.test.ts
@@ -446,7 +446,7 @@ suite('Extension Test Suite', () => {
       expect(mockSetup).to.have.been.calledOnce
     })
 
-    it.only('should set the dvc.cli.incompatible context value', async () => {
+    it('should set the dvc.cli.incompatible context value', async () => {
       stub(DvcReader.prototype, 'expShow').resolves({
         workspace: { baseline: {} }
       })

--- a/extension/src/test/suite/extension.test.ts
+++ b/extension/src/test/suite/extension.test.ts
@@ -446,7 +446,7 @@ suite('Extension Test Suite', () => {
       expect(mockSetup).to.have.been.calledOnce
     })
 
-    it('should set the dvc.cli.incompatible context value', async () => {
+    it.only('should set the dvc.cli.incompatible context value', async () => {
       stub(DvcReader.prototype, 'expShow').resolves({
         workspace: { baseline: {} }
       })
@@ -470,8 +470,7 @@ suite('Extension Test Suite', () => {
         RegisteredCommands.EXTENSION_CHECK_CLI_COMPATIBLE
       )
 
-      expect(mockVersion).to.be.calledTwice
-      mockVersion.resetHistory()
+      expect(mockVersion).to.be.calledOnce
       expect(
         executeCommandSpy,
         'should set dvc.cli.incompatible to true if the version is incompatible'
@@ -483,7 +482,6 @@ suite('Extension Test Suite', () => {
       )
 
       expect(mockVersion).to.be.calledTwice
-      mockVersion.resetHistory()
       expect(
         executeCommandSpy,
         'should set dvc.cli.incompatible to false if the version is compatible'
@@ -498,7 +496,6 @@ suite('Extension Test Suite', () => {
         RegisteredCommands.EXTENSION_CHECK_CLI_COMPATIBLE
       )
 
-      expect(mockVersion).to.be.calledTwice
       expect(
         executeCommandSpy,
         'should unset dvc.cli.incompatible if the CLI throws an error'


### PR DESCRIPTION
# 1/2 `main` <- this <- #2552

This PR fixes the UX of using a global CLI fallback when the Python extension is active. Previously the extension would give a less than helpful warning if the CLI could not be found in the selected virtual environment and the wrong version was found globally. This PR digs into the implementation and moves things around in order to give more helpful directions for this situation.

### Demo

#### not found with Python, not found globally

https://user-images.githubusercontent.com/37993418/194786089-84c5b071-59c6-4566-b177-31b593874c69.mov

### not found with Python, install globally

https://user-images.githubusercontent.com/37993418/194786263-1ab3c8f1-0f5b-4874-a7cb-ff60c4b2a9fd.mov

### not found with Python, global behind

https://user-images.githubusercontent.com/37993418/194786307-59ef3781-6d6f-4306-ae04-015123fd2da7.mov

#### behind with Python (no global check)

https://user-images.githubusercontent.com/37993418/194786333-1fd31f1f-cb10-4a5c-a798-cd90a9607b24.mov

### correct version from Python

https://user-images.githubusercontent.com/37993418/194786386-f4cee864-d82a-4f64-a00a-5e245c92aa0e.mov
