### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "ignoreDeps": ["execa", "@types/node", "@types/vscode"],
+  "ignoreDeps": ["@types/node", "@types/vscode", "execa", "process-exists"],
   "extends": ["config:base"],
   "packageRules": [
     {


### PR DESCRIPTION
`process-exists` matches `execa` in that the next version is esm only so we cannot upgrade without making some major changes to our codebase. 