### PR TITLE
Account for null being an object in workspace change data collection

### DIFF
--- a/extension/src/experiments/columns/collect/index.test.ts
+++ b/extension/src/experiments/columns/collect/index.test.ts
@@ -693,6 +693,32 @@ describe('collectChanges', () => {
     ).toStrictEqual(['params:params.yaml:a.b'])
   })
 
+  it('should handle when a parameter has a null value', () => {
+    const nullParam = {
+      param_tuning: {
+        logistic_regression: null
+      }
+    }
+
+    expect(
+      collectChanges({
+        workspace: updateParams(nullParam),
+        '9c6ba26745d2fbc286a13b99011d5126b5a245dc': updateParams(nullParam)
+      })
+    ).toStrictEqual([])
+
+    expect(
+      collectChanges({
+        workspace: updateParams(nullParam),
+        '9c6ba26745d2fbc286a13b99011d5126b5a245dc': updateParams({
+          param_tuning: {
+            logistic_regression: 1
+          }
+        })
+      })
+    ).toStrictEqual(['params:params.yaml:param_tuning.logistic_regression'])
+  })
+
   it('should compare against the most recent commit', () => {
     const matchingParams = {
       lr: 0.1

--- a/extension/src/experiments/columns/collect/metricsAndParams.ts
+++ b/extension/src/experiments/columns/collect/metricsAndParams.ts
@@ -110,7 +110,7 @@ const collectChange = (
   commitData: ExperimentFields,
   ancestors: string[] = []
 ) => {
-  if (!Array.isArray(value) && typeof value === 'object') {
+  if (value && !Array.isArray(value) && typeof value === 'object') {
     for (const [childKey, childValue] of Object.entries(value as ValueTree)) {
       collectChange(changes, type, file, childKey, childValue, commitData, [
         ...ancestors,


### PR DESCRIPTION
Closes https://github.com/iterative/vscode-dvc/issues/2569

See comment inline.

Notes: 

I had included a new test fixture as part of this change. I think that https://dagshub.com/kingabzpro/kaggle-titanic-dvc will be handy in the future (real-world project). It was the first project from https://github.com/iterative/awesome-iterative-projects#real-world-projects that gave the same error as shown in #2569. 
There were a few takeaways from looking at these projects that we can talk about tomorrow.