### PR TITLE
Fixes infinite loop in plots when workspace only is selected

### DIFF
--- a/extension/src/plots/data/index.ts
+++ b/extension/src/plots/data/index.ts
@@ -57,7 +57,7 @@ export class PlotsData extends BaseData<{ data: PlotsOutput; revs: string[] }> {
 
     this.compareFiles(files)
 
-    return this.notifyChanged({ data, revs: args })
+    return this.notifyChanged({ data, revs })
   }
 
   public managedUpdate() {


### PR DESCRIPTION
Critical issue with plot updates. This is caused by this change: https://github.com/iterative/vscode-dvc/pull/2629/files

Specifically, in this code:

```js
    const args = this.getArgs(revs)
    const data = await this.internalCommands.executeCommand<PlotsOutput>(
      AvailableCommands.PLOTS_DIFF,
      this.dvcRoot,
      ...args
    )

    const files = this.collectFiles({ data })

    this.compareFiles(files)

    return this.notifyChanged({ data, revs })
```

`args` is empty now, since we filter out the `workspace` rev. It means we don't pass it to `this.notifyChanged({ data, revs })`. It means that `workspace` is not set as "fetched". And since it triggers the update again inside (tbh, not clearly why?) it leads to an infinite loop.

https://user-images.githubusercontent.com/3659196/199377243-552ffb47-a6c5-4d1c-a8a1-c9a594d5450a.mov

We need to add test / return some tests.
