### PR TITLE
Use DVCLive signal file to indicate that an experiment is running in the workspace

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1614,6 +1614,7 @@
     "lint-staged": "13.1.0",
     "mocha": "10.0.0",
     "mock-require": "3.0.3",
+    "process-exists": "4.1.0",
     "shx": "0.3.4",
     "sinon": "15.0.0",
     "sinon-chai": "3.7.0",

--- a/extension/src/cli/dvc/constants.ts
+++ b/extension/src/cli/dvc/constants.ts
@@ -12,7 +12,7 @@ export const DVCLIVE_ONLY_RUNNING_SIGNAL_FILE = join(
   'tmp',
   'exps',
   'run',
-  'dvclive_only'
+  'DVCLIVE_ONLY'
 )
 
 export const NUM_OF_COMMITS_TO_SHOW = '3'

--- a/extension/src/cli/dvc/constants.ts
+++ b/extension/src/cli/dvc/constants.ts
@@ -7,6 +7,14 @@ export const MAX_CLI_VERSION = '3'
 export const UNEXPECTED_ERROR_CODE = 255
 
 export const TEMP_PLOTS_DIR = join('.dvc', 'tmp', 'plots')
+export const DVCLIVE_ONLY_RUNNING_SIGNAL_FILE = join(
+  '.dvc',
+  'tmp',
+  'exps',
+  'run',
+  'dvclive_only'
+)
+
 export const NUM_OF_COMMITS_TO_SHOW = '3'
 
 export enum Command {

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -1,3 +1,4 @@
+import { join } from 'path'
 import {
   ConfigurationChangeEvent,
   Event,
@@ -40,6 +41,8 @@ import { createTypedAccumulator } from '../util/object'
 import { pickPaths } from '../path/selection/quickPick'
 import { Toast } from '../vscode/toast'
 import { ConfigKey } from '../vscode/config'
+import { exists } from '../fileSystem'
+import { DVCLIVE_ONLY_RUNNING_SIGNAL_FILE } from '../cli/dvc/constants'
 
 export const ExperimentsScale = {
   ...omit(ColumnType, 'TIMESTAMP'),
@@ -165,9 +168,12 @@ export class Experiments extends BaseRepository<TableData> {
   }
 
   public async setState(data: ExperimentsOutput) {
+    const dvclive_only = exists(
+      join(this.dvcRoot, DVCLIVE_ONLY_RUNNING_SIGNAL_FILE)
+    )
     await Promise.all([
       this.columns.transformAndSet(data),
-      this.experiments.transformAndSet(data)
+      this.experiments.transformAndSet(data, dvclive_only)
     ])
 
     return this.notifyChanged(data)

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -41,7 +41,7 @@ import { createTypedAccumulator } from '../util/object'
 import { pickPaths } from '../path/selection/quickPick'
 import { Toast } from '../vscode/toast'
 import { ConfigKey } from '../vscode/config'
-import { exists } from '../fileSystem'
+import { checkSignalFile } from '../fileSystem'
 import { DVCLIVE_ONLY_RUNNING_SIGNAL_FILE } from '../cli/dvc/constants'
 
 export const ExperimentsScale = {
@@ -168,12 +168,12 @@ export class Experiments extends BaseRepository<TableData> {
   }
 
   public async setState(data: ExperimentsOutput) {
-    const dvclive_only = exists(
+    const dvcLiveOnly = await checkSignalFile(
       join(this.dvcRoot, DVCLIVE_ONLY_RUNNING_SIGNAL_FILE)
     )
     await Promise.all([
       this.columns.transformAndSet(data),
-      this.experiments.transformAndSet(data, dvclive_only)
+      this.experiments.transformAndSet(data, dvcLiveOnly)
     ])
 
     return this.notifyChanged(data)

--- a/extension/src/experiments/model/collect.test.ts
+++ b/extension/src/experiments/model/collect.test.ts
@@ -8,11 +8,14 @@ import {
 
 describe('collectExperiments', () => {
   it('should return an empty array if no branches are present', () => {
-    const { branches } = collectExperiments({
-      [EXPERIMENT_WORKSPACE_ID]: {
-        baseline: {}
-      }
-    })
+    const { branches } = collectExperiments(
+      {
+        [EXPERIMENT_WORKSPACE_ID]: {
+          baseline: {}
+        }
+      },
+      false
+    )
     expect(branches).toStrictEqual([])
   })
 
@@ -34,8 +37,10 @@ describe('collectExperiments', () => {
       baseline: { data: { name: 'branchB' } }
     }
   }
-  const { branches, experimentsByBranch, workspace } =
-    collectExperiments(repoWithTwoBranches)
+  const { branches, experimentsByBranch, workspace } = collectExperiments(
+    repoWithTwoBranches,
+    false
+  )
 
   it('should define a workspace', () => {
     expect(workspace).toBeDefined()
@@ -77,7 +82,7 @@ describe('collectExperiments', () => {
       }
     }
   }
-  const acc = collectExperiments(repoWithNestedCheckpoints)
+  const acc = collectExperiments(repoWithNestedCheckpoints, false)
 
   it('should only list the tip as a top-level experiment', () => {
     const { experimentsByBranch } = acc
@@ -98,7 +103,7 @@ describe('collectExperiments', () => {
   })
 
   it('should handle the continuation of a modified checkpoint', () => {
-    const { checkpointsByTip } = collectExperiments(modifiedFixture)
+    const { checkpointsByTip } = collectExperiments(modifiedFixture, false)
 
     const modifiedCheckpointTip = checkpointsByTip
       .get('exp-01b3a')
@@ -154,7 +159,7 @@ describe('collectExperiments', () => {
         }
       }
     }
-    const acc = collectExperiments(repoWithNestedCheckpoints)
+    const acc = collectExperiments(repoWithNestedCheckpoints, false)
 
     const { experimentsByBranch, checkpointsByTip } = acc
     const [experiment] = experimentsByBranch.get('branchA') || []

--- a/extension/src/experiments/model/collect.ts
+++ b/extension/src/experiments/model/collect.ts
@@ -313,7 +313,7 @@ const collectFromBranchesObject = (
 
 export const collectExperiments = (
   data: ExperimentsOutput,
-  dvclive_only = false
+  dvcLiveOnly = false
 ): ExperimentsAccumulator => {
   const { workspace, ...branchesObject } = data
 
@@ -323,7 +323,7 @@ export const collectExperiments = (
     EXPERIMENT_WORKSPACE_ID
   )
 
-  if (dvclive_only) {
+  if (dvcLiveOnly) {
     workspaceBaseline.executor = EXPERIMENT_WORKSPACE_ID
     workspaceBaseline.status = ExperimentStatus.RUNNING
   }

--- a/extension/src/experiments/model/collect.ts
+++ b/extension/src/experiments/model/collect.ts
@@ -14,7 +14,8 @@ import {
   ExperimentFields,
   ExperimentsBranchOutput,
   ExperimentsOutput,
-  EXPERIMENT_WORKSPACE_ID
+  EXPERIMENT_WORKSPACE_ID,
+  ExperimentStatus
 } from '../../cli/dvc/contract'
 import { addToMapArray } from '../../util/map'
 import { uniqueValues } from '../../util/array'
@@ -311,16 +312,21 @@ const collectFromBranchesObject = (
 }
 
 export const collectExperiments = (
-  data: ExperimentsOutput
+  data: ExperimentsOutput,
+  dvclive_only = false
 ): ExperimentsAccumulator => {
   const { workspace, ...branchesObject } = data
-  const workspaceId = EXPERIMENT_WORKSPACE_ID
 
   const workspaceBaseline = transformExperimentData(
-    workspaceId,
+    EXPERIMENT_WORKSPACE_ID,
     workspace.baseline,
-    workspaceId
+    EXPERIMENT_WORKSPACE_ID
   )
+
+  if (dvclive_only) {
+    workspaceBaseline.executor = EXPERIMENT_WORKSPACE_ID
+    workspaceBaseline.status = ExperimentStatus.RUNNING
+  }
 
   const acc = new ExperimentsAccumulator(workspaceBaseline)
 

--- a/extension/src/experiments/model/collect.ts
+++ b/extension/src/experiments/model/collect.ts
@@ -313,7 +313,7 @@ const collectFromBranchesObject = (
 
 export const collectExperiments = (
   data: ExperimentsOutput,
-  dvcLiveOnly = false
+  dvcLiveOnly: boolean
 ): ExperimentsAccumulator => {
   const { workspace, ...branchesObject } = data
 

--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -116,14 +116,14 @@ export class ExperimentsModel extends ModelWithPersistence {
     )
   }
 
-  public transformAndSet(data: ExperimentsOutput, dvclive_only = false) {
+  public transformAndSet(data: ExperimentsOutput, dvcLiveOnly: boolean) {
     const {
       workspace,
       branches,
       experimentsByBranch,
       checkpointsByTip,
       runningExperiments
-    } = collectExperiments(data, dvclive_only)
+    } = collectExperiments(data, dvcLiveOnly)
 
     this.workspace = workspace
     this.branches = branches

--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -116,14 +116,14 @@ export class ExperimentsModel extends ModelWithPersistence {
     )
   }
 
-  public transformAndSet(data: ExperimentsOutput) {
+  public transformAndSet(data: ExperimentsOutput, dvclive_only = false) {
     const {
       workspace,
       branches,
       experimentsByBranch,
       checkpointsByTip,
       runningExperiments
-    } = collectExperiments(data)
+    } = collectExperiments(data, dvclive_only)
 
     this.workspace = workspace
     this.branches = branches

--- a/extension/src/fileSystem/index.test.ts
+++ b/extension/src/fileSystem/index.test.ts
@@ -1,16 +1,14 @@
 import { join, relative, resolve } from 'path'
 import { ensureDirSync, remove } from 'fs-extra'
-import * as FileSystem from '.'
-import { dvcDemoPath } from '../test/util'
-
-const {
+import {
   exists,
   findAbsoluteDvcRootPath,
   findDvcRootPaths,
   isDirectory,
   isSameOrChild,
   getModifiedTime
-} = FileSystem
+} from '.'
+import { dvcDemoPath } from '../test/util'
 
 jest.mock('../cli/dvc/reader')
 

--- a/extension/src/fileSystem/index.ts
+++ b/extension/src/fileSystem/index.ts
@@ -14,6 +14,8 @@ import { standardizePath } from './path'
 import { definedAndNonEmpty } from '../util/array'
 import { Logger } from '../common/logger'
 import { gitPath } from '../cli/git/constants'
+import { createValidInteger } from '../util/number'
+import { processExists } from '../processExecution'
 
 export const exists = (path: string): boolean => existsSync(path)
 
@@ -145,4 +147,20 @@ export const writeJson = <T extends Record<string, unknown>>(
 ): void => {
   ensureFileSync(path)
   return writeFileSync(path, JSON.stringify(obj))
+}
+
+export const checkSignalFile = async (path: string): Promise<boolean> => {
+  if (!exists(path)) {
+    return false
+  }
+
+  const contents = readFileSync(path).toString()
+  const pid = createValidInteger(contents)
+
+  if (!contents || !pid || !(await processExists(pid))) {
+    removeSync(path)
+    return false
+  }
+
+  return true
 }

--- a/extension/src/fileSystem/index.ts
+++ b/extension/src/fileSystem/index.ts
@@ -157,7 +157,7 @@ export const checkSignalFile = async (path: string): Promise<boolean> => {
   const contents = readFileSync(path).toString()
   const pid = createValidInteger(contents)
 
-  if (!contents || !pid || !(await processExists(pid))) {
+  if (!pid || !(await processExists(pid))) {
     removeSync(path)
     return false
   }

--- a/extension/src/processExecution.test.ts
+++ b/extension/src/processExecution.test.ts
@@ -1,4 +1,5 @@
-import { executeProcess } from './processExecution'
+import process from 'process'
+import { executeProcess, processExists } from './processExecution'
 
 describe('executeProcess', () => {
   it('should be able to run a process', async () => {
@@ -18,5 +19,14 @@ describe('executeProcess', () => {
         executable: 'find'
       })
     ).rejects.toBeTruthy()
+  })
+})
+
+describe('processExists', () => {
+  it('should return true if the process exists', async () => {
+    expect(await processExists(process.pid)).toBe(true)
+  })
+  it('should return false if it does not', async () => {
+    expect(await processExists(-123.321)).toBe(false)
   })
 })

--- a/extension/src/processExecution.ts
+++ b/extension/src/processExecution.ts
@@ -3,6 +3,7 @@ import { Readable } from 'stream'
 import { Event, EventEmitter } from 'vscode'
 import { Disposable } from '@hediet/std/disposable'
 import execa from 'execa'
+import doesProcessExists from 'process-exists'
 
 interface RunningProcess extends ChildProcess {
   all?: Readable
@@ -58,3 +59,6 @@ export const executeProcess = async (
   const { stdout } = await createProcess(options)
   return stdout
 }
+
+export const processExists = (pid: number): Promise<boolean> =>
+  doesProcessExists(pid)

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -732,6 +732,8 @@ suite('Experiments Test Suite', () => {
     it("should be able to handle a message to toggle an experiment's status", async () => {
       const { experiments, experimentsModel } = buildExperiments(disposable)
 
+      await experiments.isReady()
+
       const experimentToToggle = 'exp-e7a67'
       const queuedExperiment = '90aea7f2482117a55dfcadcdb901aaa6610fbbc9'
 

--- a/extension/src/test/suite/experiments/model/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/tree.test.ts
@@ -677,6 +677,8 @@ suite('Experiments Tree Test Suite', () => {
     it('should be able to apply an experiment to the workspace with dvc.views.experiments.applyExperiment', async () => {
       const { experiments } = buildExperiments(disposable)
 
+      await experiments.isReady()
+
       const mockExperiment = 'd1343a87c6ee4a2e82d19525964d2fb2cb6756c9'
 
       const mockExperimentApply = stub(

--- a/extension/src/test/suite/experiments/util.ts
+++ b/extension/src/test/suite/experiments/util.ts
@@ -54,6 +54,7 @@ export const buildExperiments = (
     gitReader,
     internalCommands,
     messageSpy,
+    mockCheckSignalFile,
     mockExperimentShow,
     updatesPaused,
     resourceLocator
@@ -87,6 +88,7 @@ export const buildExperiments = (
     gitReader,
     internalCommands,
     messageSpy,
+    mockCheckSignalFile,
     mockExperimentShow,
     resourceLocator,
     updatesPaused
@@ -119,6 +121,7 @@ export const buildMultiRepoExperiments = (disposer: Disposer) => {
     updatesPaused,
     resourceLocator
   )
+
   experiments.setState(expShowFixture)
   return { experiments, internalCommands, messageSpy, workspaceExperiments }
 }

--- a/extension/src/test/suite/fileSystem/index.test.ts
+++ b/extension/src/test/suite/fileSystem/index.test.ts
@@ -1,10 +1,12 @@
 import { join, resolve } from 'path'
+import process from 'process'
 import { afterEach, beforeEach, describe, it, suite } from 'mocha'
 import { expect } from 'chai'
 import { Disposable } from '@hediet/std/disposable'
 import { restore } from 'sinon'
+import { ensureFileSync, removeSync, writeFileSync } from 'fs-extra'
 import { dvcDemoPath } from '../../util'
-import { getGitPath } from '../../../fileSystem'
+import { checkSignalFile, exists, getGitPath } from '../../../fileSystem'
 import { gitPath } from '../../../cli/git/constants'
 import { GitReader } from '../../../cli/git/reader'
 import { standardizePath } from '../../../fileSystem/path'
@@ -46,6 +48,49 @@ suite('File System Test Suite', () => {
 
       const expRefPaths = getGitPath(root, EXPERIMENTS_GIT_REFS)
       expect(expRefPaths).to.equal(join(rootDotGit, EXPERIMENTS_GIT_REFS))
+    })
+  })
+
+  describe('checkSignalFile', () => {
+    it('should check the appropriate file and remove if necessary', async () => {
+      const mockSignalFilePath = join(__dirname, 'MOCK_SIGNAL_FILE')
+
+      if (exists(mockSignalFilePath)) {
+        removeSync(mockSignalFilePath)
+      }
+
+      expect(
+        await checkSignalFile(mockSignalFilePath),
+        'should return false if the file does not exist'
+      ).to.be.false
+
+      ensureFileSync(mockSignalFilePath)
+      expect(exists(mockSignalFilePath)).to.be.true
+
+      expect(
+        await checkSignalFile(mockSignalFilePath),
+        'should return false and remove the file if it does not contain a pid'
+      ).to.be.false
+
+      expect(exists(mockSignalFilePath)).to.be.false
+
+      writeFileSync(mockSignalFilePath, `${process.pid}`)
+
+      expect(
+        await checkSignalFile(mockSignalFilePath),
+        'should return true and not remove the file if it contains a valid pid'
+      ).to.be.true
+
+      expect(exists(mockSignalFilePath)).to.be.true
+
+      writeFileSync(mockSignalFilePath, 'not a pid')
+
+      expect(
+        await checkSignalFile(mockSignalFilePath),
+        'should return false and remove the file if it contains a pid that can not be found'
+      ).to.be.false
+
+      expect(exists(mockSignalFilePath)).to.be.false
     })
   })
 })

--- a/extension/src/test/suite/util.ts
+++ b/extension/src/test/suite/util.ts
@@ -26,6 +26,7 @@ import { ExperimentsData } from '../../experiments/data'
 import { ResourceLocator } from '../../resourceLocator'
 import { DEFAULT_DEBOUNCE_WINDOW_MS } from '../../processManager'
 import { FileSystemData } from '../../fileSystem/data'
+import * as FileSystem from '../../fileSystem'
 import * as Watcher from '../../fileSystem/watcher'
 import { MessageFromWebview } from '../../webview/contract'
 import { PlotsData } from '../../plots/webview/contract'
@@ -172,6 +173,10 @@ export const buildDependencies = (
     'createFileSystemWatcher'
   ).returns(mockDisposable)
 
+  const mockCheckSignalFile = stub(FileSystem, 'checkSignalFile').resolves(
+    false
+  )
+
   const mockPlotsDiff = stub(dvcReader, 'plotsDiff').resolves(plotsDiff)
 
   const mockExperimentShow = stub(dvcReader, 'expShow').resolves(expShow)
@@ -189,6 +194,7 @@ export const buildDependencies = (
     gitReader,
     internalCommands,
     messageSpy,
+    mockCheckSignalFile,
     mockCreateFileSystemWatcher,
     mockExperimentShow,
     mockPlotsDiff,

--- a/extension/src/util/number.test.ts
+++ b/extension/src/util/number.test.ts
@@ -1,0 +1,43 @@
+import { createValidInteger } from './number'
+
+describe('createInteger', () => {
+  it('should return undefined if given undefined', () => {
+    const integer = createValidInteger(undefined)
+    expect(integer).toBeUndefined()
+  })
+
+  it('should create an integer from a valid string', () => {
+    const integer = createValidInteger('1234')
+    expect(integer).toStrictEqual(1234)
+  })
+
+  it('should return undefined if the string does not represent an integer', () => {
+    const integer = createValidInteger('1234.0001')
+    expect(integer).toBeUndefined()
+  })
+
+  it('should return  if the string does not represent an integer', () => {
+    const integer = createValidInteger('1234.0')
+    expect(integer).toStrictEqual(1234)
+  })
+
+  it('should return undefined if the string is not a number', () => {
+    const integer = createValidInteger('A string')
+    expect(integer).toBeUndefined()
+  })
+
+  it('should return undefined if given a non-integer number', () => {
+    const integer = createValidInteger(1234.1)
+    expect(integer).toBeUndefined()
+  })
+
+  it('should return undefined if given a NaN number', () => {
+    const integer = createValidInteger(Number.NaN)
+    expect(integer).toBeUndefined()
+  })
+
+  it('should return the given integer', () => {
+    const integer = createValidInteger(1234)
+    expect(integer).toStrictEqual(1234)
+  })
+})

--- a/extension/src/util/number.ts
+++ b/extension/src/util/number.ts
@@ -1,0 +1,18 @@
+const validateNumericInteger = (number: number): number | undefined =>
+  !Number.isNaN(number) && Number.isInteger(number) ? number : undefined
+
+export const createValidInteger = (
+  input: string | number | undefined
+): number | undefined => {
+  if (!input) {
+    return
+  }
+
+  if (typeof input === 'number') {
+    return validateNumericInteger(input)
+  }
+
+  return Number.parseInt(input) === Number.parseFloat(input)
+    ? Number.parseInt(input)
+    : undefined
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15067,6 +15067,13 @@ prismjs@^1.27.0, prismjs@~1.27.0:
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
   integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
 
+process-exists@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/process-exists/-/process-exists-4.1.0.tgz#4132c516324c1da72d65896851cdbd8bbdf5b9d8"
+  integrity sha512-BBJoiorUKoP2AuM5q/yKwIfT1YWRHsaxjW+Ayu9erLhqKOfnXzzVVML0XTYoQZuI1YvcWKmc1dh06DEy4+KzfA==
+  dependencies:
+    ps-list "^6.3.0"
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -15161,6 +15168,11 @@ prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
+
+ps-list@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/ps-list/-/ps-list-6.3.0.tgz#a2b775c2db7d547a28fbaa3a05e4c281771259be"
+  integrity sha512-qau0czUSB0fzSlBOQt0bo+I2v6R+xiQdj78e1BR/Qjfl5OHWJ/urXi8+ilw1eHe+5hSeDI1wrwVTgDp2wst4oA==
 
 pseudomap@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
As part of the onboarding drive, the DVC team has made it possible to run experiments using only DVCLive. In order for a new user (with a non-DVC ML project) to see the table and associated live plots, all they will need to do is:

1. Install DVC and DVCLive as Python packages. 
1. Run `dvc init`.
1. Instrument their training script with DVCLive calls/callbacks.
1. Run their training script.

This means that we will have a new way to onboard people into DVC. However, due to the changes made in #2877 the newly created experiments were no longer being auto-selected for plotting.

In order to rectify this I raised https://github.com/iterative/dvclive/pull/392 which has DVCLive create a signal file whenever one of these special DVCLive-only experiments is being run.

This PR uses the above changes to auto-select experiments run by DVCLive only (outside of a normal experiment) for plotting.

### Demo

https://user-images.githubusercontent.com/37993418/207185448-6a3fa798-73e1-4b5e-b0a1-1dcee2c791ca.mov

[Original slack discussion](https://iterativeai.slack.com/archives/C01APS0FHDM/p1670530599513299)