### PR TITLE
Improve stability of e2e tests for new VS Code release

### DIFF
--- a/extension/src/test/e2e/pageObjects/baseWebview.ts
+++ b/extension/src/test/e2e/pageObjects/baseWebview.ts
@@ -18,16 +18,17 @@ export class BaseWebview extends BasePage<
   }
 
   public async focus() {
-    const webviewContainer = await this.outerFrame$
+    await this.outerFrame$.waitForExist()
 
-    await this.outerFrame$.waitForDisplayed()
+    await browser.switchToFrame(await this.outerFrame$)
 
-    await browser.switchToFrame(webviewContainer)
-    await this.innerFrame$.waitForDisplayed()
+    await this.innerFrame$.waitForExist()
+
     const webviewInner = await browser.findElement(
       'css selector',
       this.locators.innerFrame
     )
+
     return browser.switchToFrame(webviewInner)
   }
 


### PR DESCRIPTION
# 1/2 `main` <- this <- #2896 

E2E tests started flaking out with `1.74.0` of VS Code. I went and copied the required update from

https://github.com/stateful/vscode-marquee/blob/e0d004ab216592c4e51a93955d6695ba1169228d/test/pageobjects/webview.ts#L13

(which is a repo that the framework's maintainer works on)