### PR TITLE
Add custom decorator to experiment table stories to maintain snapshots in storybook

### DIFF
--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -241,7 +241,6 @@ $bullet-size: calc(var(--design-unit) * 4px);
     padding-left: 1rem;
   }
   .tableContainer {
-    overflow: auto;
     flex: 1;
   }
   .table {

--- a/webview/src/stories/Table.stories.tsx
+++ b/webview/src/stories/Table.stories.tsx
@@ -102,6 +102,13 @@ export default {
     tableData
   },
   component: Experiments,
+  decorators: [
+    Story => (
+      <div style={{ overflow: 'auto' }}>
+        <Story />
+      </div>
+    )
+  ],
   parameters: {
     design: {
       type: 'figma',


### PR DESCRIPTION
- [fix/2840]: remove overflow auto on table container
- add custom decorator
