### PR TITLE
Fix unit tests for non en-US timezones

### DIFF
--- a/extension/src/experiments/model/quickPick.test.ts
+++ b/extension/src/experiments/model/quickPick.test.ts
@@ -5,6 +5,7 @@ import { MAX_SELECTED_EXPERIMENTS } from './status'
 import { quickPickLimitedValues } from '../../vscode/quickPick'
 import { Experiment } from '../webview/contract'
 import { Title } from '../../vscode/title'
+import { formatDate } from '../../util/date'
 
 jest.mock('../../vscode/quickPick')
 
@@ -135,19 +136,25 @@ describe('pickExperiments', () => {
       [
         {
           description: '[exp-123]',
-          detail: 'Created:Aug 19, 2022, split:0, data/data.xml:22a1a29',
+          detail: `Created:${formatDate(
+            mockedExperiments[0].Created as string
+          )}, split:0, data/data.xml:22a1a29`,
           label: '123fsf4',
           value: mockedExperiments[0]
         },
         {
           description: '[exp-456]',
-          detail: 'Created:Aug 19, 2022, split:0.2, data/data.xml:22a1a29',
+          detail: `Created:${formatDate(
+            mockedExperiments[1].Created as string
+          )}, split:0.2, data/data.xml:22a1a29`,
           label: '456fsf4',
           value: mockedExperiments[1]
         },
         {
           description: '[exp-789]',
-          detail: 'Created:Sep 15, 2022, split:0.3, data/data.xml:22a1a29',
+          detail: `Created:${formatDate(
+            mockedExperiments[2].Created as string
+          )}, split:0.3, data/data.xml:22a1a29`,
           label: '789fsf4',
           value: mockedExperiments[2]
         }

--- a/extension/src/experiments/model/tree.test.ts
+++ b/extension/src/experiments/model/tree.test.ts
@@ -16,6 +16,7 @@ import { RegisteredCommands } from '../../commands/external'
 import { getMarkdownString } from '../../vscode/markdownString'
 import { DecoratableTreeItemScheme, getDecoratableUri } from '../../tree'
 import { ExperimentStatus } from '../webview/contract'
+import { formatDate } from '../../util/date'
 
 const mockedCommands = jest.mocked(commands)
 mockedCommands.registerCommand = jest.fn()
@@ -483,8 +484,9 @@ describe('ExperimentsTree', () => {
           iconPath: expect.anything(),
           id: 'exp-123',
           label: 'a123',
-          tooltip:
-            '|||\n|:--|--|\n| Created | Aug 19, 2022 |\n| data/data.xml | 22a1a29 |\n| ...ms.yaml:featurize.random_value | undefined |\n',
+          tooltip: `|||\n|:--|--|\n| Created | ${formatDate(
+            experiments[0].Created
+          )} |\n| data/data.xml | 22a1a29 |\n| ...ms.yaml:featurize.random_value | undefined |\n`,
           type: ExperimentType.EXPERIMENT
         },
         {
@@ -499,8 +501,9 @@ describe('ExperimentsTree', () => {
           iconPath: expect.anything(),
           id: 'exp-456',
           label: 'b456',
-          tooltip:
-            '|||\n|:--|--|\n| Created | Sep 15, 2022 |\n| data/data.xml | 22a1a29 |\n| ...ms.yaml:featurize.random_value | [rbf,linear] |\n',
+          tooltip: `|||\n|:--|--|\n| Created | ${formatDate(
+            experiments[1].Created
+          )} |\n| data/data.xml | 22a1a29 |\n| ...ms.yaml:featurize.random_value | [rbf,linear] |\n`,
           type: ExperimentType.EXPERIMENT
         },
         {
@@ -515,8 +518,9 @@ describe('ExperimentsTree', () => {
           iconPath: expect.anything(),
           id: 'exp-789',
           label: 'c789',
-          tooltip:
-            '|||\n|:--|--|\n| Created | Jul 3, 2022 |\n| data/data.xml | 22a1a29 |\n| ...ms.yaml:featurize.random_value | false |\n',
+          tooltip: `|||\n|:--|--|\n| Created | ${formatDate(
+            experiments[2].Created
+          )} |\n| data/data.xml | 22a1a29 |\n| ...ms.yaml:featurize.random_value | false |\n`,
           type: ExperimentType.EXPERIMENT
         }
       ])


### PR DESCRIPTION
Unit tests were failing locally for me. The cause was the difference in formatting between `dateStyle: 'medium'` in our different timezones. => `DD MMM YYYY` vs `MMM DD, YYYY`