### PR TITLE
Fix plots file watchers (diff output key is not always a file)

### DIFF
--- a/extension/src/data/index.ts
+++ b/extension/src/data/index.ts
@@ -108,7 +108,7 @@ export abstract class BaseData<
     )
   }
 
-  abstract collectFiles(data: T): string[]
-
   abstract managedUpdate(path?: string): Promise<unknown>
+
+  protected abstract collectFiles(data: T): string[]
 }

--- a/extension/src/experiments/data/index.ts
+++ b/extension/src/experiments/data/index.ts
@@ -43,10 +43,6 @@ export class ExperimentsData extends BaseData<ExperimentsOutput> {
     this.managedUpdate(QUEUED_EXPERIMENT_PATH)
   }
 
-  public collectFiles(data: ExperimentsOutput) {
-    return collectFiles(data, this.collectedFiles)
-  }
-
   public managedUpdate(path?: string) {
     if (
       path?.includes(QUEUED_EXPERIMENT_PATH) ||
@@ -74,6 +70,10 @@ export class ExperimentsData extends BaseData<ExperimentsOutput> {
 
   public forceUpdate() {
     return this.processManager.forceRunQueued()
+  }
+
+  protected collectFiles(data: ExperimentsOutput) {
+    return collectFiles(data, this.collectedFiles)
   }
 
   private async watchExpGitRefs(): Promise<void> {

--- a/extension/src/plots/data/collect.ts
+++ b/extension/src/plots/data/collect.ts
@@ -1,0 +1,58 @@
+import { PlotsOutputOrError } from '../../cli/dvc/contract'
+import { isDvcError } from '../../cli/dvc/reader'
+import { uniqueValues } from '../../util/array'
+import { isImagePlot, Plot, TemplatePlot } from '../webview/contract'
+
+const collectImageFile = (acc: string[], file: string): void => {
+  if (acc.includes(file)) {
+    return
+  }
+  acc.push(file)
+}
+
+const collectFromDatapoint = (
+  acc: string[],
+  data: Record<string, unknown>
+): void => {
+  const filename = (data as { dvc_data_version_info?: { filename?: string } })
+    ?.dvc_data_version_info?.filename
+
+  if (!filename || acc.includes(filename)) {
+    return
+  }
+  acc.push(filename)
+}
+
+const collectTemplateFiles = (acc: string[], plot: TemplatePlot): void => {
+  for (const datapoints of Object.values(plot.datapoints || {})) {
+    for (const datapoint of datapoints) {
+      collectFromDatapoint(acc, datapoint)
+    }
+  }
+}
+
+const collectKeyData = (acc: string[], key: string, plots: Plot[]): void => {
+  for (const plot of plots) {
+    if (isImagePlot(plot)) {
+      collectImageFile(acc, key)
+      continue
+    }
+    collectTemplateFiles(acc, plot)
+  }
+}
+
+export const collectFiles = (
+  data: PlotsOutputOrError,
+  collectedFiles: string[]
+): string[] => {
+  const acc = [...collectedFiles]
+  if (isDvcError(data)) {
+    return acc
+  }
+
+  for (const [key, plots] of Object.entries(data)) {
+    collectKeyData(acc, key, plots)
+  }
+
+  return uniqueValues(acc)
+}

--- a/extension/src/plots/data/index.ts
+++ b/extension/src/plots/data/index.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'vscode'
+import { collectFiles } from './collect'
 import { PlotsOutputOrError } from '../../cli/dvc/contract'
-import { isDvcError } from '../../cli/dvc/reader'
 import { AvailableCommands, InternalCommands } from '../../commands/internal'
 import { BaseData } from '../../data'
 import {
@@ -59,22 +59,19 @@ export class PlotsData extends BaseData<{
       ...args
     )
 
+    this.notifyChanged({ data, revs })
+
     const files = this.collectFiles({ data })
 
     this.compareFiles(files)
-
-    return this.notifyChanged({ data, revs })
   }
 
   public managedUpdate() {
     return this.processManager.run('update')
   }
 
-  public collectFiles({ data }: { data: PlotsOutputOrError }) {
-    if (isDvcError(data)) {
-      return this.collectedFiles
-    }
-    return [...Object.keys(data), ...this.collectedFiles]
+  protected collectFiles({ data }: { data: PlotsOutputOrError }) {
+    return collectFiles(data, this.collectedFiles)
   }
 
   private getArgs(revs: string[]) {

--- a/extension/src/test/suite/plots/data/index.test.ts
+++ b/extension/src/test/suite/plots/data/index.test.ts
@@ -1,3 +1,4 @@
+import { join } from 'path'
 import { afterEach, beforeEach, describe, it, suite } from 'mocha'
 import { expect } from 'chai'
 import { restore, stub } from 'sinon'
@@ -5,7 +6,9 @@ import { Disposable } from '../../../../extension'
 import { PlotsData } from '../../../../plots/data'
 import { PlotsModel } from '../../../../plots/model'
 import { dvcDemoPath } from '../../../util'
-import { buildDependencies } from '../../util'
+import { buildDependencies, getFirstArgOfLastCall } from '../../util'
+import { getRelativePattern } from '../../../../fileSystem/watcher'
+import multiSourcePlotsDiffFixture from '../../../fixtures/plotsDiff/output/multiSource'
 
 suite('Plots Data Test Suite', () => {
   const disposable = Disposable.fn()
@@ -24,8 +27,13 @@ suite('Plots Data Test Suite', () => {
     missingRevisions: string[] = [],
     mutableRevisions: string[] = []
   ) => {
-    const { internalCommands, updatesPaused, mockPlotsDiff, dvcRunner } =
-      buildDependencies(disposable)
+    const {
+      internalCommands,
+      updatesPaused,
+      mockPlotsDiff,
+      dvcRunner,
+      mockCreateFileSystemWatcher
+    } = buildDependencies(disposable)
 
     stub(dvcRunner, 'isExperimentRunning').returns(experimentIsRunning)
 
@@ -48,6 +56,7 @@ suite('Plots Data Test Suite', () => {
 
     return {
       data,
+      mockCreateFileSystemWatcher,
       mockPlotsDiff
     }
   }
@@ -122,6 +131,42 @@ suite('Plots Data Test Suite', () => {
         '42b8736',
         '4fb124a',
         '53c3851'
+      )
+    })
+
+    it('should handle watching paths for top level plots', async () => {
+      const { data, mockPlotsDiff, mockCreateFileSystemWatcher } =
+        buildPlotsData(false)
+
+      const dataUpdatedEvent = new Promise(resolve =>
+        disposable.track(data.onDidUpdate(() => resolve(undefined)))
+      )
+
+      mockPlotsDiff.resolves(multiSourcePlotsDiffFixture)
+
+      data.update()
+
+      await dataUpdatedEvent
+
+      expect(getFirstArgOfLastCall(mockCreateFileSystemWatcher)).to.deep.equal(
+        getRelativePattern(
+          dvcDemoPath,
+          join(
+            '**',
+            '{' +
+              'dvc.yaml,' +
+              'dvc.lock,' +
+              [
+                join('evaluation', 'test', 'plots', 'confusion_matrix.json'),
+                join('evaluation', 'test', 'plots', 'precision_recall.json'),
+                join('evaluation', 'test', 'plots', 'roc.json'),
+                join('evaluation', 'train', 'plots', 'confusion_matrix.json'),
+                join('evaluation', 'train', 'plots', 'precision_recall.json'),
+                join('evaluation', 'train', 'plots', 'roc.json')
+              ].join(',') +
+              '}'
+          )
+        )
       )
     })
   })


### PR DESCRIPTION
# 2/2 `main` <- #2852 <- this

Closes #2851.

<img width="482" alt="image" src="https://user-images.githubusercontent.com/37993418/204439570-774e0c50-eb48-48d2-a593-6599ffa59bca.png">

☝🏻 I actually remembered correctly.

Unfortunately, I realised that the key can actually be the plot's title which means we need to interrogate the data 😢. 
