### PR TITLE
Fix aspect ratio of multi view plots

### DIFF
--- a/webview/src/plots/components/styles.module.scss
+++ b/webview/src/plots/components/styles.module.scss
@@ -229,9 +229,8 @@ $resizer-border: 2px dashed $accent-color;
 }
 
 .plot.multiViewPlot {
-  aspect-ratio: calc((0.4 - 0.1 * 5 - var(--scale)) * var(--scale) + 0.2);
+  aspect-ratio: calc(0.8 * var(--scale) + 0.2);
   grid-column: span var(--scale);
-  min-width: 600px;
   width: calc(300px * var(--scale));
   max-width: max-content;
 }

--- a/webview/src/plots/components/styles.module.scss
+++ b/webview/src/plots/components/styles.module.scss
@@ -229,8 +229,9 @@ $resizer-border: 2px dashed $accent-color;
 }
 
 .plot.multiViewPlot {
-  aspect-ratio: calc(0.6 * var(--scale) + 0.2);
+  aspect-ratio: calc((0.4 - 0.1 * 5 - var(--scale)) * var(--scale) + 0.2);
   grid-column: span var(--scale);
+  min-width: 600px;
   width: calc(300px * var(--scale));
   max-width: max-content;
 }


### PR DESCRIPTION
Saw the following and thought I had inserted a bug in the multi view plots aspect ratio. Problem turned out to be something else (I'll look into it), but I reverted the aspect ratio to the one before the resize plot feature merge because it looks better (less padding).

<img width="1635" alt="Screenshot 2022-11-25 at 9 41 59 AM" src="https://user-images.githubusercontent.com/3683420/204007881-a310e857-4b11-4dab-97b4-857ca72d1008.png">
