### PR TITLE
Update demo project and latest tested CLI version (2.34.3)

### DIFF
--- a/extension/src/cli/dvc/constants.ts
+++ b/extension/src/cli/dvc/constants.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 
 export const MIN_CLI_VERSION = '2.30.0'
-export const LATEST_TESTED_CLI_VERSION = '2.34.2'
+export const LATEST_TESTED_CLI_VERSION = '2.34.3'
 export const MAX_CLI_VERSION = '3'
 
 export const UNEXPECTED_ERROR_CODE = 255


### PR DESCRIPTION
DVC 2.34.3 was just released. Renovate updated the demo project. We should setup a webhook (or similar) to raise a PR in this repository.