### PR TITLE
Set CLI as available for project initialization purposes

### DIFF
--- a/extension/src/setup.test.ts
+++ b/extension/src/setup.test.ts
@@ -429,7 +429,7 @@ describe('setup', () => {
     await setup(extension)
     expect(mockedSetRoots).toHaveBeenCalledTimes(1)
     expect(mockedResetMembers).toHaveBeenCalledTimes(1)
-    expect(mockedSetAvailable).not.toHaveBeenCalled()
+    expect(mockedSetAvailable).not.toHaveBeenCalledWith(false)
     expect(mockedInitialize).not.toHaveBeenCalled()
   })
 

--- a/extension/src/setup.ts
+++ b/extension/src/setup.ts
@@ -164,9 +164,9 @@ export const setup = async (extension: IExtension) => {
   const { isAvailable, isCompatible } = await extensionCanRunCli(extension, cwd)
 
   extension.setCliCompatible(isCompatible)
+  extension.setAvailable(isAvailable)
 
   if (extension.hasRoots() && isAvailable) {
-    extension.setAvailable(isAvailable)
     return extension.initialize()
   }
 


### PR DESCRIPTION
Fixes #2660.

Makes this screen available when there is no DVC project available in the workspace:

![image](https://user-images.githubusercontent.com/37993418/197297878-cf848f15-0c01-4f25-8661-8e38a2eb861a.png)

Things to check:

- [x]  When CLI is not available and workspace has DVC project
- [x] When CLI is not available and workspace has no DVC project
- [x] When CLI is available and workspace has DVC project 
- [x] When CLI is available and workspace has no DVC project 
- [x] When CLI is incompatible (behind min version)
