### PR TITLE
Match VS Code version of @types/node

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1588,7 +1588,7 @@
     "@types/lodash.omit": "4.5.7",
     "@types/mocha": "10.0.0",
     "@types/mock-require": "2.0.1",
-    "@types/node": "18.11.3",
+    "@types/node": "16.x",
     "@types/react-vega": "7.0.0",
     "@types/sinon-chai": "3.2.9",
     "@types/uuid": "8.3.4",

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "ignoreDeps": ["execa", "@types/vscode"],
+  "ignoreDeps": ["execa", "@types/node", "@types/vscode"],
   "extends": ["config:base"],
   "packageRules": [
     {

--- a/webview/package.json
+++ b/webview/package.json
@@ -54,7 +54,7 @@
     "@types/classnames": "2.3.1",
     "@types/jest": "29.2.3",
     "@types/jsdom": "20.0.1",
-    "@types/node": "18.11.3",
+    "@types/node": "16.x",
     "@types/react": "18.0.25",
     "@types/react-dom": "18.0.9",
     "@types/react-measure": "2.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4127,10 +4127,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.21.tgz#864b987c0c68d07b4345845c3e63b75edd143644"
   integrity sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==
 
-"@types/node@18.11.3":
-  version "18.11.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.3.tgz#78a6d7ec962b596fc2d2ec102c4dd3ef073fea6a"
-  integrity sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==
+"@types/node@16.x":
+  version "16.18.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.4.tgz#712ba61b4caf091fc6490301b1888356638c17bd"
+  integrity sha512-9qGjJ5GyShZjUfx2ArBIGM+xExdfLvvaCyQR0t6yRXKPcWCVYF/WemtX/uIU3r7FYECXRXkIiw2Vnhn6y8d+pw==
 
 "@types/node@^14.0.10 || ^16.0.0", "@types/node@^14.14.20 || ^16.0.0":
   version "16.11.39"


### PR DESCRIPTION
The electron app that is VS Code uses Node v16.14.2. Our types were v18. This mismatch could lead us into using unavailable features by mistake. To preempt any issues I've matched the version of `@types/node` VS Code uses: https://github.com/microsoft/vscode/blob/main/package.json#L115