### PR TITLE
Revert "Update version and CHANGELOG for release"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.5.13] - 2022-11-17
-
-### 🐛 Bug Fixes
-
-- Fix map on undefined is path doesn't exist in rev [#2785](https://github.com/iterative/vscode-dvc/pull/2785) by [@shcheklein](https://github.com/shcheklein)
-
 ## [0.5.12] - 2022-11-16
 
 ### 🚀 New Features and Enhancements

--- a/extension/package.json
+++ b/extension/package.json
@@ -9,7 +9,7 @@
   "extensionDependencies": [
     "vscode.git"
   ],
-  "version": "0.5.13",
+  "version": "0.5.12",
   "license": "Apache-2.0",
   "readme": "./README.md",
   "repository": {


### PR DESCRIPTION
For some reason, the publish action was not triggered correctly by merging iterative/vscode-dvc#2786. This PR reverts us back to the previous state so we can try again.

Please 🚢 after merging this. 

I will take a note to make it possible to run the publish action manually.

This is the action that should not have skipped: https://github.com/iterative/vscode-dvc/actions/runs/3487151863/attempts/1