### PR TITLE
Improve exp selection quick pick description

### DIFF
--- a/extension/src/experiments/model/quickPick.test.ts
+++ b/extension/src/experiments/model/quickPick.test.ts
@@ -135,19 +135,19 @@ describe('pickExperiments', () => {
       [
         {
           description: '[exp-123]',
-          detail: 'Created:Aug 19, 2022 split:0.1 data/data.xml:22a1a29',
+          detail: 'Created:Aug 19, 2022, split:0.1, data/data.xml:22a1a29',
           label: '123fsf4',
           value: mockedExperiments[0]
         },
         {
           description: '[exp-456]',
-          detail: 'Created:Aug 19, 2022 split:0.2 data/data.xml:22a1a29',
+          detail: 'Created:Aug 19, 2022, split:0.2, data/data.xml:22a1a29',
           label: '456fsf4',
           value: mockedExperiments[1]
         },
         {
           description: '[exp-789]',
-          detail: 'Created:Sep 15, 2022 split:0.3 data/data.xml:22a1a29',
+          detail: 'Created:Sep 15, 2022, split:0.3, data/data.xml:22a1a29',
           label: '789fsf4',
           value: mockedExperiments[2]
         }

--- a/extension/src/experiments/model/quickPicks.ts
+++ b/extension/src/experiments/model/quickPicks.ts
@@ -13,6 +13,7 @@ import { Experiment } from '../webview/contract'
 import { Title } from '../../vscode/title'
 import { splitColumnPath } from '../columns/paths'
 import { formatDate } from '../../util/date'
+import { truncateFromLeft } from '../../util/string'
 
 type QuickPickItemAccumulator = {
   items: QuickPickItemWithValue<Experiment | undefined>[]
@@ -38,10 +39,13 @@ const getItem = (experiment: Experiment, firstThreeColumnOrder: string[]) => ({
           ? formatDate(collectedVal)
           : collectedVal?.value || collectedVal
 
-      return `${splitUpName[splitUpName.length - 1]}:${value}`
+      return `${truncateFromLeft(
+        splitUpName[splitUpName.length - 1],
+        15
+      )}:${value}`
     })
     .filter(Boolean)
-    .join(' '),
+    .join(', '),
   label: experiment.label,
   value: omit(experiment, 'checkpoints')
 })

--- a/extension/src/util/string.ts
+++ b/extension/src/util/string.ts
@@ -1,3 +1,7 @@
 export const shortenForLabel = <T extends string | null>(
   strOrNull: T
 ): T | string => (strOrNull ? strOrNull.slice(0, 7) : strOrNull)
+
+export const truncateFromLeft = (str: string, length: number): string => {
+  return str.length > length ? '...' + str.slice(str.length - length) : str
+}


### PR DESCRIPTION
* truncate key strings to a max of 15 length 
* add "," between list items

## Demo

https://user-images.githubusercontent.com/43496356/199125204-88a124c0-9b6f-4e50-bc50-1302f5a79e2d.mov

