### PR TITLE
Improve star icon contrast

### DIFF
--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -510,10 +510,6 @@ $bullet-size: calc(var(--design-unit) * 4px);
           justify-content: center;
           width: 14px;
           cursor: pointer;
-
-          &[aria-checked='true'] {
-            opacity: 1;
-          }
         }
 
         .indicatorIcon {
@@ -559,11 +555,12 @@ $bullet-size: calc(var(--design-unit) * 4px);
 }
 
 .experimentCell .rowActions .starSwitch svg {
-  fill: $row-action-icon-color;
+  fill: $row-action-star;
+}
 
-  .rowSelected & {
-    fill: $row-action-selected-icon-color;
-  }
+.experimentCell .rowActions .starSwitch[aria-checked='true'] svg {
+  fill: $row-action-star-checked;
+  opacity: 0.8;
 }
 
 .cellHintTooltip {

--- a/webview/src/shared/variables.scss
+++ b/webview/src/shared/variables.scss
@@ -36,6 +36,9 @@ $row-action-selected-icon-color: var(
   var(--vscode-icon-foreground)
 );
 
+$row-action-star: var(--vscode-descriptionForeground);
+$row-action-star-checked: var(--vscode-editorLightBulb-foreground);
+
 $shadow: var(--vscode-widget-shadow);
 
 $plot-block-bg-color: var(--vscode-dropdown-background);


### PR DESCRIPTION
Closes https://github.com/iterative/vscode-dvc/issues/2540

The best (to my mind) stable among different themes combination that I think better highlights the action. It's the same color as icon in the header:

https://user-images.githubusercontent.com/3659196/196015855-2b31d3a0-486b-4da1-bf64-acc221fac521.mov

Open to trying other things. I've tried @maxagin suggestion, but it's now becomes too light to my mind, though blends nicely with the checkbox and button:

<img width="1501" alt="Screen Shot 2022-10-15 at 8 02 00 PM" src="https://user-images.githubusercontent.com/3659196/196015958-872e07f5-a9a6-4bd5-b35f-5b606507c27f.png">
<img width="1508" alt="Screen Shot 2022-10-15 at 8 02 16 PM" src="https://user-images.githubusercontent.com/3659196/196015960-f5ee6cf5-96c7-4423-82cf-1cb1b91e3c79.png">

