### PR TITLE
Follow directions in the VS Code API docs for relative paths

### DIFF
--- a/extension/src/fileSystem/watcher.ts
+++ b/extension/src/fileSystem/watcher.ts
@@ -1,12 +1,30 @@
+import { join, relative } from 'path'
 import { utimes } from 'fs-extra'
 import { GlobPattern, RelativePattern, Uri, workspace } from 'vscode'
 import { Disposable } from '@hediet/std/disposable'
-import { isDirectory } from '.'
+import { isDirectory, isSameOrChild } from '.'
+
+const getRelativePatternForOutsideWorkspace = (
+  uri: Uri,
+  pattern: string
+): RelativePattern => new RelativePattern(uri, pattern)
 
 export const getRelativePattern = (
   path: string,
   pattern: string
-): RelativePattern => new RelativePattern(Uri.file(path), pattern)
+): RelativePattern => {
+  for (const workspaceFolder of workspace.workspaceFolders || []) {
+    const workspaceFolderPath = workspaceFolder.uri.fsPath
+    if (isSameOrChild(workspaceFolderPath, path)) {
+      return new RelativePattern(
+        workspaceFolder,
+        join(relative(workspaceFolderPath, path), pattern)
+      )
+    }
+  }
+
+  return getRelativePatternForOutsideWorkspace(Uri.file(path), pattern)
+}
 
 export const fireWatcher = (path: string): Promise<void> => {
   const now = Date.now() / 1000

--- a/extension/src/test/suite/experiments/data/index.test.ts
+++ b/extension/src/test/suite/experiments/data/index.test.ts
@@ -1,6 +1,6 @@
 import { join, resolve, sep } from 'path'
 import { afterEach, beforeEach, describe, it, suite } from 'mocha'
-import { EventEmitter, FileSystemWatcher, RelativePattern, Uri } from 'vscode'
+import { EventEmitter, FileSystemWatcher, RelativePattern } from 'vscode'
 import { expect } from 'chai'
 import { stub, restore, spy } from 'sinon'
 import { Disposable } from '../../../../extension'
@@ -11,7 +11,7 @@ import {
   getMockNow,
   stubPrivateMemberMethod
 } from '../../util'
-import { dvcDemoPath } from '../../../util'
+import { dvcDemoPath, getTestWorkspaceFolder } from '../../../util'
 import {
   ExperimentsData,
   QUEUED_EXPERIMENT_PATH
@@ -65,7 +65,7 @@ suite('Experiments Data Test Suite', () => {
 
       expect(getFirstArgOfCall(mockCreateFileSystemWatcher, 0)).to.deep.equal(
         new RelativePattern(
-          Uri.file(dvcDemoPath),
+          getTestWorkspaceFolder(),
           join(
             '**',
             `{dvc.lock,dvc.yaml,params.yaml,*.dvc,nested${sep}params.yaml,summary.json}`
@@ -139,7 +139,7 @@ suite('Experiments Data Test Suite', () => {
       expect(mockDispose).to.be.calledOnce
       expect(getFirstArgOfCall(mockCreateFileSystemWatcher, 0)).to.deep.equal(
         new RelativePattern(
-          Uri.file(dvcDemoPath),
+          getTestWorkspaceFolder(),
           join(
             '**',
             `{dvc.lock,dvc.yaml,params.yaml,*.dvc,nested${sep}params.yaml,summary.json}`
@@ -148,7 +148,7 @@ suite('Experiments Data Test Suite', () => {
       )
       expect(getFirstArgOfCall(mockCreateFileSystemWatcher, 1)).to.deep.equal(
         new RelativePattern(
-          Uri.file(dvcDemoPath),
+          getTestWorkspaceFolder(),
           join(
             '**',
             `{dvc.lock,dvc.yaml,params.yaml,*.dvc,nested${sep}params.yaml,new_params.yml,new_summary.json,summary.json}`

--- a/extension/src/test/suite/fileSystem/data/index.test.ts
+++ b/extension/src/test/suite/fileSystem/data/index.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, beforeEach, describe, it, suite } from 'mocha'
 import { stub, restore } from 'sinon'
 import { expect } from 'chai'
-import { RelativePattern, Uri } from 'vscode'
+import { RelativePattern } from 'vscode'
 import { Disposable } from '../../../../extension'
 import { FileSystemData } from '../../../../fileSystem/data'
-import { dvcDemoPath } from '../../../util'
+import { dvcDemoPath, getTestWorkspaceFolder } from '../../../util'
 import * as FileSystem from '../../../../fileSystem'
 import * as Watcher from '../../../../fileSystem/watcher'
 import { getFirstArgOfCall, mockDisposable } from '../../util'
@@ -48,7 +48,7 @@ suite('File System Data Test Suite', () => {
 
       expect(mockCreateFileSystemWatcher).to.be.calledOnce
       expect(getFirstArgOfCall(mockCreateFileSystemWatcher, 0)).to.deep.equal(
-        new RelativePattern(Uri.file(dvcDemoPath), join('**', 'dvc.yaml'))
+        new RelativePattern(getTestWorkspaceFolder(), join('**', 'dvc.yaml'))
       )
 
       await data.isReady()

--- a/extension/src/test/suite/fileSystem/watcher.test.ts
+++ b/extension/src/test/suite/fileSystem/watcher.test.ts
@@ -1,0 +1,40 @@
+import { join, resolve } from 'path'
+import { afterEach, beforeEach, describe, it, suite } from 'mocha'
+import { expect } from 'chai'
+import { Uri } from 'vscode'
+import { Disposable } from '@hediet/std/disposable'
+import { restore } from 'sinon'
+import { getRelativePattern } from '../../../fileSystem/watcher'
+import { dvcDemoPath, getTestWorkspaceFolder } from '../../util'
+
+suite('File System Watcher Test Suite', () => {
+  const disposable = Disposable.fn()
+
+  beforeEach(() => {
+    restore()
+  })
+
+  afterEach(() => {
+    disposable.dispose()
+  })
+
+  describe('getRelativePattern', () => {
+    it('should return the expected relative pattern with a path inside of the workspace', () => {
+      const relativePattern = getRelativePattern(
+        join(dvcDemoPath, '.git'),
+        '**'
+      )
+      expect(relativePattern.baseUri).to.deep.equal(
+        getTestWorkspaceFolder().uri
+      )
+      expect(relativePattern.pattern).equal(join('.git', '**'))
+    })
+
+    it('should return the expected relative pattern for a path outside of the workspace', () => {
+      const path = resolve(dvcDemoPath, '..', '.git')
+      const relativePattern = getRelativePattern(path, '**')
+      expect(relativePattern.baseUri.path).to.equal(Uri.file(path).path)
+      expect(relativePattern.pattern).to.equal('**')
+    })
+  })
+})

--- a/extension/src/test/util/index.ts
+++ b/extension/src/test/util/index.ts
@@ -1,11 +1,14 @@
 import { resolve } from 'path'
-import { Memento, Uri } from 'vscode'
+import { Memento, Uri, workspace, WorkspaceFolder } from 'vscode'
 
 const dvcRoot = resolve(__dirname, '..', '..', '..', '..', 'demo')
 export const dvcDemoPath = Uri.file(dvcRoot).fsPath
 export const basePlotsUrl = Uri.file(
   resolve(__dirname, '..', 'fixtures', 'plotsDiff', 'staticImages')
 ).fsPath
+
+export const getTestWorkspaceFolder = (): WorkspaceFolder =>
+  (workspace.workspaceFolders as WorkspaceFolder[])[0]
 
 export const buildMockMemento = (
   values: Record<string, unknown> = {}


### PR DESCRIPTION
Possible cause of #2562 and some of the stability issues that we've been seeing.

From the API:

```
    /**
     * A relative pattern is a helper to construct glob patterns that are matched
     * relatively to a base file path. The base path can either be an absolute file
     * path as string or uri or a {@link WorkspaceFolder workspace folder}, which is the
     * preferred way of creating the relative pattern.
     */
    export class RelativePattern {
...
         * @param base A base to which this pattern will be matched against relatively. It is recommended
         * to pass in a {@link WorkspaceFolder workspace folder} if the pattern should match inside the workspace.
         * Otherwise, a uri or string should only be used if the pattern is for a file path outside the workspace.
         * @param pattern A file glob pattern like `*.{ts,js}` that will be matched on paths relative to the base.
         */
        constructor(base: WorkspaceFolder | Uri | string, pattern: string);

```

The important line: **Otherwise, a uri or string should only be used if the pattern is for a file path outside the workspace.**