### PR TITLE
Add actions to experiment cell hint tooltips

### DIFF
--- a/extension/src/experiments/webview/messages.ts
+++ b/extension/src/experiments/webview/messages.ts
@@ -108,6 +108,13 @@ export class WebviewMessages {
           RegisteredCliCommands.EXPERIMENT_VIEW_REMOVE,
           { dvcRoot: this.dvcRoot, ids: [message.payload].flat() }
         )
+
+      case MessageFromWebviewType.ADD_STARRED_EXPERIMENT_FILTER: // needs analytics event
+        return commands.executeCommand(
+          RegisteredCommands.EXPERIMENT_FILTER_ADD_STARRED,
+          this.dvcRoot
+        )
+
       case MessageFromWebviewType.SELECT_COLUMNS:
         return this.setColumnsStatus()
 

--- a/extension/src/experiments/webview/messages.ts
+++ b/extension/src/experiments/webview/messages.ts
@@ -109,7 +109,7 @@ export class WebviewMessages {
           { dvcRoot: this.dvcRoot, ids: [message.payload].flat() }
         )
 
-      case MessageFromWebviewType.ADD_STARRED_EXPERIMENT_FILTER: // needs analytics event
+      case MessageFromWebviewType.ADD_STARRED_EXPERIMENT_FILTER:
         return commands.executeCommand(
           RegisteredCommands.EXPERIMENT_FILTER_ADD_STARRED,
           this.dvcRoot

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -66,6 +66,7 @@ import { DvcExecutor } from '../../../cli/dvc/executor'
 import { shortenForLabel } from '../../../util/string'
 import { GitExecutor } from '../../../cli/git/executor'
 import { WorkspacePlots } from '../../../plots/workspace'
+import { RegisteredCommands } from '../../../commands/external'
 
 suite('Experiments Test Suite', () => {
   const disposable = Disposable.fn()
@@ -948,6 +949,32 @@ suite('Experiments Test Suite', () => {
         'experiments have been starred'
       ).to.be.true
     }).timeout(WEBVIEW_TEST_TIMEOUT)
+
+    it.only(
+      'should be able to handle a message to filter to starred experiments',
+      async () => {
+        const { experiments } = setupExperimentsAndMockCommands()
+
+        const mockExecuteCommand = stub(commands, 'executeCommand')
+
+        const webview = await experiments.showWebview()
+        const mockMessageReceived = getMessageReceivedEmitter(webview)
+        const messageReceived = new Promise(resolve =>
+          disposable.track(mockMessageReceived.event(() => resolve(undefined)))
+        )
+
+        mockMessageReceived.fire({
+          type: MessageFromWebviewType.ADD_STARRED_EXPERIMENT_FILTER
+        })
+
+        await messageReceived
+
+        expect(mockExecuteCommand).to.be.calledWithExactly(
+          RegisteredCommands.EXPERIMENT_FILTER_ADD_STARRED,
+          dvcDemoPath
+        )
+      }
+    ).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should be able to handle a message to select experiments for plotting', async () => {
       const { experiments, experimentsModel } = buildExperiments(disposable)

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -950,31 +950,28 @@ suite('Experiments Test Suite', () => {
       ).to.be.true
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
-    it.only(
-      'should be able to handle a message to filter to starred experiments',
-      async () => {
-        const { experiments } = setupExperimentsAndMockCommands()
+    it('should be able to handle a message to filter to starred experiments', async () => {
+      const { experiments } = setupExperimentsAndMockCommands()
 
-        const mockExecuteCommand = stub(commands, 'executeCommand')
+      const mockExecuteCommand = stub(commands, 'executeCommand')
 
-        const webview = await experiments.showWebview()
-        const mockMessageReceived = getMessageReceivedEmitter(webview)
-        const messageReceived = new Promise(resolve =>
-          disposable.track(mockMessageReceived.event(() => resolve(undefined)))
-        )
+      const webview = await experiments.showWebview()
+      const mockMessageReceived = getMessageReceivedEmitter(webview)
+      const messageReceived = new Promise(resolve =>
+        disposable.track(mockMessageReceived.event(() => resolve(undefined)))
+      )
 
-        mockMessageReceived.fire({
-          type: MessageFromWebviewType.ADD_STARRED_EXPERIMENT_FILTER
-        })
+      mockMessageReceived.fire({
+        type: MessageFromWebviewType.ADD_STARRED_EXPERIMENT_FILTER
+      })
 
-        await messageReceived
+      await messageReceived
 
-        expect(mockExecuteCommand).to.be.calledWithExactly(
-          RegisteredCommands.EXPERIMENT_FILTER_ADD_STARRED,
-          dvcDemoPath
-        )
-      }
-    ).timeout(WEBVIEW_TEST_TIMEOUT)
+      expect(mockExecuteCommand).to.be.calledWithExactly(
+        RegisteredCommands.EXPERIMENT_FILTER_ADD_STARRED,
+        dvcDemoPath
+      )
+    }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should be able to handle a message to select experiments for plotting', async () => {
       const { experiments, experimentsModel } = buildExperiments(disposable)

--- a/extension/src/webview/contract.ts
+++ b/extension/src/webview/contract.ts
@@ -13,6 +13,7 @@ export type WebviewData = TableData | PlotsData
 export enum MessageFromWebviewType {
   INITIALIZED = 'initialized',
   APPLY_EXPERIMENT_TO_WORKSPACE = 'apply-experiment-to-workspace',
+  ADD_STARRED_EXPERIMENT_FILTER = 'add-starred-experiment-filter',
   CREATE_BRANCH_FROM_EXPERIMENT = 'create-branch-from-experiment',
   FOCUS_FILTERS_TREE = 'focus-filters-tree',
   FOCUS_SORTS_TREE = 'focus-sorts-tree',
@@ -90,6 +91,9 @@ export type MessageFromWebview =
   | {
       type: MessageFromWebviewType.APPLY_EXPERIMENT_TO_WORKSPACE
       payload: string
+    }
+  | {
+      type: MessageFromWebviewType.ADD_STARRED_EXPERIMENT_FILTER
     }
   | {
       type: MessageFromWebviewType.CREATE_BRANCH_FROM_EXPERIMENT

--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -681,6 +681,52 @@ describe('App', () => {
         expectedTooltipResult: '[true, false, string, 2]'
       })
     })
+
+    it('should show the expected tooltip for the plot experiment row action', () => {
+      const clickableText = 'Open the plots view'
+
+      renderTable(testData)
+
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+
+      const radioButton = within(getRow('workspace')).getByTestId(
+        'row-action-plot'
+      )
+      fireEvent.mouseEnter(radioButton)
+
+      jest.advanceTimersByTime(NORMAL_TOOLTIP_DELAY[0])
+      const tooltip = screen.queryByRole('tooltip')
+
+      expect(tooltip).toBeInTheDocument()
+      expect(tooltip).toHaveTextContent(`Click to plot${clickableText}`)
+      const clickableContent = screen.getByText(clickableText)
+      fireEvent.click(clickableContent)
+      expect(mockPostMessage).toHaveBeenCalledWith({
+        type: MessageFromWebviewType.OPEN_PLOTS_WEBVIEW
+      })
+    })
+
+    it('should show the expected tooltip for the star experiment row action', () => {
+      const clickableText = 'Filter experiments by starred'
+
+      renderTable(testData)
+
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+
+      const radioButton = within(getRow('main')).getByTestId('row-action-star')
+      fireEvent.mouseEnter(radioButton)
+
+      jest.advanceTimersByTime(NORMAL_TOOLTIP_DELAY[0])
+      const tooltip = screen.queryByRole('tooltip')
+
+      expect(tooltip).toBeInTheDocument()
+      expect(tooltip).toHaveTextContent(`Click to star${clickableText}`)
+      const clickableContent = screen.getByText('Filter experiments by starred')
+      fireEvent.click(clickableContent)
+      expect(mockPostMessage).toHaveBeenCalledWith({
+        type: MessageFromWebviewType.ADD_STARRED_EXPERIMENT_FILTER
+      })
+    })
   })
 
   describe('Header Context Menu', () => {

--- a/webview/src/experiments/components/table/CellHintTooltip.tsx
+++ b/webview/src/experiments/components/table/CellHintTooltip.tsx
@@ -7,20 +7,22 @@ import Tooltip, {
 
 export type CellHintTooltipProps = {
   tooltipContent: ReactNode
+  tooltipOffset?: [number, number]
   children: ReactElement
 }
 
 export const CellHintTooltip: React.FC<CellHintTooltipProps & TippyProps> = ({
   tooltipContent,
   children,
-  delay = NORMAL_TOOLTIP_DELAY
+  delay = NORMAL_TOOLTIP_DELAY,
+  tooltipOffset = [0, -2]
 }) => {
   return (
     <Tooltip
       content={<span className={styles.cellHintTooltip}>{tooltipContent}</span>}
       appendTo={document.body}
       placement="bottom-start"
-      offset={[0, -2]}
+      offset={tooltipOffset}
       delay={delay}
       interactive={true}
     >

--- a/webview/src/experiments/components/table/CellHintTooltip.tsx
+++ b/webview/src/experiments/components/table/CellHintTooltip.tsx
@@ -18,9 +18,11 @@ export const CellHintTooltip: React.FC<CellHintTooltipProps & TippyProps> = ({
   return (
     <Tooltip
       content={<span className={styles.cellHintTooltip}>{tooltipContent}</span>}
+      appendTo={document.body}
       placement="bottom-start"
       offset={[0, -2]}
       delay={delay}
+      interactive={true}
     >
       {children}
     </Tooltip>

--- a/webview/src/experiments/components/table/CellRowActions.tsx
+++ b/webview/src/experiments/components/table/CellRowActions.tsx
@@ -74,6 +74,26 @@ export const CellRowAction: React.FC<CellRowActionProps> = ({
 const getTooltipContent = (determiner: boolean, action: string): string =>
   'Click to ' + (determiner ? `un${action}` : action)
 
+type ClickableTooltipContentProps = {
+  clickableText: string
+  helperText: string
+  onClick: MouseEventHandler
+}
+
+const ClickableTooltipContent: React.FC<ClickableTooltipContentProps> = ({
+  clickableText,
+  helperText,
+  onClick
+}) => (
+  <span>
+    {helperText}
+    <br />
+    <button className={styles.buttonAsLink} onClick={onClick}>
+      {clickableText}
+    </button>
+  </span>
+)
+
 export const CellRowActions: React.FC<CellRowActionsProps> = ({
   bulletColor,
   isWorkspace,
@@ -104,20 +124,15 @@ export const CellRowActions: React.FC<CellRowActionsProps> = ({
         subRowsAffected={stars}
         testId={'row-action-star'}
         tooltipContent={
-          <span>
-            {getTooltipContent(!!starred, 'star')}
-            <br />
-            <button
-              className={styles.buttonAsLink}
-              onClick={() =>
-                sendMessage({
-                  type: MessageFromWebviewType.ADD_STARRED_EXPERIMENT_FILTER
-                })
-              }
-            >
-              Filter experiments by starred
-            </button>
-          </span>
+          <ClickableTooltipContent
+            clickableText={'Filter experiments by starred'}
+            onClick={() =>
+              sendMessage({
+                type: MessageFromWebviewType.ADD_STARRED_EXPERIMENT_FILTER
+              })
+            }
+            helperText={getTooltipContent(!!starred, 'star')}
+          />
         }
       >
         <div
@@ -144,20 +159,15 @@ export const CellRowActions: React.FC<CellRowActionsProps> = ({
           testId={'row-action-plot'}
           tooltipOffset={isWorkspace ? [0, -16] : undefined}
           tooltipContent={
-            <span>
-              {getTooltipContent(!!bulletColor, 'plot')}
-              <br />
-              <button
-                className={styles.buttonAsLink}
-                onClick={() =>
-                  sendMessage({
-                    type: MessageFromWebviewType.OPEN_PLOTS_WEBVIEW
-                  })
-                }
-              >
-                Open the plots view
-              </button>
-            </span>
+            <ClickableTooltipContent
+              clickableText={'Open the plots view'}
+              helperText={getTooltipContent(!!bulletColor, 'plot')}
+              onClick={() =>
+                sendMessage({
+                  type: MessageFromWebviewType.OPEN_PLOTS_WEBVIEW
+                })
+              }
+            />
           }
           onClick={toggleExperiment}
         >

--- a/webview/src/experiments/components/table/CellRowActions.tsx
+++ b/webview/src/experiments/components/table/CellRowActions.tsx
@@ -1,6 +1,7 @@
 import React, { MouseEventHandler } from 'react'
 import cx from 'classnames'
 import { VSCodeCheckbox } from '@vscode/webview-ui-toolkit/react'
+import { MessageFromWebviewType } from 'dvc/src/webview/contract'
 import {
   ExperimentStatus,
   isQueued
@@ -8,6 +9,7 @@ import {
 import { Indicator } from './Indicators'
 import styles from './styles.module.scss'
 import { CellHintTooltip } from './CellHintTooltip'
+import { sendMessage } from '../../../shared/vscode'
 import { clickAndEnterProps } from '../../../util/props'
 import { Clock, StarFull, StarEmpty } from '../../../shared/components/icons'
 
@@ -33,7 +35,7 @@ export type CellRowActionProps = {
   children: React.ReactElement
   hidden?: boolean
   testId?: string
-  tooltipContent: string
+  tooltipContent: string | React.ReactElement
   queued?: boolean
   onClick?: MouseEventHandler
 }
@@ -63,14 +65,8 @@ export const CellRowAction: React.FC<CellRowActionProps> = ({
   )
 }
 
-const getTooltipContent = (
-  determiner: boolean,
-  action: string,
-  helperText?: string
-): string =>
-  'Click to ' +
-  (determiner ? `un${action}` : action) +
-  (helperText ? `\n${helperText}` : '')
+const getTooltipContent = (determiner: boolean, action: string): string =>
+  'Click to ' + (determiner ? `un${action}` : action)
 
 export const CellRowActions: React.FC<CellRowActionsProps> = ({
   bulletColor,
@@ -100,11 +96,22 @@ export const CellRowActions: React.FC<CellRowActionsProps> = ({
         showSubRowStates={showSubRowStates}
         subRowsAffected={stars}
         testId={'row-action-star'}
-        tooltipContent={getTooltipContent(
-          !!starred,
-          'star',
-          'To filter by stars click the star icon above the filters tree\nor use "DVC: Filter Experiments Table to Starred" from the command palette.'
-        )}
+        tooltipContent={
+          <span>
+            {getTooltipContent(!!starred, 'star')}
+            <br />
+            <button
+              className={styles.buttonAsLink}
+              onClick={() =>
+                sendMessage({
+                  type: MessageFromWebviewType.ADD_STARRED_EXPERIMENT_FILTER
+                })
+              }
+            >
+              Filter experiments by starred
+            </button>
+          </span>
+        }
       >
         <div
           className={styles.starSwitch}
@@ -128,11 +135,22 @@ export const CellRowActions: React.FC<CellRowActionsProps> = ({
           showSubRowStates={showSubRowStates}
           subRowsAffected={plotSelections}
           testId={'row-action-plot'}
-          tooltipContent={getTooltipContent(
-            !!bulletColor,
-            'plot',
-            'To open the plots view click the plot icon in the top left corner\nor use "DVC: Show Plots" from the command palette.'
-          )}
+          tooltipContent={
+            <span>
+              {getTooltipContent(!!bulletColor, 'plot')}
+              <br />
+              <button
+                className={styles.buttonAsLink}
+                onClick={() =>
+                  sendMessage({
+                    type: MessageFromWebviewType.OPEN_PLOTS_WEBVIEW
+                  })
+                }
+              >
+                Open the plots view
+              </button>
+            </span>
+          }
           onClick={toggleExperiment}
         >
           <span className={styles.bullet} style={{ color: bulletColor }} />

--- a/webview/src/experiments/components/table/CellRowActions.tsx
+++ b/webview/src/experiments/components/table/CellRowActions.tsx
@@ -14,6 +14,7 @@ import { clickAndEnterProps } from '../../../util/props'
 import { Clock, StarFull, StarEmpty } from '../../../shared/components/icons'
 
 export type CellRowActionsProps = {
+  isWorkspace: boolean
   bulletColor?: string
   isRowSelected: boolean
   showSubRowStates: boolean
@@ -30,6 +31,7 @@ export type CellRowActionsProps = {
 }
 
 export type CellRowActionProps = {
+  tooltipOffset?: [number, number]
   showSubRowStates: boolean
   subRowsAffected: number
   children: React.ReactElement
@@ -47,12 +49,16 @@ export const CellRowAction: React.FC<CellRowActionProps> = ({
   hidden,
   testId,
   tooltipContent,
+  tooltipOffset,
   onClick
 }) => {
   const count = (showSubRowStates && subRowsAffected) || 0
 
   return (
-    <CellHintTooltip tooltipContent={tooltipContent}>
+    <CellHintTooltip
+      tooltipContent={tooltipContent}
+      tooltipOffset={tooltipOffset}
+    >
       <div
         className={cx(styles.rowActions, hidden && styles.hidden)}
         data-testid={testId}
@@ -70,6 +76,7 @@ const getTooltipContent = (determiner: boolean, action: string): string =>
 
 export const CellRowActions: React.FC<CellRowActionsProps> = ({
   bulletColor,
+  isWorkspace,
   status,
   toggleExperiment,
   isRowSelected,
@@ -135,6 +142,7 @@ export const CellRowActions: React.FC<CellRowActionsProps> = ({
           showSubRowStates={showSubRowStates}
           subRowsAffected={plotSelections}
           testId={'row-action-plot'}
+          tooltipOffset={isWorkspace ? [0, -16] : undefined}
           tooltipContent={
             <span>
               {getTooltipContent(!!bulletColor, 'plot')}

--- a/webview/src/experiments/components/table/CellRowActions.tsx
+++ b/webview/src/experiments/components/table/CellRowActions.tsx
@@ -1,15 +1,14 @@
 import React, { MouseEventHandler } from 'react'
 import cx from 'classnames'
 import { VSCodeCheckbox } from '@vscode/webview-ui-toolkit/react'
-import { MessageFromWebviewType } from 'dvc/src/webview/contract'
 import {
   ExperimentStatus,
   isQueued
 } from 'dvc/src/experiments/webview/contract'
 import { Indicator } from './Indicators'
+import { addStarredFilter, openPlotsWebview } from './messages'
 import styles from './styles.module.scss'
 import { CellHintTooltip } from './CellHintTooltip'
-import { sendMessage } from '../../../shared/vscode'
 import { clickAndEnterProps } from '../../../util/props'
 import { Clock, StarFull, StarEmpty } from '../../../shared/components/icons'
 
@@ -126,11 +125,7 @@ export const CellRowActions: React.FC<CellRowActionsProps> = ({
         tooltipContent={
           <ClickableTooltipContent
             clickableText={'Filter experiments by starred'}
-            onClick={() =>
-              sendMessage({
-                type: MessageFromWebviewType.ADD_STARRED_EXPERIMENT_FILTER
-              })
-            }
+            onClick={addStarredFilter}
             helperText={getTooltipContent(!!starred, 'star')}
           />
         }
@@ -162,11 +157,7 @@ export const CellRowActions: React.FC<CellRowActionsProps> = ({
             <ClickableTooltipContent
               clickableText={'Open the plots view'}
               helperText={getTooltipContent(!!bulletColor, 'plot')}
-              onClick={() =>
-                sendMessage({
-                  type: MessageFromWebviewType.OPEN_PLOTS_WEBVIEW
-                })
-              }
+              onClick={openPlotsWebview}
             />
           }
           onClick={toggleExperiment}

--- a/webview/src/experiments/components/table/Indicators.tsx
+++ b/webview/src/experiments/components/table/Indicators.tsx
@@ -1,17 +1,16 @@
 import React, { MouseEventHandler, ReactElement, ReactNode } from 'react'
 import { useSelector } from 'react-redux'
 import cx from 'classnames'
-import { MessageFromWebviewType } from 'dvc/src/webview/contract'
 import { FilteredCounts } from 'dvc/src/experiments/model/filterBy/collect'
 import styles from './styles.module.scss'
 import { CellHintTooltip } from './CellHintTooltip'
+import { focusFiltersTree, focusSortsTree, openPlotsWebview } from './messages'
 import { Icon } from '../../../shared/components/Icon'
 import {
   Filter,
   GraphScatter,
   SortPrecedence
 } from '../../../shared/components/icons'
-import { sendMessage } from '../../../shared/vscode'
 import { pluralize } from '../../../util/strings'
 import { ExperimentsState } from '../../store'
 
@@ -62,13 +61,6 @@ export const Indicator = ({
     content
   )
 }
-
-const focusFiltersTree = () =>
-  sendMessage({ type: MessageFromWebviewType.FOCUS_FILTERS_TREE })
-const focusSortsTree = () =>
-  sendMessage({ type: MessageFromWebviewType.FOCUS_SORTS_TREE })
-const openPlotsWebview = () =>
-  sendMessage({ type: MessageFromWebviewType.OPEN_PLOTS_WEBVIEW })
 
 const formatCountMessage = (
   item: string,

--- a/webview/src/experiments/components/table/Row.tsx
+++ b/webview/src/experiments/components/table/Row.tsx
@@ -167,6 +167,7 @@ export const RowContent: React.FC<
           bulletColor={displayColor}
           starred={starred}
           isRowSelected={isRowSelected}
+          isWorkspace={isWorkspace}
           showSubRowStates={!isExpanded && depth > 0}
           subRowStates={subRowStates}
           toggleExperiment={toggleExperiment}

--- a/webview/src/experiments/components/table/messages.ts
+++ b/webview/src/experiments/components/table/messages.ts
@@ -1,0 +1,16 @@
+import { MessageFromWebviewType } from 'dvc/src/webview/contract'
+import { sendMessage } from '../../../shared/vscode'
+
+export const focusFiltersTree = () =>
+  sendMessage({ type: MessageFromWebviewType.FOCUS_FILTERS_TREE })
+
+export const focusSortsTree = () =>
+  sendMessage({ type: MessageFromWebviewType.FOCUS_SORTS_TREE })
+
+export const openPlotsWebview = () =>
+  sendMessage({ type: MessageFromWebviewType.OPEN_PLOTS_WEBVIEW })
+
+export const addStarredFilter = () =>
+  sendMessage({
+    type: MessageFromWebviewType.ADD_STARRED_EXPERIMENT_FILTER
+  })

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -835,3 +835,21 @@ $badge-size: 0.85rem;
     cursor: col-resize;
   }
 }
+
+.buttonAsLink {
+  background: none !important;
+  border: none;
+  padding: 0 !important;
+  font-size: 0.65rem;
+  color: var(--vscode-textLink-foreground);
+
+  &:hover {
+    color: var(--vscode-textLink-activeForeground);
+  }
+
+  &:active {
+    color: var(--vscode-textLink-activeForeground);
+  }
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -1,6 +1,7 @@
 // Variables
 
 @import '../../../shared/variables.scss';
+@import '../../../shared/style.scss';
 
 $nested-row-padding: 1.35rem;
 $row-border: 1px solid $border-color;
@@ -837,19 +838,9 @@ $badge-size: 0.85rem;
 }
 
 .buttonAsLink {
+  @extend a;
   background: none !important;
   border: none;
   padding: 0 !important;
   font-size: 0.65rem;
-  color: var(--vscode-textLink-foreground);
-
-  &:hover {
-    color: var(--vscode-textLink-activeForeground);
-  }
-
-  &:active {
-    color: var(--vscode-textLink-activeForeground);
-  }
-  text-decoration: underline;
-  cursor: pointer;
 }

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -839,8 +839,8 @@ $badge-size: 0.85rem;
 
 .buttonAsLink {
   @extend a;
-  background: none !important;
+  background: none;
   border: none;
-  padding: 0 !important;
+  padding: 0;
   font-size: 0.65rem;
 }

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -843,4 +843,5 @@ $badge-size: 0.85rem;
   border: none;
   padding: 0;
   font-size: 0.65rem;
+  cursor: pointer;
 }


### PR DESCRIPTION
Follow up from [this comment](https://github.com/iterative/vscode-dvc/pull/2567#issuecomment-1279634170)

I have added clickable links to the tooltips for both the star and experiment plot row action items.

### Demo

https://user-images.githubusercontent.com/37993418/196098945-2295b171-d046-4753-9195-f5e1b60e5062.mov

