### PR TITLE
Revert e2e tests back on to insiders

### DIFF
--- a/extension/src/test/e2e/wdio.conf.ts
+++ b/extension/src/test/e2e/wdio.conf.ts
@@ -33,7 +33,7 @@ export const config: Options.Testrunner = {
   capabilities: [
     {
       browserName: 'vscode',
-      browserVersion: 'stable',
+      browserVersion: 'insiders',
       'wdio:vscodeOptions': {
         extensionPath,
         userSettings: {


### PR DESCRIPTION
The runner needs to download the applicable manifest from `https://raw.githubusercontent.com/microsoft/vscode/${VERSION}/cgmanifest.json` so that it can grab the correct version chromedriver. As you can see here: https://raw.githubusercontent.com/microsoft/vscode/1.74.1/cgmanifest.json this is not available yet. 

I have to the maintainer of the service and he asked me to raise https://github.com/webdriverio-community/wdio-vscode-service/issues/56

In the meantime we can use `insiders` (again).