### PR TITLE
Prevent unnecessary CLI calls in the integration test suite

### DIFF
--- a/extension/src/experiments/data/index.ts
+++ b/extension/src/experiments/data/index.ts
@@ -66,10 +66,6 @@ export class ExperimentsData extends BaseData<ExperimentsOutput> {
     return this.notifyChanged(data)
   }
 
-  public forceUpdate() {
-    return this.processManager.forceRunQueued()
-  }
-
   protected collectFiles(data: ExperimentsOutput) {
     this.collectedFiles = collectFiles(data, this.collectedFiles)
   }

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -163,10 +163,6 @@ export class Experiments extends BaseRepository<TableData> {
     return this.cliData.managedUpdate()
   }
 
-  public forceUpdate() {
-    return this.cliData.forceUpdate()
-  }
-
   public async setState(data: ExperimentsOutput) {
     const dvcLiveOnly = await checkSignalFile(
       join(this.dvcRoot, DVCLIVE_ONLY_RUNNING_SIGNAL_FILE)

--- a/extension/src/processManager.ts
+++ b/extension/src/processManager.ts
@@ -55,17 +55,6 @@ export class ProcessManager extends Disposable {
     return this.runQueued()
   }
 
-  public async forceRunQueued(): Promise<void> {
-    const next = this.getNextFromQueue()
-    if (!next) {
-      return
-    }
-
-    const { process } = this.processes[next]
-    await Promise.all([process(), this.setLastStarted(next)])
-    return this.forceRunQueued()
-  }
-
   public isOngoingOrQueued(name: string) {
     return this.isOngoing(name) || this.isQueued(name)
   }
@@ -92,7 +81,7 @@ export class ProcessManager extends Disposable {
 
   private runQueued(): Promise<void> {
     const next = this.getNextFromQueue()
-    if (!next) {
+    if (!next || this.dispose.disposed) {
       return Promise.resolve()
     }
 

--- a/extension/src/test/suite/experiments/data/index.test.ts
+++ b/extension/src/test/suite/experiments/data/index.test.ts
@@ -2,11 +2,11 @@ import { afterEach, beforeEach, describe, it, suite } from 'mocha'
 import { EventEmitter, RelativePattern } from 'vscode'
 import { expect } from 'chai'
 import { stub, restore, spy } from 'sinon'
-import { Disposable } from '../../../../extension'
 import {
   bypassProcessManagerDebounce,
   getFirstArgOfCall,
   getMockNow,
+  getSafeWatcherDisposer,
   stubPrivateMemberMethod
 } from '../../util'
 import { dvcDemoPath, getTestWorkspaceFolder } from '../../../util'
@@ -27,14 +27,14 @@ import { gitPath } from '../../../../cli/git/constants'
 import { getGitPath } from '../../../../fileSystem'
 
 suite('Experiments Data Test Suite', () => {
-  const disposable = Disposable.fn()
+  const disposable = getSafeWatcherDisposer()
 
   beforeEach(() => {
     restore()
   })
 
   afterEach(() => {
-    disposable.dispose()
+    return disposable.disposeAndFlush()
   })
 
   describe('ExperimentsData', () => {

--- a/extension/src/test/suite/experiments/model/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/tree.test.ts
@@ -12,12 +12,12 @@ import {
   window
 } from 'vscode'
 import { addFilterViaQuickInput } from './filterBy/util'
-import { Disposable } from '../../../../extension'
 import { ExperimentsModel, ExperimentType } from '../../../../experiments/model'
 import { UNSELECTED } from '../../../../experiments/model/status'
 import {
   experimentsUpdatedEvent,
   getFirstArgOfLastCall,
+  getSafeWatcherDisposer,
   spyOnPrivateMethod,
   stubPrivatePrototypeMethod
 } from '../../util'
@@ -55,14 +55,14 @@ import { ExperimentItem } from '../../../../experiments/model/collect'
 import { EXPERIMENT_WORKSPACE_ID } from '../../../../cli/dvc/contract'
 
 suite('Experiments Tree Test Suite', () => {
-  const disposable = Disposable.fn()
+  const disposable = getSafeWatcherDisposer()
 
   beforeEach(() => {
     restore()
   })
 
   afterEach(() => {
-    disposable.dispose()
+    return disposable.disposeAndFlush()
   })
 
   // eslint-disable-next-line sonarjs/cognitive-complexity

--- a/extension/src/test/suite/experiments/util.ts
+++ b/extension/src/test/suite/experiments/util.ts
@@ -153,6 +153,7 @@ export const buildSingleRepoExperiments = (disposer: Disposer) => {
 
   return { messageSpy, workspaceExperiments }
 }
+
 const buildExperimentsDataDependencies = (disposer: Disposer) => {
   const mockCreateFileSystemWatcher = stub(
     Watcher,

--- a/extension/src/test/suite/experiments/util.ts
+++ b/extension/src/test/suite/experiments/util.ts
@@ -10,7 +10,8 @@ import {
   buildDependencies,
   buildInternalCommands,
   buildMockData,
-  mockDisposable
+  mockDisposable,
+  SafeWatcherDisposer
 } from '../util'
 import {
   ExperimentsOutput,
@@ -95,7 +96,7 @@ export const buildExperiments = (
   }
 }
 
-export const buildMultiRepoExperiments = (disposer: Disposer) => {
+export const buildMultiRepoExperiments = (disposer: SafeWatcherDisposer) => {
   const {
     internalCommands,
     experiments: mockExperiments,
@@ -126,7 +127,7 @@ export const buildMultiRepoExperiments = (disposer: Disposer) => {
   return { experiments, internalCommands, messageSpy, workspaceExperiments }
 }
 
-export const buildSingleRepoExperiments = (disposer: Disposer) => {
+export const buildSingleRepoExperiments = (disposer: SafeWatcherDisposer) => {
   const {
     internalCommands,
     gitReader,
@@ -165,7 +166,7 @@ const buildExperimentsDataDependencies = (disposer: Disposer) => {
   return { internalCommands, mockCreateFileSystemWatcher, mockExperimentShow }
 }
 
-export const buildExperimentsData = (disposer: Disposer) => {
+export const buildExperimentsData = (disposer: SafeWatcherDisposer) => {
   const { internalCommands, mockExperimentShow, mockCreateFileSystemWatcher } =
     buildExperimentsDataDependencies(disposer)
 

--- a/extension/src/test/suite/experiments/workspace.test.ts
+++ b/extension/src/test/suite/experiments/workspace.test.ts
@@ -12,7 +12,12 @@ import { Disposable } from '../../../extension'
 import { Experiments } from '../../../experiments'
 import * as QuickPick from '../../../vscode/quickPick'
 import { DvcExecutor } from '../../../cli/dvc/executor'
-import { closeAllEditors, getInputBoxEvent, mockDuration } from '../util'
+import {
+  closeAllEditors,
+  getInputBoxEvent,
+  getSafeWatcherDisposer,
+  mockDuration
+} from '../util'
 import { dvcDemoPath } from '../../util'
 import { RegisteredCliCommands } from '../../../commands/external'
 import * as Telemetry from '../../../telemetry'
@@ -30,15 +35,14 @@ import { GitExecutor } from '../../../cli/git/executor'
 import { EXPERIMENT_WORKSPACE_ID } from '../../../cli/dvc/contract'
 
 suite('Workspace Experiments Test Suite', () => {
-  const disposable = Disposable.fn()
+  const disposable = getSafeWatcherDisposer()
 
   beforeEach(() => {
     restore()
   })
 
   afterEach(() => {
-    disposable.dispose()
-    return closeAllEditors()
+    return Promise.all([closeAllEditors(), disposable.disposeAndFlush()])
   })
 
   const onDidChangeIsWebviewFocused = (

--- a/extension/src/test/suite/extension.test.ts
+++ b/extension/src/test/suite/extension.test.ts
@@ -6,6 +6,7 @@ import { window, commands, workspace, Uri } from 'vscode'
 import {
   closeAllEditors,
   configurationChangeEvent,
+  mockDisposable,
   mockDuration,
   quickPickInitialized,
   selectQuickPickItem
@@ -23,6 +24,7 @@ import {
   RegisteredCommands
 } from '../../commands/external'
 import * as Setup from '../../setup'
+import * as Watcher from '../../fileSystem/watcher'
 import * as Telemetry from '../../telemetry'
 import { EventName } from '../../telemetry/constants'
 import { OutputChannel } from '../../vscode/outputChannel'
@@ -447,6 +449,7 @@ suite('Extension Test Suite', () => {
     })
 
     it('should set the dvc.cli.incompatible context value', async () => {
+      stub(Watcher, 'createFileSystemWatcher').returns(mockDisposable)
       stub(DvcReader.prototype, 'expShow').resolves({
         [EXPERIMENT_WORKSPACE_ID]: { baseline: {} }
       })

--- a/extension/src/test/suite/fileSystem/data/index.test.ts
+++ b/extension/src/test/suite/fileSystem/data/index.test.ts
@@ -2,23 +2,26 @@ import { afterEach, beforeEach, describe, it, suite } from 'mocha'
 import { stub, restore } from 'sinon'
 import { expect } from 'chai'
 import { RelativePattern } from 'vscode'
-import { Disposable } from '../../../../extension'
 import { FileSystemData } from '../../../../fileSystem/data'
 import { dvcDemoPath, getTestWorkspaceFolder } from '../../../util'
 import * as FileSystem from '../../../../fileSystem'
 import * as Watcher from '../../../../fileSystem/watcher'
-import { getFirstArgOfCall, mockDisposable } from '../../util'
+import {
+  getFirstArgOfCall,
+  getSafeWatcherDisposer,
+  mockDisposable
+} from '../../util'
 import { join } from '../../../util/path'
 
 suite('File System Data Test Suite', () => {
-  const disposable = Disposable.fn()
+  const disposable = getSafeWatcherDisposer()
 
   beforeEach(() => {
     restore()
   })
 
   afterEach(() => {
-    disposable.dispose()
+    return disposable.disposeAndFlush()
   })
 
   describe('FileSystemData', () => {

--- a/extension/src/test/suite/getStarted/index.test.ts
+++ b/extension/src/test/suite/getStarted/index.test.ts
@@ -23,8 +23,10 @@ suite('GetStarted Test Suite', () => {
 
   describe('Get Started', () => {
     it('should handle a initialize project message from the webview', async () => {
-      const { messageSpy, getStarted, mockInitializeProject } =
-        await buildGetStarted(disposable, true)
+      const { messageSpy, getStarted, mockInitializeProject } = buildGetStarted(
+        disposable,
+        true
+      )
 
       const webview = await getStarted.showWebview()
       await webview.isReady()
@@ -40,8 +42,10 @@ suite('GetStarted Test Suite', () => {
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should handle a open experiments message from the webview', async () => {
-      const { messageSpy, getStarted, mockOpenExperiments } =
-        await buildGetStarted(disposable, true)
+      const { messageSpy, getStarted, mockOpenExperiments } = buildGetStarted(
+        disposable,
+        true
+      )
 
       const webview = await getStarted.showWebview()
       await webview.isReady()
@@ -57,7 +61,7 @@ suite('GetStarted Test Suite', () => {
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should log an error message if the message from the webview is anything else than initialize project', async () => {
-      const { messageSpy, getStarted } = await buildGetStarted(disposable)
+      const { messageSpy, getStarted } = buildGetStarted(disposable)
 
       const webview = await getStarted.showWebview()
       await webview.isReady()

--- a/extension/src/test/suite/plots/data/index.test.ts
+++ b/extension/src/test/suite/plots/data/index.test.ts
@@ -3,14 +3,14 @@ import { afterEach, beforeEach, describe, it, suite } from 'mocha'
 import { EventEmitter } from 'vscode'
 import { expect } from 'chai'
 import { restore, spy, stub } from 'sinon'
-import { Disposable } from '../../../../extension'
 import { PlotsData } from '../../../../plots/data'
 import { PlotsModel } from '../../../../plots/model'
 import { dvcDemoPath } from '../../../util'
 import {
   buildDependencies,
   bypassProcessManagerDebounce,
-  getMockNow
+  getMockNow,
+  getSafeWatcherDisposer
 } from '../../util'
 import {
   AvailableCommands,
@@ -23,7 +23,7 @@ import { removeDir } from '../../../../fileSystem'
 import { EXPERIMENT_WORKSPACE_ID } from '../../../../cli/dvc/contract'
 
 suite('Plots Data Test Suite', () => {
-  const disposable = Disposable.fn()
+  const disposable = getSafeWatcherDisposer()
 
   beforeEach(() => {
     restore()
@@ -31,7 +31,7 @@ suite('Plots Data Test Suite', () => {
 
   afterEach(function () {
     this.timeout(6000)
-    disposable.dispose()
+    return disposable.disposeAndFlush()
   })
 
   const buildPlotsData = (

--- a/extension/src/test/suite/processManager.test.ts
+++ b/extension/src/test/suite/processManager.test.ts
@@ -119,46 +119,5 @@ suite('Process Manager Test Suite', () => {
       expect(await updatesRestartedEvent).to.be.false
       expect(mockUpdate, 'the queue is flushed on restart').to.be.calledOnce
     })
-
-    it('should empty the queue with forceRunQueued even if all processes are paused', async () => {
-      const mockPartialUpdate = stub()
-      const mockFullUpdate = stub()
-      const processesPaused = disposable.track(new EventEmitter<boolean>())
-      const processManager = disposable.track(
-        new ProcessManager(
-          processesPaused,
-          {
-            name: 'partialUpdate',
-            process: mockPartialUpdate
-          },
-          {
-            name: 'fullUpdate',
-            process: mockFullUpdate
-          }
-        )
-      )
-      processesPaused.fire(true)
-
-      await Promise.all([
-        processManager.run('partialUpdate'),
-        processManager.run('fullUpdate'),
-        processManager.run('partialUpdate'),
-        processManager.run('fullUpdate'),
-        processManager.run('partialUpdate'),
-        processManager.run('fullUpdate')
-      ])
-
-      expect(mockPartialUpdate, 'all calls are sent to the queue').not.to.be
-        .called
-      expect(mockFullUpdate).not.to.be.called
-
-      await processManager.forceRunQueued()
-
-      expect(
-        mockPartialUpdate,
-        'the queue is flushed when forceRunQueued is called'
-      ).to.be.calledOnce
-      expect(mockFullUpdate).to.be.calledOnce
-    })
   })
 })

--- a/extension/src/test/suite/repository/data/index.test.ts
+++ b/extension/src/test/suite/repository/data/index.test.ts
@@ -3,7 +3,6 @@ import { expect } from 'chai'
 import { restore, spy, stub } from 'sinon'
 import { EventEmitter } from 'vscode'
 import { buildRepositoryData } from '../util'
-import { Disposable } from '../../../../extension'
 import { dvcDemoPath } from '../../../util'
 import { fireWatcher } from '../../../../fileSystem/watcher'
 import { RepositoryData } from '../../../../repository/data'
@@ -14,16 +13,17 @@ import {
 } from '../../../../commands/internal'
 import { gitPath } from '../../../../cli/git/constants'
 import { getGitPath } from '../../../../fileSystem'
+import { getSafeWatcherDisposer } from '../../util'
 
 suite('Repository Data Test Suite', () => {
-  const disposable = Disposable.fn()
+  const disposable = getSafeWatcherDisposer()
 
   beforeEach(() => {
     restore()
   })
 
   afterEach(() => {
-    disposable.dispose()
+    return disposable.disposeAndFlush()
   })
 
   describe('RepositoryData', () => {

--- a/extension/src/test/suite/repository/model/tree.test.ts
+++ b/extension/src/test/suite/repository/model/tree.test.ts
@@ -215,7 +215,7 @@ suite('Repositories Tree Test Suite', () => {
     })
 
     it('should be able to compare two files', async () => {
-      const baseline = Uri.file(join(dvcDemoPath, 'logs.json'))
+      const baseline = Uri.file(join(dvcDemoPath, 'dvc.yaml'))
       const comparison = Uri.file(join(dvcDemoPath, 'requirements.txt'))
       const executeCommandSpy = spy(commands, 'executeCommand')
 
@@ -283,10 +283,11 @@ suite('Repositories Tree Test Suite', () => {
     })
 
     it('should pull the correct target(s) when asked to dvc.pullTarget a non-tracked directory', async () => {
-      const { dvcReader, gitReader, internalCommands, updatesPaused } =
+      const { gitReader, internalCommands, mockDataStatus, updatesPaused } =
         buildDependencies(disposable)
 
-      stub(dvcReader, 'dataStatus').resolves({
+      mockDataStatus.resetBehavior()
+      mockDataStatus.resolves({
         unchanged: [
           join('data', 'data.xml'),
           join('data', 'features'),

--- a/extension/src/test/suite/repository/util.ts
+++ b/extension/src/test/suite/repository/util.ts
@@ -13,7 +13,6 @@ import * as Time from '../../../util/time'
 import * as Watcher from '../../../fileSystem/watcher'
 import { Repository } from '../../../repository'
 import { InternalCommands } from '../../../commands/internal'
-import { DataStatusOutput } from '../../../cli/dvc/contract'
 
 export const buildDependencies = (disposer: Disposer) => {
   const { dvcReader, gitReader, internalCommands } =
@@ -57,7 +56,7 @@ export const buildRepositoryData = async (disposer: Disposer) => {
     updatesPaused
   } = buildDependencies(disposer)
 
-  mockDataStatus.resolves({} as DataStatusOutput)
+  mockDataStatus.resolves({})
   mockGetAllUntracked.resolves(new Set())
   mockNow.returns(FIRST_TRUTHY_TIME)
 

--- a/extension/src/test/suite/repository/util.ts
+++ b/extension/src/test/suite/repository/util.ts
@@ -5,6 +5,7 @@ import {
   buildInternalCommands,
   FIRST_TRUTHY_TIME,
   mockDisposable,
+  SafeWatcherDisposer,
   spyOnPrivateMemberMethod
 } from '../util'
 import { Disposer } from '../../../extension'
@@ -46,7 +47,7 @@ export const buildDependencies = (disposer: Disposer) => {
   }
 }
 
-export const buildRepositoryData = async (disposer: Disposer) => {
+export const buildRepositoryData = async (disposer: SafeWatcherDisposer) => {
   const {
     internalCommands,
     mockCreateFileSystemWatcher,

--- a/extension/src/test/suite/util.ts
+++ b/extension/src/test/suite/util.ts
@@ -177,6 +177,8 @@ export const buildDependencies = (
     false
   )
 
+  const mockDataStatus = stub(dvcReader, 'dataStatus').resolves({})
+
   const mockPlotsDiff = stub(dvcReader, 'plotsDiff').resolves(plotsDiff)
 
   const mockExperimentShow = stub(dvcReader, 'expShow').resolves(expShow)
@@ -196,6 +198,7 @@ export const buildDependencies = (
     messageSpy,
     mockCheckSignalFile,
     mockCreateFileSystemWatcher,
+    mockDataStatus,
     mockExperimentShow,
     mockPlotsDiff,
     resourceLocator,
@@ -243,3 +246,15 @@ export const spyOnPrivateMemberMethod = <T>(
   memberName: string,
   method: string
 ) => spy((classWithPrivateMember as any)[memberName], method)
+
+export const getSafeWatcherDisposer = (): Disposer & {
+  disposeAndFlush: () => Promise<unknown>
+} => {
+  const disposer = Disposable.fn()
+  return Object.assign(disposer, {
+    disposeAndFlush: () => {
+      disposer.dispose()
+      return Time.delay(500)
+    }
+  })
+}

--- a/extension/src/test/suite/util.ts
+++ b/extension/src/test/suite/util.ts
@@ -247,6 +247,10 @@ export const spyOnPrivateMemberMethod = <T>(
   method: string
 ) => spy((classWithPrivateMember as any)[memberName], method)
 
+export type SafeWatcherDisposer = Disposer & {
+  disposeAndFlush: () => Promise<unknown>
+}
+
 export const getSafeWatcherDisposer = (): Disposer & {
   disposeAndFlush: () => Promise<unknown>
 } => {

--- a/extension/src/util/disposable.test.ts
+++ b/extension/src/util/disposable.test.ts
@@ -25,7 +25,9 @@ describe('reset', () => {
     const aDisposable = disposer.track(Disposable.fn())
     let disposables: Record<string, Disposer> = { aDisposable, bDisposable }
 
-    disposables = reset<Disposer>(disposables, disposer)
+    disposables = reset<Disposer>(disposables, disposable =>
+      disposer.untrack(disposable)
+    )
 
     expect(disposables).toStrictEqual({})
   })
@@ -37,7 +39,7 @@ describe('reset', () => {
     const cDisposable = disposer.track(Disposable.fn())
     const disposables = { aDisposable, bDisposable, cDisposable }
 
-    reset(disposables, disposer)
+    reset(disposables, disposable => disposer.untrack(disposable))
 
     expect(mockedDispose).toHaveBeenCalledTimes(3)
   })
@@ -48,7 +50,7 @@ describe('reset', () => {
     const disposable = disposer.track(Disposable.fn())
     const disposables = { aDisposable: disposable }
 
-    reset(disposables, disposer)
+    reset(disposables, disposable => disposer.untrack(disposable))
 
     expect(mockedUntrack).toHaveBeenCalledWith(disposable)
   })

--- a/extension/src/util/disposable.ts
+++ b/extension/src/util/disposable.ts
@@ -1,13 +1,13 @@
-import { Disposable, Disposer } from '@hediet/std/disposable'
+import { Disposable } from '@hediet/std/disposable'
 
 export type Disposables<T> = Record<string, T>
 
 export const reset = <T extends Disposable>(
   disposables: Disposables<T>,
-  disposer: Disposer
+  untrack: (disposable: T) => void
 ): Disposables<T> => {
   for (const disposable of Object.values(disposables)) {
-    disposer.untrack(disposable)
+    untrack(disposable)
     disposable.dispose()
   }
   disposables = {} as Disposables<T>

--- a/extension/src/workspace/index.ts
+++ b/extension/src/workspace/index.ts
@@ -38,7 +38,9 @@ export abstract class BaseWorkspace<
   }
 
   public reset(): void {
-    this.repositories = reset<T>(this.repositories, this.dispose)
+    this.repositories = reset<T>(this.repositories, (disposable: T) =>
+      this.dispose.untrack(disposable)
+    )
     this.resetDeferred()
   }
 


### PR DESCRIPTION
After seeing #2929 fail numerous times on 🪟s I went down the rabbit hole of trying to completely clean our integration test logs (and thus clean up unexpected behaviour). Found some very weird behaviour and dead code but think I got to the bottom of it all. Comments inline.