### PR TITLE
Separate comparison table and plot ribbon revision orders

### DIFF
--- a/extension/src/plots/model/collect.test.ts
+++ b/extension/src/plots/model/collect.test.ts
@@ -365,72 +365,236 @@ describe('collectWorkspaceRaceConditionData', () => {
 describe('collectOverrideRevisionDetails', () => {
   it('should override the revision details for running checkpoint tips', () => {
     const runningId = 'b'
+    const runningGroup = `[${runningId}]`
 
-    const { overrideOrder, overrideRevisions, unfinishedRunningExperiments } =
+    const {
+      overrideComparison,
+      overrideRevisions,
+      unfinishedRunningExperiments
+    } = collectOverrideRevisionDetails(
+      ['a', 'b', 'c', 'd'],
+      [
+        {
+          checkpoint_tip: 'b',
+          displayColor: '#4299e1',
+          id: 'a',
+          label: 'a',
+          logicalGroupName: 'a',
+          sha: 'a',
+          status: ExperimentStatus.SUCCESS
+        },
+        {
+          checkpoint_tip: 'b',
+          displayColor: '#13adc7',
+          id: runningId,
+          label: 'b',
+          logicalGroupName: runningGroup,
+          sha: 'b',
+          status: ExperimentStatus.RUNNING
+        },
+        {
+          checkpoint_tip: 'c',
+          displayColor: '#48bb78',
+          id: 'c',
+          label: 'c',
+          logicalGroupName: 'c',
+          sha: 'c',
+          status: ExperimentStatus.SUCCESS
+        },
+        {
+          checkpoint_tip: 'd',
+          displayColor: '#f56565',
+          id: 'd',
+          label: 'd',
+          logicalGroupName: 'd',
+          sha: 'd',
+          status: ExperimentStatus.SUCCESS
+        }
+      ] as SelectedExperimentWithColor[],
+      new Set(['a', 'c', 'd', 'e']),
+      new Set(),
+      (id: string) =>
+        ({
+          [runningId]: [
+            {
+              checkpoint_tip: 'f',
+              id: 'f',
+              label: 'f',
+              logicalGroupName: runningGroup,
+              sha: 'f',
+              status: ExperimentStatus.SUCCESS
+            },
+            {
+              checkpoint_tip: 'e',
+              id: 'e',
+              label: 'e',
+              logicalGroupName: runningGroup,
+              sha: 'e',
+              status: ExperimentStatus.SUCCESS
+            }
+          ] as Experiment[]
+        }[id])
+    )
+    expect(overrideComparison.map(({ revision }) => revision)).toStrictEqual([
+      'a',
+      'e',
+      'c',
+      'd'
+    ])
+    expect(overrideRevisions).toStrictEqual([
+      {
+        displayColor: '#4299e1',
+        fetched: true,
+        group: 'a',
+        id: 'a',
+        revision: 'a'
+      },
+      {
+        displayColor: '#13adc7',
+        fetched: true,
+        group: runningGroup,
+        id: 'e',
+        revision: 'e'
+      },
+      {
+        displayColor: '#48bb78',
+        fetched: true,
+        group: 'c',
+        id: 'c',
+        revision: 'c'
+      },
+
+      {
+        displayColor: '#f56565',
+        fetched: true,
+        group: 'd',
+        id: 'd',
+        revision: 'd'
+      }
+    ])
+    expect(unfinishedRunningExperiments).toStrictEqual(new Set([runningId]))
+  })
+
+  it('should order the comparison revisions according to the provided', () => {
+    const runningId = 'b'
+    const runningGroup = `[${runningId}]`
+
+    const { overrideComparison, overrideRevisions } =
       collectOverrideRevisionDetails(
-        ['a', 'b', 'c', 'd'],
+        ['a', 'b', 'c', 'd'].reverse(),
         [
-          { label: 'a' },
+          {
+            checkpoint_tip: 'b',
+            displayColor: '#4299e1',
+            id: 'a',
+            label: 'a',
+            logicalGroupName: 'a',
+            sha: 'a',
+            status: ExperimentStatus.SUCCESS
+          },
           {
             checkpoint_tip: 'b',
             displayColor: '#13adc7',
             id: runningId,
             label: 'b',
+            logicalGroupName: runningGroup,
             sha: 'b',
             status: ExperimentStatus.RUNNING
           },
-          { label: 'c' },
-          { label: 'd' }
+          {
+            checkpoint_tip: 'c',
+            displayColor: '#48bb78',
+            id: 'c',
+            label: 'c',
+            logicalGroupName: 'c',
+            sha: 'c',
+            status: ExperimentStatus.SUCCESS
+          },
+          {
+            checkpoint_tip: 'd',
+            displayColor: '#f56565',
+            id: 'd',
+            label: 'd',
+            logicalGroupName: 'd',
+            sha: 'd',
+            status: ExperimentStatus.SUCCESS
+          }
         ] as SelectedExperimentWithColor[],
         new Set(['a', 'c', 'd', 'e']),
         new Set(),
-        (id: string) => ({ [runningId]: [{ label: 'e' }] as Experiment[] }[id])
+        (id: string) =>
+          ({
+            [runningId]: [
+              {
+                checkpoint_tip: 'f',
+                id: 'f',
+                label: 'f',
+                logicalGroupName: runningGroup,
+                sha: 'f',
+                status: ExperimentStatus.SUCCESS
+              },
+              {
+                checkpoint_tip: 'e',
+                id: 'e',
+                label: 'e',
+                logicalGroupName: runningGroup,
+                sha: 'e',
+                status: ExperimentStatus.SUCCESS
+              }
+            ] as Experiment[]
+          }[id])
       )
-    expect(overrideOrder).toStrictEqual(['a', 'e', 'c', 'd'])
-    expect(overrideRevisions).toStrictEqual([
-      { label: 'a' },
-      {
-        displayColor: '#13adc7',
-        label: 'e'
-      },
-      { label: 'c' },
-      { label: 'd' }
+    expect(overrideComparison.map(({ revision }) => revision)).toStrictEqual([
+      'd',
+      'c',
+      'e',
+      'a'
     ])
-    expect(unfinishedRunningExperiments).toStrictEqual(new Set([runningId]))
+    expect(overrideRevisions.map(({ revision }) => revision)).toStrictEqual([
+      'a',
+      'e',
+      'c',
+      'd'
+    ])
   })
 
   it('should override the revision details for finished but unfetched checkpoint tips', () => {
     const justFinishedRunningId = 'exp-was-running'
-    const { overrideOrder, overrideRevisions, unfinishedRunningExperiments } =
-      collectOverrideRevisionDetails(
-        ['a', 'b', 'c', 'd'],
-        [
-          { label: 'a' },
-          {
-            checkpoint_tip: 'b',
-            displayColor: '#13adc7',
-            id: justFinishedRunningId,
-            label: 'b',
-            sha: 'b',
-            status: ExperimentStatus.SUCCESS
-          },
-          { label: 'c' },
-          { label: 'd' }
-        ] as SelectedExperimentWithColor[],
-        new Set(['a', 'c', 'd', 'e']),
-        new Set([justFinishedRunningId]),
-        (id: string) =>
-          ({ [justFinishedRunningId]: [{ label: 'e' }] as Experiment[] }[id])
-      )
-    expect(overrideOrder).toStrictEqual(['a', 'e', 'c', 'd'])
-    expect(overrideRevisions).toStrictEqual([
-      { label: 'a' },
-      {
-        displayColor: '#13adc7',
-        label: 'e'
-      },
-      { label: 'c' },
-      { label: 'd' }
+    const {
+      overrideComparison,
+      overrideRevisions,
+      unfinishedRunningExperiments
+    } = collectOverrideRevisionDetails(
+      ['a', 'b', 'c', 'd'],
+      [
+        { label: 'a' },
+        {
+          checkpoint_tip: 'b',
+          displayColor: '#13adc7',
+          id: justFinishedRunningId,
+          label: 'b',
+          sha: 'b',
+          status: ExperimentStatus.SUCCESS
+        },
+        { label: 'c' },
+        { label: 'd' }
+      ] as SelectedExperimentWithColor[],
+      new Set(['a', 'c', 'd', 'e']),
+      new Set([justFinishedRunningId]),
+      (id: string) =>
+        ({ [justFinishedRunningId]: [{ label: 'e' }] as Experiment[] }[id])
+    )
+    expect(overrideComparison.map(({ revision }) => revision)).toStrictEqual([
+      'a',
+      'e',
+      'c',
+      'd'
+    ])
+    expect(overrideRevisions.map(({ revision }) => revision)).toStrictEqual([
+      'a',
+      'e',
+      'c',
+      'd'
     ])
     expect(unfinishedRunningExperiments).toStrictEqual(
       new Set([justFinishedRunningId])
@@ -439,33 +603,74 @@ describe('collectOverrideRevisionDetails', () => {
 
   it('should remove the id from the unfinishedRunningExperiments set once the revision has been fetched', () => {
     const justFinishedRunningId = 'exp-was-running'
-    const { overrideOrder, overrideRevisions, unfinishedRunningExperiments } =
-      collectOverrideRevisionDetails(
-        ['a', 'b', 'c', 'd'],
-        [
-          { label: 'a' },
-          {
-            checkpoint_tip: 'b',
-            displayColor: '#13adc7',
-            id: justFinishedRunningId,
-            label: 'b',
-            sha: 'b',
-            status: ExperimentStatus.SUCCESS
-          },
-          { label: 'c' },
-          { label: 'd' }
-        ] as SelectedExperimentWithColor[],
-        new Set(['a', 'b', 'c', 'd', 'e']),
-        new Set([justFinishedRunningId]),
-        (id: string) =>
-          ({ [justFinishedRunningId]: [{ label: 'e' }] as Experiment[] }[id])
-      )
-    expect(overrideOrder).toStrictEqual(['a', 'b', 'c', 'd'])
-    expect(overrideRevisions).toStrictEqual([
-      { label: 'a' },
-      expect.objectContaining({ label: 'b' }),
-      { label: 'c' },
-      { label: 'd' }
+    const justFinishedRunningGroup = `[${justFinishedRunningId}]`
+    const {
+      overrideComparison,
+      overrideRevisions,
+      unfinishedRunningExperiments
+    } = collectOverrideRevisionDetails(
+      ['a', 'b', 'c', 'd'],
+      [
+        {
+          checkpoint_tip: 'b',
+          displayColor: '#ed8936',
+          id: 'a',
+          label: 'a',
+          logicalGroupName: justFinishedRunningGroup,
+          sha: 'a'
+        },
+        {
+          checkpoint_tip: 'b',
+          displayColor: '#13adc7',
+          id: justFinishedRunningId,
+          label: 'b',
+          logicalGroupName: justFinishedRunningGroup,
+          sha: 'b',
+          status: ExperimentStatus.SUCCESS
+        },
+        {
+          checkpoint_tip: 'q',
+          displayColor: '#48bb78',
+          id: 'c',
+          label: 'c',
+          logicalGroupName: 'c',
+          sha: 'c'
+        },
+        {
+          checkpoint_tip: 'q',
+          displayColor: '#f46837',
+          id: 'd',
+          label: 'd',
+          logicalGroupName: 'c',
+          sha: 'd'
+        }
+      ] as SelectedExperimentWithColor[],
+      new Set(['a', 'b', 'c', 'd', 'e']),
+      new Set([justFinishedRunningId]),
+      (id: string) =>
+        ({
+          [justFinishedRunningId]: [
+            {
+              checkpoint_tip: 'b',
+              id: 'e',
+              label: 'e',
+              logicalGroupName: justFinishedRunningGroup,
+              sha: 'e'
+            }
+          ] as Experiment[]
+        }[id])
+    )
+    expect(overrideComparison.map(({ revision }) => revision)).toStrictEqual([
+      'a',
+      'b',
+      'c',
+      'd'
+    ])
+    expect(overrideRevisions.map(({ revision }) => revision)).toStrictEqual([
+      'a',
+      'b',
+      'c',
+      'd'
     ])
     expect(unfinishedRunningExperiments).toStrictEqual(new Set([]))
   })

--- a/extension/src/plots/model/index.test.ts
+++ b/extension/src/plots/model/index.test.ts
@@ -125,7 +125,7 @@ describe('plotsModel', () => {
     )
 
     expect(
-      model.getSelectedRevisionDetails().map(({ revision }) => revision)
+      model.getComparisonRevisions().map(({ revision }) => revision)
     ).toStrictEqual(newOrder)
   })
 
@@ -137,7 +137,7 @@ describe('plotsModel', () => {
     model.setComparisonOrder(newOrder)
 
     expect(
-      model.getSelectedRevisionDetails().map(({ revision }) => revision)
+      model.getComparisonRevisions().map(({ revision }) => revision)
     ).toStrictEqual([
       ...newOrder,
       ...mockedRevisions
@@ -163,19 +163,19 @@ describe('plotsModel', () => {
     model.setComparisonOrder(initialOrder)
 
     expect(
-      model.getSelectedRevisionDetails().map(({ revision }) => revision)
+      model.getComparisonRevisions().map(({ revision }) => revision)
     ).toStrictEqual(initialOrder)
 
     model.setComparisonOrder()
 
     expect(
-      model.getSelectedRevisionDetails().map(({ revision }) => revision)
+      model.getComparisonRevisions().map(({ revision }) => revision)
     ).toStrictEqual(initialOrder.filter(revision => revision !== 'main'))
 
     model.setComparisonOrder()
 
     expect(
-      model.getSelectedRevisionDetails().map(({ revision }) => revision)
+      model.getComparisonRevisions().map(({ revision }) => revision)
     ).toStrictEqual(['workspace', '71f31cf', 'main'])
   })
 })

--- a/extension/src/plots/webview/contract.ts
+++ b/extension/src/plots/webview/contract.ts
@@ -46,6 +46,7 @@ export type Revision = {
 export interface PlotsComparisonData {
   plots: ComparisonPlots
   size: number
+  revisions: Revision[]
 }
 
 export type CheckpointPlotValues = {

--- a/extension/src/plots/webview/messages.ts
+++ b/extension/src/plots/webview/messages.ts
@@ -49,17 +49,17 @@ export class WebviewMessages {
   }
 
   public sendWebviewMessage() {
-    const selectedRevisions = this.plots.getOverrideRevisionDetails()
-    const selectedLabels = selectedRevisions.map(({ revision }) => revision)
+    const { overrideComparison, overrideRevisions } =
+      this.plots.getOverrideRevisionDetails()
 
     this.getWebview()?.show({
       checkpoint: this.getCheckpointPlots(),
-      comparison: this.getComparisonPlots(selectedLabels),
+      comparison: this.getComparisonPlots(overrideComparison),
       hasPlots: !!this.paths?.hasPaths(),
       hasSelectedPlots: definedAndNonEmpty(this.paths.getSelected()),
       sectionCollapsed: this.plots.getSectionCollapsed(),
-      selectedRevisions,
-      template: this.getTemplatePlots(selectedRevisions)
+      selectedRevisions: overrideRevisions,
+      template: this.getTemplatePlots(overrideRevisions)
     })
   }
 
@@ -223,8 +223,7 @@ export class WebviewMessages {
 
   private sendComparisonPlots() {
     this.getWebview()?.show({
-      comparison: this.getComparisonPlots(),
-      selectedRevisions: this.plots.getSelectedRevisionDetails()
+      comparison: this.getComparisonPlots()
     })
   }
 
@@ -248,9 +247,12 @@ export class WebviewMessages {
     }
   }
 
-  private getComparisonPlots(overrideRevs?: string[]) {
+  private getComparisonPlots(overrideRevs?: Revision[]) {
     const paths = this.paths.getComparisonPaths()
-    const comparison = this.plots.getComparisonPlots(paths, overrideRevs)
+    const comparison = this.plots.getComparisonPlots(
+      paths,
+      overrideRevs?.map(({ revision }) => revision)
+    )
     if (!comparison || isEmpty(comparison)) {
       return null
     }
@@ -259,6 +261,7 @@ export class WebviewMessages {
       plots: comparison.map(({ path, revisions }) => {
         return { path, revisions: this.getRevisionsWithCorrectUrls(revisions) }
       }),
+      revisions: overrideRevs || this.plots.getComparisonRevisions(),
       size: this.plots.getPlotSize(Section.COMPARISON_TABLE)
     }
   }

--- a/extension/src/test/fixtures/plotsDiff/index.ts
+++ b/extension/src/test/fixtures/plotsDiff/index.ts
@@ -10,7 +10,9 @@ import {
   TemplatePlotGroup,
   TemplatePlotsData,
   TemplatePlots,
-  PlotSizeNumber
+  PlotSizeNumber,
+  Revision,
+  PlotsComparisonData
 } from '../../../plots/webview/contract'
 import { join } from '../../util/path'
 import { copyOriginalColors } from '../../../experiments/model/status/colors'
@@ -506,7 +508,7 @@ const extendedSpecs = (plotsOutput: TemplatePlots): TemplatePlotSection[] => {
   return [singleViewPlots, multiViewPlots]
 }
 
-export const getRevisions = () => {
+export const getRevisions = (): Revision[] => {
   const [workspace, main, _4fb124a, _42b8735, _1ba7bcd] = copyOriginalColors()
   return [
     {
@@ -572,7 +574,7 @@ export const MOCK_IMAGE_MTIME = 946684800000
 export const getComparisonWebviewMessage = (
   baseUrl: string,
   joinFunc?: (...args: string[]) => string
-) => {
+): PlotsComparisonData => {
   const plotAcc = [] as ComparisonPlots
   for (const [path, plots] of Object.entries(getImageData(baseUrl, joinFunc))) {
     const revisionsAcc: ComparisonRevisionData = {}
@@ -588,6 +590,7 @@ export const getComparisonWebviewMessage = (
   }
 
   return {
+    revisions: getRevisions(),
     plots: plotAcc,
     size: PlotSizeNumber.REGULAR
   }

--- a/extension/src/test/suite/experiments/model/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/tree.test.ts
@@ -356,6 +356,13 @@ suite('Experiments Tree Test Suite', () => {
           revision: 'workspace'
         },
         {
+          displayColor: colors[1],
+          fetched: true,
+          group: '[exp-83425]',
+          id: '23250b33e3d6dd0e136262d1d26a2face031cb03',
+          revision: '23250b3'
+        },
+        {
           displayColor: colors[2],
           fetched: true,
           group: '[exp-e7a67]',
@@ -368,13 +375,6 @@ suite('Experiments Tree Test Suite', () => {
           group: '[test-branch]',
           id: 'test-branch',
           revision: '42b8736'
-        },
-        {
-          displayColor: colors[1],
-          fetched: true,
-          group: '[exp-83425]',
-          id: '23250b33e3d6dd0e136262d1d26a2face031cb03',
-          revision: '23250b3'
         },
         {
           displayColor: colors[4],

--- a/extension/src/test/suite/plots/index.test.ts
+++ b/extension/src/test/suite/plots/index.test.ts
@@ -425,12 +425,14 @@ suite('Plots Test Suite', () => {
         messageSpy,
         "should update the webview's comparison revision state"
       ).to.be.calledWithExactly({
-        comparison: comparisonPlotsFixture,
-        selectedRevisions: reorderObjectList(
-          mockComparisonOrder,
-          plotsRevisionsFixture,
-          'revision'
-        )
+        comparison: {
+          ...comparisonPlotsFixture,
+          revisions: reorderObjectList(
+            mockComparisonOrder,
+            comparisonPlotsFixture.revisions,
+            'revision'
+          )
+        }
       })
       expect(mockSendTelemetryEvent).to.be.calledOnce
       expect(mockSendTelemetryEvent).to.be.calledWithExactly(
@@ -483,8 +485,7 @@ suite('Plots Test Suite', () => {
             comparisonPlotsFixture.plots,
             'path'
           )
-        },
-        selectedRevisions: plotsRevisionsFixture
+        }
       })
       expect(mockSendTelemetryEvent).to.be.calledOnce
       expect(mockSendTelemetryEvent).to.be.calledWithExactly(

--- a/webview/src/plots/components/comparisonTable/ComparisonTable.test.tsx
+++ b/webview/src/plots/components/comparisonTable/ComparisonTable.test.tsx
@@ -63,7 +63,6 @@ describe('ComparisonTable', () => {
 
   const renderTable = (
     props = comparisonTableFixture,
-    revisions: Revision[] = plotsRevisionsFixture,
     renderWith: (ui: React.ReactElement) => RenderResult | void = render
   ) => {
     return (
@@ -77,7 +76,6 @@ describe('ComparisonTable', () => {
               },
               webview: {
                 ...webviewInitialState,
-                selectedRevisions: revisions,
                 zoomedInPlot: undefined
               }
             },
@@ -230,7 +228,13 @@ describe('ComparisonTable', () => {
       ({ revision }) => revision !== revisions[3]
     )
 
-    renderTable(comparisonTableFixture, filteredRevisions, rerender)
+    renderTable(
+      {
+        ...comparisonTableFixture,
+        revisions: filteredRevisions
+      },
+      rerender
+    )
 
     headers = getHeaders().map(header => header.textContent)
 
@@ -250,7 +254,10 @@ describe('ComparisonTable', () => {
       { displayColor: '#000000', fetched: true, revision: newRevName }
     ] as Revision[]
 
-    renderTable(comparisonTableFixture, newRevisions, rerender)
+    renderTable(
+      { ...comparisonTableFixture, revisions: newRevisions },
+      rerender
+    )
     const headers = getHeaders().map(header => header.textContent)
 
     expect(headers).toStrictEqual([...namedRevisions, newRevName])
@@ -259,22 +266,20 @@ describe('ComparisonTable', () => {
   it('should display a refresh button for each revision that has a missing image', () => {
     const revisionWithNoData = 'missing-data'
 
-    renderTable(
-      {
-        ...comparisonTableFixture,
-        plots: comparisonTableFixture.plots.map(({ path, revisions }) => ({
-          path,
-          revisions: {
-            ...revisions,
-            [revisionWithNoData]: {
-              revision: revisionWithNoData,
-              url: undefined
-            }
+    renderTable({
+      ...comparisonTableFixture,
+      plots: comparisonTableFixture.plots.map(({ path, revisions }) => ({
+        path,
+        revisions: {
+          ...revisions,
+          [revisionWithNoData]: {
+            revision: revisionWithNoData,
+            url: undefined
           }
-        }))
-      },
-      [
-        ...selectedRevisions,
+        }
+      })),
+      revisions: [
+        ...comparisonTableFixture.revisions,
         {
           displayColor: '#f56565',
           fetched: true,
@@ -283,7 +288,7 @@ describe('ComparisonTable', () => {
           revision: revisionWithNoData
         }
       ]
-    )
+    })
 
     const refreshButtons = screen.getAllByText('Refresh')
 

--- a/webview/src/plots/components/comparisonTable/ComparisonTable.tsx
+++ b/webview/src/plots/components/comparisonTable/ComparisonTable.tsx
@@ -15,10 +15,8 @@ import { PlotsState } from '../../store'
 import { EmptyState } from '../../../shared/components/emptyState/EmptyState'
 
 export const ComparisonTable: React.FC = () => {
-  const { plots } = useSelector((state: PlotsState) => state.comparison)
-
-  const { selectedRevisions: revisions } = useSelector(
-    (state: PlotsState) => state.webview
+  const { revisions, plots } = useSelector(
+    (state: PlotsState) => state.comparison
   )
 
   const pinnedColumn = useRef('')

--- a/webview/src/plots/components/comparisonTable/comparisonTableSlice.ts
+++ b/webview/src/plots/components/comparisonTable/comparisonTableSlice.ts
@@ -18,6 +18,7 @@ export const comparisonTableInitialState: ComparisonTableState = {
   hasData: false,
   isCollapsed: DEFAULT_SECTION_COLLAPSED[Section.COMPARISON_TABLE],
   plots: [],
+  revisions: [],
   rowHeight: DEFAULT_ROW_HEIGHT,
   size: DEFAULT_SECTION_SIZES[Section.COMPARISON_TABLE]
 }

--- a/webview/src/stories/ComparisonTable.stories.tsx
+++ b/webview/src/stories/ComparisonTable.stories.tsx
@@ -6,7 +6,6 @@ import { Provider, useDispatch } from 'react-redux'
 import plotsRevisionsFixture from 'dvc/src/test/fixtures/plotsDiff/revisions'
 import {
   ComparisonRevisionData,
-  Revision,
   PlotsComparisonData,
   PlotSizeNumber
 } from 'dvc/src/plots/webview/contract'
@@ -14,28 +13,25 @@ import comparisonTableFixture from 'dvc/src/test/fixtures/plotsDiff/comparison'
 import { ComparisonTable } from '../plots/components/comparisonTable/ComparisonTable'
 import { WebviewWrapper } from '../shared/components/webviewWrapper/WebviewWrapper'
 import { update } from '../plots/components/comparisonTable/comparisonTableSlice'
-import { updateSelectedRevisions } from '../plots/components/webviewSlice'
 import { plotsReducers } from '../plots/store'
 
 const MockedState: React.FC<{
   data: PlotsComparisonData
-  selectedRevisions: Revision[]
   children: React.ReactNode
-}> = ({ children, data, selectedRevisions }) => {
+}> = ({ children, data }) => {
   const dispatch = useDispatch()
   dispatch(update(data))
-  dispatch(updateSelectedRevisions(selectedRevisions))
 
   return <>{children}</>
 }
 
 export default {
-  args: { ...comparisonTableFixture, revisions: plotsRevisionsFixture },
+  args: comparisonTableFixture,
   component: ComparisonTable,
   title: 'Comparison Table'
 } as Meta
 
-const Template: Story = ({ plots, revisions }) => {
+const Template: Story = ({ plots }) => {
   const store = configureStore({
     reducer: plotsReducers
   })
@@ -44,9 +40,9 @@ const Template: Story = ({ plots, revisions }) => {
       <MockedState
         data={{
           plots,
+          revisions: plotsRevisionsFixture,
           size: PlotSizeNumber.REGULAR
         }}
-        selectedRevisions={revisions}
       >
         <WebviewWrapper>
           <div


### PR DESCRIPTION
# 2/2 `main` <- #2841 <- this

Immediate follow-up from the previous PR. The aim here is to separate the plots ribbon and comparison table states (order) and simplify the code in the process.

### Demo

https://user-images.githubusercontent.com/37993418/204763584-71579d04-040b-4959-ba73-6bf54350a0bc.mov

The last thing that I want to do before moving on is add some enhanced empty states for when we only have loading revisions present in the webview.