### PR TITLE
Revert moving experiment names to right in table's experiment column (maintain heirarchy)

### DIFF
--- a/webview/src/experiments/components/Experiments.tsx
+++ b/webview/src/experiments/components/Experiments.tsx
@@ -77,7 +77,7 @@ const getDefaultColumnWithIndicatorsPlaceHolder = () => {
     }: Cell<Row>) => {
       return (
         <div className={styles.experimentCellContents}>
-          <span className={styles.experimentCellPrimaryName}>{label}</span>
+          <span>{label}</span>
           {displayNameOrParent && (
             <span className={styles.experimentCellSecondaryName}>
               {displayNameOrParent}

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -174,6 +174,7 @@ $bullet-size: calc(var(--design-unit) * 4px);
   height: 32px;
   padding: 0;
   flex: 0 0 20px;
+  right: 6px;
   display: inline-block;
   position: relative;
   border: none;

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -402,7 +402,7 @@ $bullet-size: calc(var(--design-unit) * 4px);
       .experimentHeader {
         @extend %headerCellPadding;
         padding-left: $cell-padding;
-        text-align: right;
+        text-align: left;
         direction: ltr;
         overflow-x: hidden;
         text-overflow: ellipsis;
@@ -674,18 +674,17 @@ $bullet-size: calc(var(--design-unit) * 4px);
 .experimentCellContentsContainer {
   @extend .cellContents;
   display: flex;
-  width: 100%;
-  justify-content: flex-end;
-  text-align: right;
+  justify-content: flex-start;
+  text-align: left;
 }
 
 .experimentCellContents {
+  @extend .cellContents;
   display: flex;
   flex-flow: row wrap;
   line-height: normal;
   direction: ltr;
-  width: 100%;
-  justify-content: flex-end;
+  align-items: center;
   cursor: text;
 
   > * {
@@ -695,12 +694,7 @@ $bullet-size: calc(var(--design-unit) * 4px);
   }
 }
 
-.experimentCellPrimaryName {
-  width: 100%;
-}
-
 .experimentCellSecondaryName {
-  width: 100%;
   color: $meta-cell-color;
   font-size: 0.8em;
 }


### PR DESCRIPTION
Related to #2553

From https://github.com/iterative/vscode-dvc/pull/2553#issuecomment-1279627066

> Hmm, I prefer it way better the way it was before. It was more informative (in an important way - there is child-parent relationship). We've removed lines and hierarchy. It means either we'll have to implement something like in studio (sections per branch) or we need to go back and introduce the hierarchy back.

This PR reverts the change in question.

### Screenshot

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/37993418/195963886-b1bcdd23-2f3b-41dc-ae83-c83970449428.png">