### PR TITLE
Set default chromatic viewport for table stories

### DIFF
--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -241,7 +241,6 @@ $bullet-size: calc(var(--design-unit) * 4px);
     padding-left: 1rem;
   }
   .tableContainer {
-    overflow: auto;
     flex: 1;
   }
   .table {

--- a/webview/src/stories/Table.stories.tsx
+++ b/webview/src/stories/Table.stories.tsx
@@ -19,8 +19,8 @@ import {
   findByText,
   getAllByRole
 } from '@storybook/testing-library'
-import Experiments from '../experiments/components/Experiments'
 
+import Experiments from '../experiments/components/Experiments'
 import './test-vscode-styles.scss'
 import '../shared/style.scss'
 import {
@@ -103,6 +103,7 @@ export default {
   },
   component: Experiments,
   parameters: {
+    chromatic: { viewPorts: [1600] },
     design: {
       type: 'figma',
       url: 'https://www.figma.com/file/AuQXbrFj60xA2QXOjo9Z65/Experiments-Panel-%E2%80%A2-496'


### PR DESCRIPTION
- [fix/2840]: remove overflow auto on table container
- set viewport for chromatic in table stories
