### PR TITLE
Fix exp tree tooltips and quick pick selection ignoring columns with falsy values

### DIFF
--- a/extension/src/experiments/model/quickPicks.ts
+++ b/extension/src/experiments/model/quickPicks.ts
@@ -11,7 +11,7 @@ import {
 import { Toast } from '../../vscode/toast'
 import { Experiment } from '../webview/contract'
 import { Title } from '../../vscode/title'
-import { truncate, truncateFromLeft } from '../../util/string'
+import { truncateFromLeft } from '../../util/string'
 
 type QuickPickItemAccumulator = {
   items: QuickPickItemWithValue<Experiment | undefined>[]
@@ -32,10 +32,8 @@ const getItem = (experiment: Experiment, firstThreeColumnOrder: string[]) => ({
         splitUpPath[splitUpPath.length - 1],
         15
       )
-      const truncatedVal =
-        typeof value === 'number' ? truncate(String(value), 7) : value
 
-      return value !== null ? `${truncatedKey}:${truncatedVal}` : ''
+      return value !== null ? `${truncatedKey}:${value}` : ''
     })
     .filter(Boolean)
     .join(', '),

--- a/extension/src/experiments/model/quickPicks.ts
+++ b/extension/src/experiments/model/quickPicks.ts
@@ -35,7 +35,7 @@ const getItem = (experiment: Experiment, firstThreeColumnOrder: string[]) => ({
       const truncatedVal =
         typeof value === 'number' ? truncate(String(value), 7) : value
 
-      return value ? `${truncatedKey}:${truncatedVal}` : ''
+      return value !== null ? `${truncatedKey}:${truncatedVal}` : ''
     })
     .filter(Boolean)
     .join(', '),

--- a/extension/src/experiments/model/tree.ts
+++ b/extension/src/experiments/model/tree.ts
@@ -357,7 +357,7 @@ export class ExperimentsTree
         )
         const truncatedVal =
           typeof value === 'number' ? truncate(String(value), 7) : value
-        return value ? `| ${truncatedKey} | ${truncatedVal} |\n` : ''
+        return value !== null ? `| ${truncatedKey} | ${truncatedVal} |\n` : ''
       })
       .join('')
     return getMarkdownString(`|||\n|:--|--|\n${data}`)

--- a/extension/src/experiments/model/tree.ts
+++ b/extension/src/experiments/model/tree.ts
@@ -33,7 +33,7 @@ import { sum } from '../../util/math'
 import { Disposable } from '../../class/dispose'
 import { Experiment, ExperimentStatus, isRunning } from '../webview/contract'
 import { getMarkdownString } from '../../vscode/markdownString'
-import { truncate, truncateFromLeft } from '../../util/string'
+import { truncateFromLeft } from '../../util/string'
 
 export class ExperimentsTree
   extends Disposable
@@ -355,9 +355,7 @@ export class ExperimentsTree
           path.slice(type.length + 1) || path,
           30
         )
-        const truncatedVal =
-          typeof value === 'number' ? truncate(String(value), 7) : value
-        return value !== null ? `| ${truncatedKey} | ${truncatedVal} |\n` : ''
+        return value !== null ? `| ${truncatedKey} | ${value} |\n` : ''
       })
       .join('')
     return getMarkdownString(`|||\n|:--|--|\n${data}`)

--- a/extension/src/experiments/model/util.ts
+++ b/extension/src/experiments/model/util.ts
@@ -13,8 +13,9 @@ export const getDataFromColumnPath = (
     columnPath === 'Created' && collectedVal
       ? formatDate(collectedVal)
       : collectedVal?.value || collectedVal
+
   return {
     splitUpPath,
-    value: value || null
+    value: value === 0 || value ? value : null
   }
 }


### PR DESCRIPTION
Currently our code will not show a column if its collected value is "falsy", which means it ignores columns with falsy values.

**Current:**

<img width="955" alt="image" src="https://user-images.githubusercontent.com/43496356/200610187-2fece513-fdab-448d-8656-f516855e1287.png">


**PR:**

<img width="925" alt="image" src="https://user-images.githubusercontent.com/43496356/200610032-d9b03038-e72e-48ca-ad9a-d51350220a1e.png">

