### PR TITLE
Fix missing exp selection quick pick details on inital extension render

### DIFF
--- a/extension/src/experiments/columns/model.test.ts
+++ b/extension/src/experiments/columns/model.test.ts
@@ -194,6 +194,40 @@ describe('ColumnsModel', () => {
       expect(model.getColumnOrder()).toStrictEqual(persistedState)
     })
 
+    it('should return the first three columns from the persisted state', () => {
+      const persistedState = [
+        { path: 'A', width: 0 },
+        { path: 'B', width: 0 },
+        { path: 'C', width: 0 },
+        { path: 'D', width: 0 },
+        { path: 'E', width: 0 },
+        { path: 'F', width: 0 }
+      ]
+
+      const model = new ColumnsModel(
+        exampleDvcRoot,
+        buildMockMemento({
+          [PersistenceKey.METRICS_AND_PARAMS_COLUMN_ORDER + exampleDvcRoot]:
+            persistedState
+        })
+      )
+
+      expect(model.getFirstThreeColumnOrder()).toStrictEqual(
+        persistedState.slice(1, 4)
+      )
+    })
+
+    it('should return first three columns collected from data if state is empty', async () => {
+      const model = new ColumnsModel(exampleDvcRoot, buildMockMemento())
+      await model.transformAndSet(outputFixture)
+
+      expect(model.getFirstThreeColumnOrder()).toStrictEqual([
+        'Created',
+        'metrics:summary.json:loss',
+        'metrics:summary.json:accuracy'
+      ])
+    })
+
     it('should re-order the columns if a new columnOrder is set', () => {
       const model = new ColumnsModel(
         exampleDvcRoot,

--- a/extension/src/experiments/columns/model.ts
+++ b/extension/src/experiments/columns/model.ts
@@ -29,7 +29,9 @@ export class ColumnsModel extends PathSelectionModel<Column> {
   }
 
   public getFirstThreeColumnOrder(): string[] {
-    return this.columnOrderState.slice(1, 4)
+    return this.columnOrderState.length === 0
+      ? this.getFirstThreeColumnOrderFromData()
+      : this.columnOrderState.slice(1, 4)
   }
 
   public getColumnWidths(): Record<string, number> {
@@ -80,6 +82,13 @@ export class ColumnsModel extends PathSelectionModel<Column> {
 
   public hasNonDefaultColumns() {
     return this.data.length > 1
+  }
+
+  private getFirstThreeColumnOrderFromData(): string[] {
+    return this.data
+      .filter(({ hasChildren }) => !hasChildren)
+      .slice(0, 3)
+      .map(({ path }) => path)
   }
 
   private filterChildren(path?: string) {


### PR DESCRIPTION
* has `getFirstThreeColumnOrder` collect column order from data if `columnOrder` is an empty array

Currently, our `columnOrder` variable is an empty array until a user moves a column. If a user attempts to select experiments for plots, but hasn't moved columns in the table, they won't see any experiment details.

**Current:**

<img width="703" alt="image" src="https://user-images.githubusercontent.com/43496356/198682777-e066bcef-c31d-4ff3-943f-70a27931983f.png">

**PR:**

<img width="717" alt="image" src="https://user-images.githubusercontent.com/43496356/198683623-087f7b5b-1277-483c-ac2e-61e2ea8f6530.png">




