### PR TITLE
Watch workspace and filter results before calling for data updates

### DIFF
--- a/extension/src/experiments/data/collect.ts
+++ b/extension/src/experiments/data/collect.ts
@@ -1,16 +1,15 @@
 import { ExperimentsOutput } from '../../cli/dvc/contract'
+import { uniqueValues } from '../../util/array'
 
 export const collectFiles = (
   data: ExperimentsOutput,
   existingFiles: string[]
 ): string[] => {
-  const files = new Set<string>([
+  return uniqueValues([
     ...Object.keys({
       ...data?.workspace.baseline?.data?.params,
       ...data?.workspace.baseline?.data?.metrics
     }).filter(Boolean),
     ...existingFiles
   ])
-
-  return [...files]
 }

--- a/extension/src/experiments/data/index.ts
+++ b/extension/src/experiments/data/index.ts
@@ -36,7 +36,7 @@ export class ExperimentsData extends BaseData<ExperimentsOutput> {
         },
         { name: 'fullUpdate', process: () => this.update() }
       ],
-      ['dvc.lock', 'dvc.yaml', 'params.yaml', '*.dvc']
+      ['dvc.lock', 'dvc.yaml', 'params.yaml', '.dvc']
     )
 
     this.watchExpGitRefs()
@@ -61,9 +61,7 @@ export class ExperimentsData extends BaseData<ExperimentsOutput> {
       ...args
     )
 
-    const files = this.collectFiles(data)
-
-    this.compareFiles(files)
+    this.collectFiles(data)
 
     return this.notifyChanged(data)
   }
@@ -73,7 +71,7 @@ export class ExperimentsData extends BaseData<ExperimentsOutput> {
   }
 
   protected collectFiles(data: ExperimentsOutput) {
-    return collectFiles(data, this.collectedFiles)
+    this.collectedFiles = collectFiles(data, this.collectedFiles)
   }
 
   private async watchExpGitRefs(): Promise<void> {

--- a/extension/src/plots/data/index.ts
+++ b/extension/src/plots/data/index.ts
@@ -65,9 +65,7 @@ export class PlotsData extends BaseData<{
 
     this.notifyChanged({ data, revs })
 
-    const files = this.collectFiles({ data })
-
-    this.compareFiles(files)
+    this.collectFiles({ data })
   }
 
   public managedUpdate() {
@@ -75,7 +73,7 @@ export class PlotsData extends BaseData<{
   }
 
   protected collectFiles({ data }: { data: PlotsOutputOrError }) {
-    return collectFiles(data, this.collectedFiles)
+    this.collectedFiles = collectFiles(data, this.collectedFiles)
   }
 
   private getArgs(revs: string[]) {

--- a/extension/src/test/suite/experiments/util.ts
+++ b/extension/src/test/suite/experiments/util.ts
@@ -145,8 +145,7 @@ export const buildSingleRepoExperiments = (disposer: Disposer) => {
 
   return { messageSpy, workspaceExperiments }
 }
-
-export const buildExperimentsDataDependencies = (disposer: Disposer) => {
+const buildExperimentsDataDependencies = (disposer: Disposer) => {
   const mockCreateFileSystemWatcher = stub(
     Watcher,
     'createFileSystemWatcher'


### PR DESCRIPTION
Related to #2830

This PR simplifies our use of watchers. It could also help with some of the issues that we are seeing in Codespaces. 

Instead of sending a complex glob to VS Code when we create file system watchers we now ask for all events and filter the result on our end. This means that we do not need to destroy/recreate watchers whenever the collected files change. It also gives us a more reliable way of filtering the events.