### PR TITLE
Match the way that undefined/numeric experiment column values are shown in the table in tooltips and quick picks

### DIFF
--- a/extension/src/experiments/model/quickPick.test.ts
+++ b/extension/src/experiments/model/quickPick.test.ts
@@ -101,7 +101,7 @@ describe('pickExperiments', () => {
         label: '456fsf4',
         params: {
           'params.yaml': {
-            prepare: { split: 0.2 }
+            prepare: { split: 2200043556 }
           }
         },
         selected: false
@@ -116,7 +116,7 @@ describe('pickExperiments', () => {
         label: '789fsf4',
         params: {
           'params.yaml': {
-            prepare: { split: 0.3 }
+            prepare: { split: 0.000311111 }
           }
         },
         selected: false
@@ -146,7 +146,7 @@ describe('pickExperiments', () => {
           description: '[exp-456]',
           detail: `Created:${formatDate(
             mockedExperiments[1].Created as string
-          )}, split:0.2, data/data.xml:22a1a29`,
+          )}, split:2.2000e+9, data/data.xml:22a1a29`,
           label: '456fsf4',
           value: mockedExperiments[1]
         },
@@ -154,7 +154,7 @@ describe('pickExperiments', () => {
           description: '[exp-789]',
           detail: `Created:${formatDate(
             mockedExperiments[2].Created as string
-          )}, split:0.3, data/data.xml:22a1a29`,
+          )}, split:0.00031111, data/data.xml:22a1a29`,
           label: '789fsf4',
           value: mockedExperiments[2]
         }

--- a/extension/src/experiments/model/tree.test.ts
+++ b/extension/src/experiments/model/tree.test.ts
@@ -486,7 +486,7 @@ describe('ExperimentsTree', () => {
           label: 'a123',
           tooltip: `|||\n|:--|--|\n| Created | ${formatDate(
             experiments[0].Created
-          )} |\n| data/data.xml | 22a1a29 |\n| ...ms.yaml:featurize.random_value | undefined |\n`,
+          )} |\n| data/data.xml | 22a1a29 |\n| ...ms.yaml:featurize.random_value | - |\n`,
           type: ExperimentType.EXPERIMENT
         },
         {

--- a/extension/src/experiments/model/util.ts
+++ b/extension/src/experiments/model/util.ts
@@ -1,40 +1,38 @@
 import get from 'lodash.get'
 import { formatDate } from '../../util/date'
-import { truncate } from '../../util/string'
 import { splitColumnPath } from '../columns/paths'
 import { Experiment } from '../webview/contract'
 
 type Value = undefined | null | [] | string | number
 
-const getValueType = (value: Value): string => {
-  let type: string = typeof value
-  if (Number.isNaN(value)) {
-    type = 'NaN'
-  } else if (typeof value === 'string' && Date.parse(value)) {
-    type = 'date'
-  } else if (Array.isArray(value)) {
-    type = 'array'
-  } else if (value === '') {
-    type = 'empty'
-  }
-  return type
-}
+const isDate = (value: Value): boolean =>
+  !!(typeof value === 'string' && Date.parse(value))
+
+const isLongNumber = (value: Value): boolean =>
+  typeof value === 'number' && value.toString().length > 7
 
 const getStringifiedValue = (value: Value): string => {
-  const type = getValueType(value)
-  switch (type) {
-    case 'date':
-      return typeof value === 'string' ? formatDate(value) : ''
-    case 'array':
-      return `[${value?.toString()}]`
-    case 'empty':
-    case 'NaN':
-      return type
-    case 'number':
-      return truncate(String(value), 7)
-    default:
-      return String(value)
+  if (Number.isNaN(value)) {
+    return 'NaN'
   }
+
+  if (isDate(value)) {
+    return formatDate(value as string)
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value?.toString()}]`
+  }
+
+  if (value === undefined) {
+    return '-'
+  }
+
+  if (isLongNumber(value)) {
+    return (value as number).toPrecision(5)
+  }
+
+  return String(value)
 }
 
 export const getDataFromColumnPath = (

--- a/webview/src/experiments/util/buildDynamicColumns.tsx
+++ b/webview/src/experiments/util/buildDynamicColumns.tsx
@@ -40,7 +40,7 @@ const CellContents: React.FC<{ displayValue: string }> = ({ displayValue }) => (
 
 const UndefinedCell: React.FC = () => (
   <div className={styles.innerCell}>
-    <CellContents displayValue={'...'} />
+    <CellContents displayValue={'-'} />
   </div>
 )
 


### PR DESCRIPTION
This PR changes the way that we display experiment column values that are undefined in the experiments view tooltip and experiments quick pick. We now match the way that undefined is displayed in the table. I have also removed the truncation marks from truncated values as I didn't feel they added much value to the user.

Main reason for doing this is that `undefined` means nothing to the average Python user.

LMK what you think.

### Screenshots

Updated after feedback: 

<img width="1196" alt="image" src="https://user-images.githubusercontent.com/37993418/203424444-b4ebb54f-c483-49ba-a6b2-e45c2312853d.png">

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/37993418/203431045-8fb12ff1-b0e8-4356-bd7e-4731a63f1ebf.png">


<img width="1728" alt="image" src="https://user-images.githubusercontent.com/37993418/203424518-2de79ed2-51c4-47b8-bfa2-4876094d98b1.png">


