### PR TITLE
Standardize dvc root paths as they come into the system

### DIFF
--- a/extension/src/fileSystem/index.ts
+++ b/extension/src/fileSystem/index.ts
@@ -10,6 +10,7 @@ import {
 } from 'fs-extra'
 import { load } from 'js-yaml'
 import { Uri } from 'vscode'
+import { standardizePath } from './path'
 import { definedAndNonEmpty } from '../util/array'
 import { Logger } from '../common/logger'
 
@@ -36,7 +37,7 @@ export const findDvcSubRootPaths = async (
 
   return children
     .filter(child => isDirectory(join(cwd, child, '.dvc')))
-    .map(child => join(cwd, child))
+    .map(child => standardizePath(join(cwd, child)) as string)
 }
 
 export const findDvcRootPaths = async (cwd: string): Promise<string[]> => {
@@ -57,7 +58,7 @@ export const findAbsoluteDvcRootPath = async (
     return []
   }
 
-  const absoluteRoot = resolve(cwd, relativePath)
+  const absoluteRoot = standardizePath(resolve(cwd, relativePath)) as string
 
   return [absoluteRoot]
 }


### PR DESCRIPTION
Follow-up from #2590 

We shouldn't have to do this but it is better to be safe than sorry, especially with 🪟s paths. If we standardize the paths at the edge of the system then we shouldn't have to do it for dvc roots anywhere else 👍🏻.