### PR TITLE
Match open webviews welcome view button titles with command palette actions

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -392,8 +392,8 @@
         "icon": "$(graph-scatter)"
       },
       {
-        "title": "%command.showPlotsAndExperiments%",
-        "command": "dvc.showPlotsAndExperiments",
+        "title": "%command.showExperimentsAndPlots%",
+        "command": "dvc.showExperimentsAndPlots",
         "category": "DVC"
       },
       {
@@ -787,7 +787,7 @@
           "when": "dvc.commands.available && dvc.project.available"
         },
         {
-          "command": "dvc.showPlotsAndExperiments",
+          "command": "dvc.showExperimentsAndPlots",
           "when": "dvc.commands.available && dvc.project.available"
         },
         {
@@ -1350,7 +1350,7 @@
     "viewsWelcome": [
       {
         "view": "dvc.views.webviews",
-        "contents": "[Open experiments](command:dvc.showExperiments)\n[Open plots](command:dvc.showPlots)\n[Open both views](command:dvc.showPlotsAndExperiments)",
+        "contents": "[Show Experiments](command:dvc.showExperiments)\n[Show Plots](command:dvc.showPlots)\n[Show Experiments and Plots](command:dvc.showExperimentsAndPlots)",
         "when": "dvc.commands.available && dvc.project.available"
       },
       {

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -54,7 +54,7 @@
   "command.showExperiments": "Show Experiments",
   "command.showOutput": "Show DVC Output",
   "command.showPlots": "Show Plots",
-  "command.showPlotsAndExperiments": "Show Plots and Experiments",
+  "command.showExperimentsAndPlots": "Show Experiments and Plots",
   "command.stopRunningExperiment": "Stop Running Experiment",
   "command.views.experimentsColumnsTree.selectColumns": "Select Columns to Display in the Experiments Table",
   "command.views.experimentsFilterByTree.removeAllFilters": "Remove All Filters From Experiments Table",

--- a/extension/src/commands/external.ts
+++ b/extension/src/commands/external.ts
@@ -71,7 +71,7 @@ export enum RegisteredCommands {
   PLOTS_SELECT = 'dvc.views.plotsPathsTree.selectPlots',
   PLOTS_REFRESH = 'dvc.views.plotsPathsTree.refreshPlots',
 
-  PLOTS_AND_EXPERIMENT_SHOW = 'dvc.showPlotsAndExperiments',
+  EXPERIMENT_AND_PLOTS_SHOW = 'dvc.showExperimentsAndPlots',
 
   EXTENSION_CHECK_CLI_COMPATIBLE = 'dvc.checkCLICompatible',
   EXTENSION_GET_STARTED = 'dvc.getStarted',

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -239,7 +239,7 @@ export class Extension extends Disposable implements IExtension {
     registerExperimentCommands(this.experiments, this.internalCommands)
     registerPlotsCommands(this.plots, this.internalCommands)
     this.internalCommands.registerExternalCommand(
-      RegisteredCommands.PLOTS_AND_EXPERIMENT_SHOW,
+      RegisteredCommands.EXPERIMENT_AND_PLOTS_SHOW,
       async (context: VsCodeContext) => {
         await this.experiments.showWebview(
           getDvcRootFromContext(context),

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -112,7 +112,7 @@ export interface IEventNamePropertyMapping {
     wasStopped?: boolean
   }
 
-  [EventName.PLOTS_AND_EXPERIMENT_SHOW]: undefined
+  [EventName.EXPERIMENT_AND_PLOTS_SHOW]: undefined
   [EventName.EXPERIMENT_APPLY]: undefined
   [EventName.EXPERIMENT_AUTO_APPLY_FILTERS]: undefined
   [EventName.EXPERIMENT_DISABLE_AUTO_APPLY_FILTERS]: undefined

--- a/extension/src/test/e2e/extension.test.ts
+++ b/extension/src/test/e2e/extension.test.ts
@@ -112,7 +112,8 @@ suite('DVC Extension For Visual Studio Code', () => {
 
     it('should load the plots webview with non-empty plots', async () => {
       const workbench = await browser.getWorkbench()
-      await workbench.executeCommand('DVC: Show Plots')
+      await workbench.openCommandPrompt()
+      await browser.keys([...'DVC: Show Plots', 'ArrowDown', 'Enter'])
 
       await waitForDvcToFinish()
 


### PR DESCRIPTION
Minor update to button titles for the new show webviews welcome view (as discussed in the planning meeting).

### Screenshot

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/37993418/203470655-db221b68-9358-4268-ac7b-3a0b5bdd0355.png">
