### PR TITLE
Add util for identifying ValueTree type

### DIFF
--- a/extension/src/cli/dvc/contract.ts
+++ b/extension/src/cli/dvc/contract.ts
@@ -39,6 +39,11 @@ export interface ValueTreeNode {
 
 export type ValueTree = ValueTreeRoot | ValueTreeNode
 
+export const isValueTree = (
+  value: Value | ValueTree
+): value is NonNullable<ValueTree> =>
+  !!(value && !Array.isArray(value) && typeof value === 'object')
+
 export enum ExperimentStatus {
   FAILED = 'Failed',
   QUEUED = 'Queued',

--- a/extension/src/experiments/columns/collect/metricsAndParams.ts
+++ b/extension/src/experiments/columns/collect/metricsAndParams.ts
@@ -9,9 +9,9 @@ import {
 import { ColumnType } from '../../webview/contract'
 import {
   ExperimentFields,
+  isValueTree,
   Value,
   ValueTree,
-  ValueTreeNode,
   ValueTreeOrError,
   ValueTreeRoot
 } from '../../../cli/dvc/contract'
@@ -57,9 +57,6 @@ const collectMetricOrParam = (
   )
 }
 
-const notLeaf = (value: ValueTreeNode): boolean =>
-  value && !Array.isArray(value) && typeof value === 'object'
-
 const walkValueTree = (
   acc: ColumnAccumulator,
   type: ColumnType,
@@ -67,7 +64,7 @@ const walkValueTree = (
   ancestors: string[] = []
 ) => {
   for (const [label, value] of Object.entries(tree)) {
-    if (notLeaf(value)) {
+    if (isValueTree(value)) {
       walkValueTree(acc, type, value, [...ancestors, label])
     } else {
       collectMetricOrParam(acc, type, ancestors, label, value)
@@ -110,8 +107,8 @@ const collectChange = (
   commitData: ExperimentFields,
   ancestors: string[] = []
 ) => {
-  if (value && !Array.isArray(value) && typeof value === 'object') {
-    for (const [childKey, childValue] of Object.entries(value as ValueTree)) {
+  if (isValueTree(value)) {
+    for (const [childKey, childValue] of Object.entries(value)) {
       collectChange(changes, type, file, childKey, childValue, commitData, [
         ...ancestors,
         key

--- a/extension/src/experiments/model/modify/collect.ts
+++ b/extension/src/experiments/model/modify/collect.ts
@@ -1,4 +1,4 @@
-import { Value, ValueTree } from '../../../cli/dvc/contract'
+import { isValueTree, Value, ValueTree } from '../../../cli/dvc/contract'
 import { appendColumnToPath } from '../../columns/paths'
 import { MetricOrParamColumns } from '../../webview/contract'
 
@@ -15,8 +15,8 @@ const collectFromParamsFile = (
 ) => {
   const pathArray = [...ancestors, key].filter(Boolean) as string[]
 
-  if (!Array.isArray(value) && typeof value === 'object') {
-    for (const [childKey, childValue] of Object.entries(value as ValueTree)) {
+  if (isValueTree(value)) {
+    for (const [childKey, childValue] of Object.entries(value)) {
       collectFromParamsFile(acc, childKey, childValue, pathArray)
     }
     return

--- a/extension/src/plots/model/collect.ts
+++ b/extension/src/plots/model/collect.ts
@@ -19,6 +19,7 @@ import {
   ExperimentsBranchOutput,
   ExperimentsOutput,
   ExperimentStatus,
+  isValueTree,
   PlotsOutput,
   Value,
   ValueTree
@@ -58,8 +59,8 @@ const collectFromMetricsFile = (
 ) => {
   const pathArray = [...ancestors, key].filter(Boolean) as string[]
 
-  if (typeof value === 'object') {
-    for (const [childKey, childValue] of Object.entries(value as ValueTree)) {
+  if (isValueTree(value)) {
+    for (const [childKey, childValue] of Object.entries(value)) {
       collectFromMetricsFile(
         acc,
         name,


### PR DESCRIPTION
First follow-up from https://github.com/iterative/vscode-dvc/pull/2617.

Seems like we need to do the same check in a few different places, I considered adding a more general object util but this is what we need for now.

This is not something that I'll forget in a hurry.