### PR TITLE
Use JSON5 library to parse non-standard JSON

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1541,6 +1541,7 @@
     "execa": "5.1.1",
     "fs-extra": "10.1.0",
     "js-yaml": "4.1.0",
+    "json5": "^2.2.1",
     "lodash.clonedeep": "4.5.0",
     "lodash.get": "4.4.2",
     "lodash.isempty": "4.4.0",

--- a/extension/src/cli/dvc/reader.ts
+++ b/extension/src/cli/dvc/reader.ts
@@ -19,6 +19,7 @@ import { getOptions } from './options'
 import { typeCheckCommands } from '..'
 import { MaybeConsoleError } from '../error'
 import { Logger } from '../../common/logger'
+import { parseNonStandardJson } from '../../util/json'
 
 const defaultExperimentsOutput: ExperimentsOutput = {
   workspace: { baseline: {} }
@@ -122,7 +123,7 @@ export class DvcReader extends DvcCli {
     try {
       const output =
         (await this.executeDvcProcess(cwd, ...args)) || defaultValue
-      return JSON.parse(output) as T
+      return parseNonStandardJson(output) as T
     } catch (error: unknown) {
       const msg =
         (error as MaybeConsoleError).stderr || (error as Error).message

--- a/extension/src/util/json.test.ts
+++ b/extension/src/util/json.test.ts
@@ -1,0 +1,20 @@
+import { parseNonStandardJson } from './json'
+
+describe('parseNonStandardJson', () => {
+  it('should parse NaN', () => {
+    expect(parseNonStandardJson('{NotANumber:NaN}')).toStrictEqual({
+      NotANumber: Number.NaN
+    })
+  })
+
+  it('should parse Infinity', () => {
+    expect(
+      parseNonStandardJson(
+        '{negativeInfinity:-Infinity, positiveInfinity: Infinity}'
+      )
+    ).toStrictEqual({
+      negativeInfinity: Number.NEGATIVE_INFINITY,
+      positiveInfinity: Number.POSITIVE_INFINITY
+    })
+  })
+})

--- a/extension/src/util/json.ts
+++ b/extension/src/util/json.ts
@@ -1,0 +1,3 @@
+import JSON5 from 'json5'
+
+export const parseNonStandardJson = (str: string) => JSON5.parse(str)


### PR DESCRIPTION
Fixes https://github.com/iterative/vscode-dvc/issues/2733 by using `JSON5` to parse non-standard JSON values (e.g NaN and Infinity as per the issue).

`JSON5`: https://www.npmjs.com/package/json5