### PR TITLE
Plot resize row prototype

### DIFF
--- a/webview/src/plots/components/styles.module.scss
+++ b/webview/src/plots/components/styles.module.scss
@@ -110,7 +110,7 @@ $gap: 20px;
   display: grid;
   gap: $gap;
   grid-auto-flow: row;
-  grid-template-columns: repeat(auto-fill, var(--size));
+  grid-template-columns: repeat(auto-fill, minmax(var(--size), 1fr));
 
   + .singleViewPlotsGrid,
   + .multiViewPlotsGrid {


### PR DESCRIPTION
For #2585 (discussion).

This is as rough as #2680. It is to show how a resize on the plots could control the number of items on a row.

## Demo

https://user-images.githubusercontent.com/3683420/198068692-c7c1b4a8-ddb0-453e-be7e-4ef557d36354.mov

(The first resize was to reset the previous state, I don't think it had anything to do with this prototype)

IMO this method won't work and is counter-intuitive. You can see in the demo that I'm trying to resize twice without any changes. That is because we are rounding up to always fill the row and the change in size wouldn't impact the number of items in the row. You can also see that when it does resize, the change can be surprisingly bigger than expected.

I know our use case is a little different as we are not creating a new table, but if what we want is to change the number of items per row, then the first thing that comes to mind is something similar to this:

https://user-images.githubusercontent.com/3683420/198070731-6b4363b9-b740-4d14-915d-5a2361e6acea.mov

Everyone is familiar with this example. 

It can be a simple input as well, no need for a custom control like this.

In the end, I think it's better to offer a resize control that represents the resize behaviour. If we are changing the number of items per row on resize, then this is what we should let the user change. Changing the control = change in the layout.

The size of a plot only matters if it affects the number of items on a row. Changing the size does not always change the layout.
