### PR TITLE
Fix map on undefined is path doesn't exist in rev

### DIFF
--- a/extension/src/plots/model/collect.ts
+++ b/extension/src/plots/model/collect.ts
@@ -508,15 +508,16 @@ const updateDatapoints = (
   fields: string[]
 ): unknown[] =>
   selectedRevisions
-    .flatMap(revision =>
-      revisionData?.[revision]?.[path].map(data => {
+    .flatMap(revision => {
+      const datapoints = revisionData?.[revision]?.[path] || []
+      datapoints.map(data => {
         const obj = data as Record<string, unknown>
         return {
           ...obj,
           [key]: mergeFields(fields.map(field => obj[field] as string))
         }
       })
-    )
+    })
     .filter(Boolean)
 
 const updateRevisions = (

--- a/extension/src/plots/model/collect.ts
+++ b/extension/src/plots/model/collect.ts
@@ -510,7 +510,7 @@ const updateDatapoints = (
   selectedRevisions
     .flatMap(revision => {
       const datapoints = revisionData?.[revision]?.[path] || []
-      datapoints.map(data => {
+      return datapoints.map(data => {
         const obj = data as Record<string, unknown>
         return {
           ...obj,


### PR DESCRIPTION
Fixes critical part of the https://github.com/iterative/vscode-dvc-demo/pull/7#issuecomment-1315854742 .

I'm not sure how did plots work tbh with this, unless I'm missing something.

At least I'm getting now this:

<img width="1141" alt="Screen Shot 2022-11-16 at 10 08 03 PM" src="https://user-images.githubusercontent.com/3659196/202369451-f4a4cebd-a851-46ac-a7fe-4a5b242ffbc3.png">

@sroy3 layout for matrices is pretty bad here :(

As a followup I'll try to find what's wrong with flexible plots and add tests if it's a reasonable effort.