### PR TITLE
bump latest DVC tested version to 2.31.0

### DIFF
--- a/extension/src/cli/dvc/constants.ts
+++ b/extension/src/cli/dvc/constants.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 
 export const MIN_CLI_VERSION = '2.30.0'
-export const LATEST_TESTED_CLI_VERSION = '2.30.0'
+export const LATEST_TESTED_CLI_VERSION = '2.31.0'
 export const MAX_CLI_VERSION = '3'
 
 export const UNEXPECTED_ERROR_CODE = 255


### PR DESCRIPTION
Before the release better to bump it if there are no objections.