### PR TITLE
Recheck for global CLI becoming available

### DIFF
--- a/extension/src/cli/dvc/discovery.ts
+++ b/extension/src/cli/dvc/discovery.ts
@@ -18,6 +18,7 @@ import {
   selectPythonInterpreter
 } from '../../extensions/python'
 import { getFirstWorkspaceFolder } from '../../vscode/workspaceFolders'
+import { delay } from '../../util/time'
 
 const getToastOptions = (isPythonExtensionInstalled: boolean): Response[] => {
   return isPythonExtensionInstalled
@@ -229,8 +230,10 @@ export const extensionCanRunCli = async (
 
 export const recheckGlobal = async (
   extension: IExtension,
-  setup: () => Promise<void[] | undefined>
+  setup: () => Promise<void[] | undefined>,
+  recheckInterval: number
 ): Promise<void> => {
+  await delay(recheckInterval)
   const roots = extension.getRoots()
   const cwd = roots.length > 0 ? roots[0] : getFirstWorkspaceFolder()
 
@@ -243,8 +246,7 @@ export const recheckGlobal = async (
   const isCompatible = isCliCompatible(cliCompatible)
 
   if (!isCompatible) {
-    setTimeout(() => recheckGlobal(extension, setup), 5000)
-    return
+    return recheckGlobal(extension, setup, recheckInterval)
   }
 
   setup()

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -21,7 +21,7 @@ import { IExtension } from './interfaces'
 import { registerRepositoryCommands } from './repository/commands/register'
 import { ResourceLocator } from './resourceLocator'
 import { definedAndNonEmpty } from './util/array'
-import { setup, setupWorkspace } from './setup'
+import { setup, setupWithGlobalRecheck, setupWorkspace } from './setup'
 import { Status } from './status'
 import { reRegisterVsCodeCommands } from './vscode/commands'
 import { InternalCommands } from './commands/internal'
@@ -62,7 +62,6 @@ import { createFileSystemWatcher } from './fileSystem/watcher'
 import { GitExecutor } from './cli/git/executor'
 import { GitReader } from './cli/git/reader'
 import { GetStarted } from './getStarted'
-import { recheckGlobal } from './cli/dvc/discovery'
 
 export class Extension extends Disposable implements IExtension {
   protected readonly internalCommands: InternalCommands
@@ -205,17 +204,13 @@ export class Extension extends Disposable implements IExtension {
       new RepositoriesTree(this.internalCommands, this.repositories)
     )
 
-    setup(this)
+    setupWithGlobalRecheck(this)
       .then(async () => {
         sendTelemetryEvent(
           EventName.EXTENSION_LOAD,
           await this.getEventProperties(),
           { duration: stopWatch.getElapsedTime() }
         )
-
-        if (!this.cliAccessible) {
-          recheckGlobal(this, () => setup(this))
-        }
       })
       .catch(async error =>
         sendTelemetryEventAndThrow(

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -62,6 +62,7 @@ import { createFileSystemWatcher } from './fileSystem/watcher'
 import { GitExecutor } from './cli/git/executor'
 import { GitReader } from './cli/git/reader'
 import { GetStarted } from './getStarted'
+import { recheckGlobal } from './cli/dvc/discovery'
 
 export class Extension extends Disposable implements IExtension {
   protected readonly internalCommands: InternalCommands
@@ -205,13 +206,17 @@ export class Extension extends Disposable implements IExtension {
     )
 
     setup(this)
-      .then(async () =>
+      .then(async () => {
         sendTelemetryEvent(
           EventName.EXTENSION_LOAD,
           await this.getEventProperties(),
           { duration: stopWatch.getElapsedTime() }
         )
-      )
+
+        if (!this.cliAccessible) {
+          recheckGlobal(this, () => setup(this))
+        }
+      })
       .catch(async error =>
         sendTelemetryEventAndThrow(
           EventName.EXTENSION_LOAD,

--- a/extension/src/interfaces.ts
+++ b/extension/src/interfaces.ts
@@ -13,6 +13,7 @@ export interface IExtension {
   resetMembers: () => void
 
   setAvailable: (available: boolean) => void
+  getAvailable: () => boolean
   setCliCompatible: (compatible: boolean | undefined) => void
   setRoots: () => Promise<void>
   unsetPythonBinPath: () => void

--- a/extension/src/setup.test.ts
+++ b/extension/src/setup.test.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'path'
 import { extensions, Extension, commands } from 'vscode'
-import { setup, setupWorkspace } from './setup'
+import { setup, setupWithGlobalRecheck, setupWorkspace } from './setup'
 import { flushPromises } from './test/util/jest'
 import {
   getConfigValue,
@@ -24,6 +24,7 @@ import {
   MIN_CLI_VERSION
 } from './cli/dvc/constants'
 import { extractSemver, ParsedSemver } from './cli/dvc/version'
+import { delay } from './util/time'
 
 jest.mock('vscode')
 jest.mock('./vscode/config')
@@ -617,5 +618,104 @@ describe('setup', () => {
     await setup(extension)
     expect(mockedResetMembers).toHaveBeenCalledTimes(1)
     expect(mockedInitialize).not.toHaveBeenCalled()
+  })
+})
+
+describe('setupWithGlobalRecheck', () => {
+  const extension = {
+    getAvailable: mockedGetAvailable,
+    getCliVersion: mockedGetCliVersion,
+    getRoots: mockedGetRoots,
+    hasRoots: mockedHasRoots,
+    initialize: mockedInitialize,
+    isPythonExtensionUsed: mockedIsPythonExtensionUsed,
+    resetMembers: mockedResetMembers,
+    setAvailable: mockedSetAvailable,
+    setCliCompatible: mockedSetCliCompatible,
+    setRoots: mockedSetRoots,
+    setupWorkspace: mockedSetupWorkspace,
+    unsetPythonBinPath: mockedUnsetPythonBinPath
+  }
+
+  it('should periodically check to see if the CLI is available globally if the extension fails to initialize', async () => {
+    mockedGetFirstWorkspaceFolder.mockReturnValue(mockedCwd)
+
+    const mockedRecheckInterval = 0
+
+    mockedGetAvailable
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(false)
+
+    mockedGetCliVersion
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(LATEST_TESTED_CLI_VERSION)
+      .mockResolvedValueOnce(LATEST_TESTED_CLI_VERSION)
+
+    await setupWithGlobalRecheck(extension, mockedRecheckInterval)
+
+    expect(mockedGetCliVersion).toHaveBeenCalledTimes(1)
+    expect(mockedGetAvailable).toHaveBeenCalledTimes(1)
+
+    await delay(mockedRecheckInterval)
+
+    expect(mockedGetCliVersion).toHaveBeenCalledTimes(2)
+    expect(mockedGetAvailable).toHaveBeenCalledTimes(2)
+
+    await delay(mockedRecheckInterval)
+
+    expect(mockedGetCliVersion).toHaveBeenCalledTimes(4)
+    expect(mockedGetAvailable).toHaveBeenCalledTimes(3)
+
+    await delay(mockedRecheckInterval)
+
+    expect(mockedGetCliVersion).toHaveBeenCalledTimes(4)
+    expect(mockedGetAvailable).toHaveBeenCalledTimes(3)
+  })
+
+  it('should not periodically check to see if the CLI is available globally if the extension initializes', async () => {
+    mockedGetFirstWorkspaceFolder.mockReturnValue(mockedCwd)
+
+    mockedGetAvailable.mockReturnValueOnce(true)
+
+    mockedGetCliVersion.mockResolvedValueOnce(LATEST_TESTED_CLI_VERSION)
+
+    await setupWithGlobalRecheck(extension, 0)
+
+    expect(mockedGetCliVersion).toHaveBeenCalledTimes(1)
+    expect(mockedGetAvailable).toHaveBeenCalledTimes(1)
+
+    await delay(0)
+
+    expect(mockedGetCliVersion).toHaveBeenCalledTimes(1)
+    expect(mockedGetAvailable).toHaveBeenCalledTimes(1)
+
+    await delay(0)
+
+    expect(mockedGetCliVersion).toHaveBeenCalledTimes(1)
+    expect(mockedGetAvailable).toHaveBeenCalledTimes(1)
+  })
+
+  it('should stop checking if the extension is available globally if it initializes', async () => {
+    mockedGetFirstWorkspaceFolder.mockReturnValue(mockedCwd)
+
+    mockedGetAvailable.mockReturnValueOnce(false).mockReturnValueOnce(true)
+    mockedGetCliVersion.mockResolvedValueOnce(undefined)
+
+    await setupWithGlobalRecheck(extension, 0)
+
+    expect(mockedGetCliVersion).toHaveBeenCalledTimes(1)
+    expect(mockedGetAvailable).toHaveBeenCalledTimes(1)
+
+    await delay(0)
+
+    expect(mockedGetCliVersion).toHaveBeenCalledTimes(1)
+    expect(mockedGetAvailable).toHaveBeenCalledTimes(2)
+
+    await delay(0)
+
+    expect(mockedGetCliVersion).toHaveBeenCalledTimes(1)
+    expect(mockedGetAvailable).toHaveBeenCalledTimes(2)
   })
 })

--- a/extension/src/setup.test.ts
+++ b/extension/src/setup.test.ts
@@ -32,7 +32,6 @@ jest.mock('./vscode/quickPick')
 jest.mock('./vscode/toast')
 jest.mock('./vscode/workspaceFolders')
 jest.mock('./processExecution')
-jest.mock('./setupUtil')
 
 const mockedExtensions = jest.mocked(extensions)
 const mockedCommands = jest.mocked(commands)
@@ -63,6 +62,7 @@ const mockedVscodePython = {
 }
 
 const mockedCwd = __dirname
+const mockedGetAvailable = jest.fn()
 const mockedGetCliVersion = jest.fn()
 const mockedGetFirstWorkspaceFolder = jest.mocked(getFirstWorkspaceFolder)
 const mockedHasRoots = jest.fn()
@@ -259,6 +259,7 @@ describe('setupWorkspace', () => {
 
 describe('setup', () => {
   const extension = {
+    getAvailable: mockedGetAvailable,
     getCliVersion: mockedGetCliVersion,
     getRoots: mockedGetRoots,
     hasRoots: mockedHasRoots,

--- a/extension/src/setup.ts
+++ b/extension/src/setup.ts
@@ -10,7 +10,6 @@ import { getFirstWorkspaceFolder } from './vscode/workspaceFolders'
 import { getSelectTitle, Title } from './vscode/title'
 import { isPythonExtensionInstalled } from './extensions/python'
 import { extensionCanRunCli } from './cli/dvc/discovery'
-import { willRecheck } from './setupUtil'
 
 const setConfigPath = async (
   option: ConfigKey,
@@ -156,13 +155,11 @@ export const setupWorkspace = async (): Promise<boolean> => {
 
 export const checkAvailable = async (
   extension: IExtension,
-  dvcRootOrFirstFolder: string,
-  recheck = false
+  dvcRootOrFirstFolder: string
 ) => {
   const { isAvailable, isCompatible } = await extensionCanRunCli(
     extension,
-    dvcRootOrFirstFolder,
-    recheck
+    dvcRootOrFirstFolder
   )
 
   extension.setCliCompatible(isCompatible)
@@ -176,7 +173,6 @@ export const checkAvailable = async (
 
   if (!isAvailable) {
     extension.setAvailable(false)
-    willRecheck(extension, dvcRootOrFirstFolder)
   }
 }
 

--- a/extension/src/setup.ts
+++ b/extension/src/setup.ts
@@ -9,7 +9,7 @@ import { pickFile } from './vscode/resourcePicker'
 import { getFirstWorkspaceFolder } from './vscode/workspaceFolders'
 import { getSelectTitle, Title } from './vscode/title'
 import { isPythonExtensionInstalled } from './extensions/python'
-import { extensionCanRunCli } from './cli/dvc/discovery'
+import { extensionCanRunCli, recheckGlobal } from './cli/dvc/discovery'
 
 const setConfigPath = async (
   option: ConfigKey,
@@ -170,10 +170,6 @@ export const checkAvailable = async (
   }
 
   extension.resetMembers()
-
-  if (!isAvailable) {
-    extension.setAvailable(false)
-  }
 }
 
 export const setup = async (extension: IExtension) => {
@@ -188,4 +184,15 @@ export const setup = async (extension: IExtension) => {
   const dvcRootOrFirstFolder = roots.length > 0 ? roots[0] : cwd
 
   return checkAvailable(extension, dvcRootOrFirstFolder)
+}
+
+export const setupWithGlobalRecheck = async (
+  extension: IExtension,
+  recheckInterval = 5000
+): Promise<void> => {
+  await setup(extension)
+
+  if (!extension.getAvailable()) {
+    recheckGlobal(extension, () => setup(extension), recheckInterval)
+  }
 }

--- a/extension/src/setupUtil.ts
+++ b/extension/src/setupUtil.ts
@@ -1,9 +1,0 @@
-import { IExtension } from './interfaces'
-import { checkAvailable } from './setup'
-
-export const willRecheck = (
-  extension: IExtension,
-  dvcRootOrFirstFolder: string
-) => {
-  setTimeout(() => checkAvailable(extension, dvcRootOrFirstFolder, true), 5000)
-}

--- a/extension/src/test/suite/extension.test.ts
+++ b/extension/src/test/suite/extension.test.ts
@@ -22,7 +22,6 @@ import {
   RegisteredCliCommands,
   RegisteredCommands
 } from '../../commands/external'
-import * as Discovery from '../../cli/dvc/discovery'
 import * as Setup from '../../setup'
 import * as Telemetry from '../../telemetry'
 import { EventName } from '../../telemetry/constants'
@@ -359,7 +358,6 @@ suite('Extension Test Suite', () => {
 
       const mockErrorMessage = 'NOPE'
       stub(Setup, 'setupWorkspace').rejects(new Error(mockErrorMessage))
-      stub(Discovery, 'recheckGlobal').resolves(undefined)
       const mockSendTelemetryEvent = stub(Telemetry, 'sendTelemetryEvent')
 
       await expect(

--- a/extension/src/test/suite/extension.test.ts
+++ b/extension/src/test/suite/extension.test.ts
@@ -22,6 +22,7 @@ import {
   RegisteredCliCommands,
   RegisteredCommands
 } from '../../commands/external'
+import * as Discovery from '../../cli/dvc/discovery'
 import * as Setup from '../../setup'
 import * as Telemetry from '../../telemetry'
 import { EventName } from '../../telemetry/constants'
@@ -55,7 +56,6 @@ suite('Extension Test Suite', () => {
     ])
   })
 
-  // eslint-disable-next-line sonarjs/cognitive-complexity
   describe('dvc.setupWorkspace', () => {
     it('should set dvc.dvcPath to the default when dvc is installed in a virtual environment', async () => {
       stub(Python, 'isPythonExtensionInstalled').returns(true)
@@ -359,6 +359,7 @@ suite('Extension Test Suite', () => {
 
       const mockErrorMessage = 'NOPE'
       stub(Setup, 'setupWorkspace').rejects(new Error(mockErrorMessage))
+      stub(Discovery, 'recheckGlobal').resolves(undefined)
       const mockSendTelemetryEvent = stub(Telemetry, 'sendTelemetryEvent')
 
       await expect(


### PR DESCRIPTION
Paired on this solution this morning with @sroy3 

Follow up from [#2894 (comment)](https://github.com/iterative/vscode-dvc/pull/2894/files#r1045301489)

If the CLI cannot be located when the extension runs setup for the first time then we need to recheck periodically if the extension has become available globally. The previous implementation would recursively call `setup` every 5 seconds if the CLI could not be found on the first pass. This had a couple of issues:

- There are 4 different things that trigger setup and each of these checked every 5 seconds if they don't find the correct thing (including manual setup the workspace). This could have led to multiple redundant calls.
- The code inside `setup` was unnecessarily complicated

The solution is to split out the global recheck from the rest of the setup code and only call it once at the extension's instantiation.

### Demo

https://user-images.githubusercontent.com/37993418/207483094-af9313c5-99ee-4792-99cc-71038a8abd67.mov

