### PR TITLE
Upload vsix as part of publish action

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -42,6 +42,12 @@ jobs:
             turbo-${{ github.job }}-${{ github.ref_name }}-
 
       - run: yarn run install-frozen-lockfile
+      - run: yarn build
+
+      - name: Upload VSIX
+        uses: actions/upload-artifact@v3
+        with:
+          path: ./extension/dvc.vsix
 
       - run: yarn run lint
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -42,11 +42,12 @@ jobs:
             turbo-${{ github.job }}-${{ github.ref_name }}-
 
       - run: yarn run install-frozen-lockfile
-      - run: yarn build
+      - run: yarn build --force
 
       - name: Upload VSIX
         uses: actions/upload-artifact@v3
         with:
+          name: dvc.vsix
           path: ./extension/dvc.vsix
 
       - run: yarn run lint

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -42,13 +42,6 @@ jobs:
             turbo-${{ github.job }}-${{ github.ref_name }}-
 
       - run: yarn run install-frozen-lockfile
-      - run: yarn build --force
-
-      - name: Upload VSIX
-        uses: actions/upload-artifact@v3
-        with:
-          name: dvc.vsix
-          path: ./extension/dvc.vsix
 
       - run: yarn run lint
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,11 @@ jobs:
       - run: yarn run install-frozen-lockfile
       - run: yarn build
 
+      - name: Upload VSIX
+        uses: actions/upload-artifact@v3
+        with:
+          path: ./extension/dvc.vsix
+
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Upload VSIX
         uses: actions/upload-artifact@v3
         with:
+          name: dvc.vsix
           path: ./extension/dvc.vsix
 
       - name: Publish to Visual Studio Marketplace


### PR DESCRIPTION
See https://iterativeai.slack.com/archives/C01RB7BTG4C/p1666046325944219?thread_ts=1666044263.449979&cid=C01RB7BTG4C

As part of trying to recover from this error, I had to build the VSIX locally. This PR adds an upload step so that the VSIX built by the CI will always be available.

Example of a CI run including the same upload action: https://github.com/iterative/vscode-dvc/actions/runs/3269609097 from https://github.com/iterative/vscode-dvc/pull/2615/commits/aef55ec76fd599a58e8ec7cef01ab07bc8d56801