### PR TITLE
Use stable version of VS Code for e2e tests (again)

### DIFF
--- a/extension/src/test/e2e/wdio.conf.ts
+++ b/extension/src/test/e2e/wdio.conf.ts
@@ -33,7 +33,7 @@ export const config: Options.Testrunner = {
   capabilities: [
     {
       browserName: 'vscode',
-      browserVersion: 'insiders',
+      browserVersion: 'stable',
       'wdio:vscodeOptions': {
         extensionPath,
         userSettings: {


### PR DESCRIPTION
Seems like CI is failing for the same reason as last time. Won't be switching back to insiders for the e2e tests again as it is too unstable.