### PR TITLE
Do not process CLI errors thrown by plots diff

### DIFF
--- a/extension/src/cli/dvc/contract.ts
+++ b/extension/src/cli/dvc/contract.ts
@@ -93,3 +93,5 @@ export interface ExperimentsOutput {
 export interface PlotsOutput {
   [path: string]: Plot[]
 }
+
+export type PlotsOutputOrError = PlotsOutput | DvcError

--- a/extension/src/cli/dvc/reader.ts
+++ b/extension/src/cli/dvc/reader.ts
@@ -13,7 +13,8 @@ import {
   DataStatusOutput,
   DvcError,
   ExperimentsOutput,
-  PlotsOutput
+  PlotsOutput,
+  PlotsOutputOrError
 } from './contract'
 import { getOptions } from './options'
 import { typeCheckCommands } from '..'
@@ -29,7 +30,8 @@ export const isDvcError = <
   T extends ExperimentsOutput | DataStatusOutput | PlotsOutput
 >(
   dataOrError: T | DvcError
-): dataOrError is DvcError => !!(dataOrError as DvcError).error
+): dataOrError is DvcError =>
+  !!(Object.keys(dataOrError).length === 1 && (dataOrError as DvcError).error)
 
 export const autoRegisteredCommands = {
   DATA_STATUS: 'dataStatus',
@@ -80,7 +82,7 @@ export class DvcReader extends DvcCli {
   public plotsDiff(
     cwd: string,
     ...revisions: string[]
-  ): Promise<PlotsOutput | DvcError> {
+  ): Promise<PlotsOutputOrError> {
     return this.readProcessJson<PlotsOutput>(
       cwd,
       Command.PLOTS,
@@ -127,7 +129,7 @@ export class DvcReader extends DvcCli {
     } catch (error: unknown) {
       const msg =
         (error as MaybeConsoleError).stderr || (error as Error).message
-      Logger.error(`${args} failed with ${msg} retrying...`)
+      Logger.error(`${args} failed with ${msg}`)
       return { error: { msg, type: 'Caught error' } }
     }
   }

--- a/extension/src/data/index.ts
+++ b/extension/src/data/index.ts
@@ -7,12 +7,12 @@ import {
 } from '../fileSystem/watcher'
 import { ProcessManager } from '../processManager'
 import { InternalCommands } from '../commands/internal'
-import { ExperimentsOutput, PlotsOutput } from '../cli/dvc/contract'
+import { ExperimentsOutput, PlotsOutputOrError } from '../cli/dvc/contract'
 import { definedAndNonEmpty, sameContents, uniqueValues } from '../util/array'
 import { DeferredDisposable } from '../class/deferred'
 
 export abstract class BaseData<
-  T extends { data: PlotsOutput; revs: string[] } | ExperimentsOutput
+  T extends { data: PlotsOutputOrError; revs: string[] } | ExperimentsOutput
 > extends DeferredDisposable {
   public readonly onDidUpdate: Event<T>
 

--- a/extension/src/plots/model/index.ts
+++ b/extension/src/plots/model/index.ts
@@ -25,7 +25,7 @@ import {
   SectionCollapsed,
   PlotSizeNumber
 } from '../webview/contract'
-import { ExperimentsOutput, PlotsOutput } from '../../cli/dvc/contract'
+import { ExperimentsOutput, PlotsOutputOrError } from '../../cli/dvc/contract'
 import { Experiments } from '../../experiments'
 import { getColorScale, truncateVerticalTitle } from '../vega/util'
 import { definedAndNonEmpty, reorderObjectList } from '../../util/array'
@@ -39,6 +39,7 @@ import {
   MultiSourceEncoding,
   MultiSourceVariations
 } from '../multiSource/collect'
+import { isDvcError } from '../../cli/dvc/reader'
 
 export class PlotsModel extends ModelWithPersistence {
   private readonly experiments: Experiments
@@ -104,7 +105,11 @@ export class PlotsModel extends ModelWithPersistence {
     return this.removeStaleData()
   }
 
-  public async transformAndSetPlots(data: PlotsOutput, revs: string[]) {
+  public async transformAndSetPlots(data: PlotsOutputOrError, revs: string[]) {
+    if (isDvcError(data)) {
+      return
+    }
+
     const cliIdToLabel = this.getCLIIdToLabel()
 
     this.fetchedRevs = new Set([

--- a/extension/src/plots/paths/model.test.ts
+++ b/extension/src/plots/paths/model.test.ts
@@ -257,4 +257,16 @@ describe('PathsModel', () => {
     const noChildren = model.getChildren(logsLoss)
     expect(noChildren).toStrictEqual([])
   })
+
+  it('should not provide error as a path when the CLI throws an error', () => {
+    const model = new PathsModel(mockDvcRoot, buildMockMemento())
+    model.transformAndSet({
+      error: {
+        msg: 'UNEXPECTED ERROR: a strange thing happened',
+        type: 'Caught Error'
+      }
+    })
+
+    expect(model.getTerminalNodes()).toStrictEqual([])
+  })
 })

--- a/extension/src/plots/paths/model.ts
+++ b/extension/src/plots/paths/model.ts
@@ -6,11 +6,12 @@ import {
   PlotPath,
   TemplateOrder
 } from './collect'
-import { PlotsOutput } from '../../cli/dvc/contract'
 import { PathSelectionModel } from '../../path/selection/model'
 import { PersistenceKey } from '../../persistence/constants'
 import { performSimpleOrderedUpdate } from '../../util/array'
 import { MultiSourceEncoding } from '../multiSource/collect'
+import { isDvcError } from '../../cli/dvc/reader'
+import { PlotsOutputOrError } from '../../cli/dvc/contract'
 
 export class PathsModel extends PathSelectionModel<PlotPath> {
   private templateOrder: TemplateOrder
@@ -26,7 +27,11 @@ export class PathsModel extends PathSelectionModel<PlotPath> {
     )
   }
 
-  public transformAndSet(data: PlotsOutput) {
+  public transformAndSet(data: PlotsOutputOrError) {
+    if (isDvcError(data)) {
+      return
+    }
+
     const paths = collectPaths(this.data, data)
 
     this.setNewStatuses(paths)


### PR DESCRIPTION
# 1/2 `main` <- this <- #2854

Addresses [this comment](https://github.com/iterative/vscode-dvc/issues/1649#issuecomment-1295969178) from #1649.

We will not display "error" as a node in the plots tree. As a quick solution, I've excluded CLI errors from all processing by the extension. This will be reworked when we return to #1649 but in the interim, this will stop the code from falling over.