### PR TITLE
Remove sort menu option from the parent params column drop down

### DIFF
--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -702,9 +702,7 @@ describe('App', () => {
       const itemLabels = menuitems.map(item => item.textContent)
       expect(itemLabels).toStrictEqual([
         'Open to the Side',
-        'Set Max Header Height',
-        'Sort Ascending',
-        'Sort Descending'
+        'Set Max Header Height'
       ])
     })
 
@@ -717,7 +715,7 @@ describe('App', () => {
       jest.advanceTimersByTime(100)
 
       const menuitems = screen.getAllByRole('menuitem')
-      expect(menuitems).toHaveLength(4)
+      expect(menuitems).toHaveLength(2)
 
       fireEvent.keyDown(paramsFileHeader, { bubbles: true, key: 'Escape' })
       expect(screen.queryAllByRole('menuitem')).toHaveLength(0)

--- a/webview/src/experiments/components/table/TableHeader.tsx
+++ b/webview/src/experiments/components/table/TableHeader.tsx
@@ -108,7 +108,7 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
       menuContent={
         <div>
           <MessagesMenu options={contextMenuOptions} />
-          {
+          {isSortable && (
             <>
               <VSCodeDivider />
               <MessagesMenu
@@ -149,7 +149,7 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
                 ]}
               />
             </>
-          }
+          )}
         </div>
       }
     />


### PR DESCRIPTION
From https://github.com/iterative/vscode-dvc/issues/2256

This PR will remove the sort options of the table headers that are not sortable.