### PR TITLE
Delay creation of plots to remove optional logic

### DIFF
--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -7,7 +7,6 @@ import { ResourceLocator } from '../resourceLocator'
 import { Toast } from '../vscode/toast'
 import { getInput } from '../vscode/inputBox'
 import { BaseWorkspaceWebviews } from '../webview/workspace'
-import { WorkspacePlots } from '../plots/workspace'
 import { Title } from '../vscode/title'
 import { setContextValue } from '../vscode/context'
 
@@ -58,12 +57,6 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
         setContextValue('dvc.experiment.checkpoints', workspaceHasCheckpoints)
       })
     )
-  }
-
-  public linkRepositories(workspace: WorkspacePlots) {
-    for (const [dvcRoot, repository] of Object.entries(this.repositories)) {
-      workspace.getRepository(dvcRoot).setExperiments(repository)
-    }
   }
 
   public async addFilter(overrideRoot?: string) {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -393,11 +393,14 @@ export class Extension extends Disposable implements IExtension {
         this.dvcRoots,
         this.updatesPaused,
         this.resourceLocator
-      ),
-      this.plots.create(this.dvcRoots, this.updatesPaused, this.resourceLocator)
+      )
     ])
-
-    this.experiments.linkRepositories(this.plots)
+    this.plots.create(
+      this.dvcRoots,
+      this.updatesPaused,
+      this.resourceLocator,
+      this.experiments
+    )
 
     return Promise.all([
       this.repositories.isReady(),

--- a/extension/src/plots/data/index.ts
+++ b/extension/src/plots/data/index.ts
@@ -10,11 +10,12 @@ import {
 import { PlotsModel } from '../model'
 
 export class PlotsData extends BaseData<{ data: PlotsOutput; revs: string[] }> {
-  private model?: PlotsModel
+  private readonly model: PlotsModel
 
   constructor(
     dvcRoot: string,
     internalCommands: InternalCommands,
+    model: PlotsModel,
     updatesPaused: EventEmitter<boolean>
   ) {
     super(
@@ -29,12 +30,13 @@ export class PlotsData extends BaseData<{ data: PlotsOutput; revs: string[] }> {
       ],
       ['dvc.yaml', 'dvc.lock']
     )
+    this.model = model
   }
 
   public async update(): Promise<void> {
     const revs = flattenUnique([
-      this.model?.getMissingRevisions() || [],
-      this.model?.getMutableRevisions() || []
+      this.model.getMissingRevisions(),
+      this.model.getMutableRevisions()
     ])
 
     if (
@@ -66,10 +68,6 @@ export class PlotsData extends BaseData<{ data: PlotsOutput; revs: string[] }> {
 
   public collectFiles({ data }: { data: PlotsOutput }) {
     return Object.keys(data)
-  }
-
-  public setModel(model: PlotsModel) {
-    this.model = model
   }
 
   private getArgs(revs: string[]) {

--- a/extension/src/plots/workspace.ts
+++ b/extension/src/plots/workspace.ts
@@ -3,6 +3,7 @@ import { Plots } from '.'
 import { PlotsData } from './webview/contract'
 import { ResourceLocator } from '../resourceLocator'
 import { BaseWorkspaceWebviews } from '../webview/workspace'
+import { WorkspaceExperiments } from '../experiments/workspace'
 
 export class WorkspacePlots extends BaseWorkspaceWebviews<Plots, PlotsData> {
   public readonly pathsChanged = this.dispose.track(new EventEmitter<void>())
@@ -10,12 +11,14 @@ export class WorkspacePlots extends BaseWorkspaceWebviews<Plots, PlotsData> {
   public createRepository(
     dvcRoot: string,
     updatesPaused: EventEmitter<boolean>,
-    resourceLocator: ResourceLocator
+    resourceLocator: ResourceLocator,
+    experiments: WorkspaceExperiments
   ) {
     const plots = this.dispose.track(
       new Plots(
         dvcRoot,
         this.internalCommands,
+        experiments.getRepository(dvcRoot),
         updatesPaused,
         resourceLocator.scatterGraph,
         this.workspaceState

--- a/extension/src/test/suite/plots/data/index.test.ts
+++ b/extension/src/test/suite/plots/data/index.test.ts
@@ -29,10 +29,6 @@ suite('Plots Data Test Suite', () => {
 
     stub(dvcRunner, 'isExperimentRunning').returns(experimentIsRunning)
 
-    const data = disposable.track(
-      new PlotsData(dvcDemoPath, internalCommands, updatesPaused)
-    )
-
     const mockGetMissingRevisions = stub().returns(missingRevisions)
     const mockGetMutableRevisions = stub().returns(mutableRevisions)
 
@@ -41,7 +37,14 @@ suite('Plots Data Test Suite', () => {
       getMutableRevisions: mockGetMutableRevisions
     } as unknown as PlotsModel
 
-    data.setModel(mockPlotsModel)
+    const data = disposable.track(
+      new PlotsData(
+        dvcDemoPath,
+        internalCommands,
+        mockPlotsModel,
+        updatesPaused
+      )
+    )
 
     return {
       data,

--- a/extension/src/webview/workspace.ts
+++ b/extension/src/webview/workspace.ts
@@ -2,13 +2,12 @@ import { Memento, ViewColumn } from 'vscode'
 import { BaseRepository } from './repository'
 import { WebviewData } from './contract'
 import { InternalCommands } from '../commands/internal'
-import { ResourceLocator } from '../resourceLocator'
 import { BaseWorkspace } from '../workspace'
 
 export abstract class BaseWorkspaceWebviews<
   T extends BaseRepository<U>,
   U extends WebviewData
-> extends BaseWorkspace<T, ResourceLocator> {
+> extends BaseWorkspace<T, unknown> {
   protected readonly workspaceState: Memento
 
   protected focusedWebviewDvcRoot: string | undefined

--- a/extension/src/workspace/index.ts
+++ b/extension/src/workspace/index.ts
@@ -1,13 +1,12 @@
 import { EventEmitter } from 'vscode'
 import { InternalCommands } from '../commands/internal'
-import { ResourceLocator } from '../resourceLocator'
 import { Disposables, reset } from '../util/disposable'
 import { quickPickOne } from '../vscode/quickPick'
 import { DeferredDisposable } from '../class/deferred'
 
 export abstract class BaseWorkspace<
   T extends DeferredDisposable,
-  U extends ResourceLocator | undefined = undefined
+  U = undefined
 > extends DeferredDisposable {
   protected repositories: Disposables<T> = {}
   protected readonly internalCommands: InternalCommands
@@ -21,10 +20,10 @@ export abstract class BaseWorkspace<
   public create(
     dvcRoots: string[],
     updatesPaused: EventEmitter<boolean>,
-    optional?: U
+    ...args: U[]
   ): T[] {
     const repositories = dvcRoots.map(dvcRoot =>
-      this.createRepository(dvcRoot, updatesPaused, optional)
+      this.createRepository(dvcRoot, updatesPaused, ...args)
     )
 
     Promise.all(repositories.map(repository => repository.isReady())).then(() =>
@@ -67,6 +66,6 @@ export abstract class BaseWorkspace<
   abstract createRepository(
     dvcRoot: string,
     updatesPaused: EventEmitter<boolean>,
-    arg?: U
+    ...args: U[]
   ): T
 }


### PR DESCRIPTION
This is a precursor to the work being done in #2831. We can simplify some of the logic in `Plots` and `PlotsData` by delaying the creation of plots repositories until after `Experiments` have been created for each dvc root.