### PR TITLE
Make plots ribbon sticky on scroll

### DIFF
--- a/webview/src/plots/components/ribbon/Ribbon.tsx
+++ b/webview/src/plots/components/ribbon/Ribbon.tsx
@@ -1,7 +1,9 @@
+import cx from 'classnames'
 import { MessageFromWebviewType } from 'dvc/src/webview/contract'
 import React, { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { performOrderedUpdate, reorderObjectList } from 'dvc/src/util/array'
+import { useInView } from 'react-intersection-observer'
 import styles from './styles.module.scss'
 import { RibbonBlock } from './RibbonBlock'
 import { sendMessage } from '../../../shared/vscode'
@@ -12,6 +14,12 @@ import { Lines, Refresh } from '../../../shared/components/icons'
 const MAX_NB_EXP = 7
 
 export const Ribbon: React.FC = () => {
+  const [ref, needsShadow] = useInView({
+    root: document.querySelector('#webview-wrapper'),
+    rootMargin: '-5px',
+    threshold: 0.95
+  })
+
   const revisions = useSelector(
     (state: PlotsState) => state.webview.selectedRevisions
   )
@@ -42,7 +50,11 @@ export const Ribbon: React.FC = () => {
   }
 
   return (
-    <ul className={styles.list} data-testid="ribbon">
+    <ul
+      ref={ref}
+      data-testid="ribbon"
+      className={cx(styles.list, needsShadow && styles.withShadow)}
+    >
       <li className={styles.buttonWrapper}>
         <IconButton
           onClick={selectRevisions}

--- a/webview/src/plots/components/ribbon/styles.module.scss
+++ b/webview/src/plots/components/ribbon/styles.module.scss
@@ -73,12 +73,22 @@
 
 .list {
   display: flex;
+  position: sticky;
   align-items: center;
   gap: 6px;
   border-bottom: 1px solid $border-color;
   padding: 10px 15px;
   margin: 0;
   flex-wrap: wrap;
+  top: 0;
+  width: 100%;
+  z-index: 100;
+  background-color: var(--vscode-editor-background);
+  transition: box-shadow 0.25s;
+
+  &.withShadow {
+    box-shadow: 0 5px 8px -2px $shadow;
+  }
 }
 
 .buttonWrapper {

--- a/webview/src/plots/components/ribbon/styles.module.scss
+++ b/webview/src/plots/components/ribbon/styles.module.scss
@@ -83,7 +83,7 @@
   top: 0;
   width: 100%;
   z-index: 100;
-  background-color: var(--vscode-editor-background);
+  background-color: $bg-color;
   transition: box-shadow 0.25s;
 
   &.withShadow {

--- a/webview/src/shared/components/webviewWrapper/WebviewWrapper.tsx
+++ b/webview/src/shared/components/webviewWrapper/WebviewWrapper.tsx
@@ -14,6 +14,7 @@ export const WebviewWrapper = ({
 
   return (
     <div
+      id="webview-wrapper"
       className={cx(styles.webviewWrapper, className)}
       style={themeVariables}
       onContextMenu={e => {

--- a/webview/src/shared/components/webviewWrapper/styles.module.scss
+++ b/webview/src/shared/components/webviewWrapper/styles.module.scss
@@ -1,4 +1,5 @@
 .webviewWrapper {
   width: 100%;
-  height: 100%;
+  height: auto;
+  min-height: 100%;
 }


### PR DESCRIPTION
Closes #2731

https://user-images.githubusercontent.com/3659196/201453111-936dea0b-2dd7-43c0-a86e-d0aace3f2fdc.mov

(writing it here primarily for the sake of future generation wondering how to use intersection observer API / `react-intersection-observer` to handle top nav bar / menu that changes its size):

- `rootMargin` can be used to offset the root / parent element to the height of the menu. It works well if menu / nav bar height is stable. But would require creating a new observer when / if size changes. It breaks the point of using it and complicates code, etc, etc. See also https://github.com/w3c/IntersectionObserver/issues/428
- Idea here is simple - let's offset the main parent element by a small margin (1-10px) and require full intersection with the menu (`threshold` is 1 or close to that)

I was not able to make 1.0 threshold work (some pixels are not visible in the sticky mode?), but it work well with 0.95-0.99, etc. 