### PR TITLE
Fix scheduled CLI output test by moving TEMP_DIR outside of Git repository

### DIFF
--- a/extension/src/cli/git/constants.ts
+++ b/extension/src/cli/git/constants.ts
@@ -14,6 +14,7 @@ export enum Command {
   CLEAN = 'clean',
   COMMIT = 'commit',
   DIFF = 'diff',
+  INITIALIZE = 'init',
   LS_FILES = 'ls-files',
   PUSH = 'push',
   RESET = 'reset',

--- a/extension/src/cli/git/executor.ts
+++ b/extension/src/cli/git/executor.ts
@@ -17,6 +17,12 @@ export class GitExecutor extends GitCli {
     this
   )
 
+  public init(cwd: string) {
+    const options = getOptions(cwd, Command.INITIALIZE)
+
+    return this.executeProcess(options)
+  }
+
   public pushBranch(cwd: string, branchName?: string) {
     const args: Args = [Command.PUSH, Flag.SET_UPSTREAM, DEFAULT_REMOTE]
 

--- a/extension/src/test/cli/constants.ts
+++ b/extension/src/test/cli/constants.ts
@@ -1,4 +1,4 @@
-import { join } from 'path'
+import { resolve } from 'path'
 
 export const ENV_DIR = '.env'
-export const TEMP_DIR = join(__dirname, 'temp')
+export const TEMP_DIR = resolve(__dirname, '..', '..', '..', '..', '..', 'temp')

--- a/extension/src/test/cli/expShow.test.ts
+++ b/extension/src/test/cli/expShow.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, suite } from 'mocha'
 import isEmpty from 'lodash.isempty'
-import omit from 'lodash.omit'
 import { expect } from 'chai'
 import { TEMP_DIR } from './constants'
 import { dvcReader, initializeDemoRepo, initializeEmptyRepo } from './util'
@@ -77,50 +76,13 @@ suite('exp show --show-json', () => {
   })
 
   describe('Empty Repository', () => {
-    it('should return the expected output', async () => {
+    it('should return the default output', async () => {
       await initializeEmptyRepo()
       const output = await dvcReader.expShow(TEMP_DIR)
 
-      expect(
-        Object.keys(output),
-        'should have at least two entries'
-      ).to.have.lengthOf.greaterThanOrEqual(2)
-
-      const { workspace } = output
-
-      expect(workspace, 'should have a workspace key').not.to.be.undefined
-
-      const data = workspace.baseline.data
-
-      expect(
-        data,
-        'should have data inside of the workspace baseline'
-      ).to.be.an('object')
-
-      expect(data?.timestamp, 'should have a timestamp').to.be.a('null')
-
-      expect(data?.deps, 'should have deps inside of the workspace').to.be.an(
-        'object'
-      )
-
-      expect(data?.outs, 'should have outs inside of the workspace').to.be.an(
-        'object'
-      )
-
-      expect(
-        data?.metrics,
-        'should have metrics inside of the workspace'
-      ).to.be.an('object')
-
-      expect(
-        data?.params,
-        'should not have params inside of the workspace'
-      ).to.be.a('undefined')
-
-      for (const obj of Object.values(omit(output, 'workspace'))) {
-        expect(obj, 'should have a child object').to.be.an('object')
-        expect(obj.baseline, 'should have a baseline entry').to.be.an('object')
-      }
+      expect(output).to.deep.equal({
+        workspace: { baseline: {} }
+      })
     })
   })
 })

--- a/extension/src/test/cli/util.ts
+++ b/extension/src/test/cli/util.ts
@@ -6,6 +6,7 @@ import { Config } from '../../config'
 import { exists } from '../../fileSystem'
 import { getVenvBinPath } from '../../python/path'
 import { dvcDemoPath } from '../util'
+import { GitExecutor } from '../../cli/git/executor'
 
 const config = {
   getCliPath: () => '',
@@ -14,6 +15,7 @@ const config = {
 
 export const dvcReader = new DvcReader(config)
 export const dvcExecutor = new DvcExecutor(config)
+const gitExecutor = new GitExecutor()
 
 let demoInitialized: Promise<string>
 export const initializeDemoRepo = (): Promise<string> => {
@@ -23,10 +25,12 @@ export const initializeDemoRepo = (): Promise<string> => {
   return demoInitialized
 }
 
-export const initializeEmptyRepo = (): Promise<string> => {
+export const initializeEmptyRepo = async (): Promise<string> => {
   if (exists(join(TEMP_DIR, '.dvc'))) {
-    return Promise.resolve('')
+    return ''
   }
+
+  await gitExecutor.init(TEMP_DIR)
 
   return dvcExecutor.init(TEMP_DIR)
 }


### PR DESCRIPTION
Seems that having a submodule inside of the project when initializing a new DVC sub-project causes `exp show` to throw an error:

```json
{
	"workspace": {
		"baseline": {
			"error": {
				"msg": "\u001b[31mERROR\u001b[39m: unexpected error - 'data'",
				"type": "Caught error"
			}
		}
	}
}
```

I have moved the creation of a temp project outside of our project which fixes the issue 🙏🏻.

<img width="379" alt="image" src="https://user-images.githubusercontent.com/37993418/198796523-a129351d-cbe1-4a9a-9680-e6493d015b8d.png">

