### PR TITLE
Remove auto-merge component from renovate config (does not work)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,14 +3,6 @@
   "extends": ["config:base"],
   "packageRules": [
     {
-      "description": "Automatically merge non-major updates",
-      "automerge": true,
-      "automergeType": "branch",
-      "excludePackageNames": ["vsce"],
-      "matchDatasources": ["npm"],
-      "matchUpdateTypes": ["minor", "patch", "digest", "pin"]
-    },
-    {
       "internalChecksFilter": "strict",
       "matchDatasources": ["npm"],
       "prConcurrentLimit": 1,


### PR DESCRIPTION
Auto-merge won't work without us relaxing/updating our merge rules. Let's see how prConcurrencyLimit = 1 works out for us.