### PR TITLE
Check availability and compatibility on DVC projects in multi root workspaces

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -379,6 +379,10 @@ export class Extension extends Disposable implements IExtension {
     return this.setProjectAvailability()
   }
 
+  public getRoots() {
+    return this.dvcRoots
+  }
+
   public async initialize() {
     this.resetMembers()
 

--- a/extension/src/interfaces.ts
+++ b/extension/src/interfaces.ts
@@ -3,6 +3,7 @@ export interface IExtension {
     cwd: string,
     isCliGlobal?: true
   ) => Promise<string | undefined>
+  getRoots: () => string[]
   hasRoots: () => boolean
   isPythonExtensionUsed: () => Promise<boolean>
 

--- a/extension/src/setup.test.ts
+++ b/extension/src/setup.test.ts
@@ -65,6 +65,7 @@ const mockedCwd = __dirname
 const mockedGetCliVersion = jest.fn()
 const mockedGetFirstWorkspaceFolder = jest.mocked(getFirstWorkspaceFolder)
 const mockedHasRoots = jest.fn()
+const mockedGetRoots = jest.mocked(() => [])
 const mockedInitialize = jest.fn()
 const mockedIsPythonExtensionUsed = jest.fn()
 const mockedResetMembers = jest.fn()
@@ -258,6 +259,7 @@ describe('setupWorkspace', () => {
 describe('setup', () => {
   const extension = {
     getCliVersion: mockedGetCliVersion,
+    getRoots: mockedGetRoots,
     hasRoots: mockedHasRoots,
     initialize: mockedInitialize,
     isPythonExtensionUsed: mockedIsPythonExtensionUsed,

--- a/extension/src/setup.ts
+++ b/extension/src/setup.ts
@@ -161,7 +161,13 @@ export const setup = async (extension: IExtension) => {
 
   await extension.setRoots()
 
-  const { isAvailable, isCompatible } = await extensionCanRunCli(extension, cwd)
+  const roots = extension.getRoots()
+  const dvcRootOrFirstFolder = roots.length > 0 ? roots[0] : cwd
+
+  const { isAvailable, isCompatible } = await extensionCanRunCli(
+    extension,
+    dvcRootOrFirstFolder
+  )
 
   extension.setCliCompatible(isCompatible)
   extension.setAvailable(isAvailable)


### PR DESCRIPTION
Closes #2673. This check on the Python path and DVC path of the first root with a DVC project (if there is one) instead of just looking at the first folder.