### PR TITLE
Do not rely on number of call to execute process stub in integration tests

### DIFF
--- a/extension/src/test/suite/repository/sourceControlManagement/index.test.ts
+++ b/extension/src/test/suite/repository/sourceControlManagement/index.test.ts
@@ -213,6 +213,7 @@ suite('Source Control Management Test Suite', () => {
         GitCli.prototype,
         'getGitRepositoryRoot'
       ).resolves(gitRoot)
+
       const mockExecuteProcess = stubPrivatePrototypeMethod(
         Cli,
         'executeProcess'
@@ -223,8 +224,7 @@ suite('Source Control Management Test Suite', () => {
       })
 
       expect(mockGetGitRepositoryRoot).to.be.calledOnce
-      expect(mockExecuteProcess).to.be.calledOnce
-      expect(mockExecuteProcess).to.be.calledWith({
+      expect(mockExecuteProcess).to.be.calledWithExactly({
         args: ['add', '.'],
         cwd: gitRoot,
         executable: 'git'
@@ -241,8 +241,7 @@ suite('Source Control Management Test Suite', () => {
         rootUri
       })
 
-      expect(mockExecuteProcess).to.be.calledOnce
-      expect(mockExecuteProcess).to.be.calledWith({
+      expect(mockExecuteProcess).to.be.calledWithExactly({
         args: ['reset'],
         cwd: dvcDemoPath,
         executable: 'git'
@@ -251,10 +250,6 @@ suite('Source Control Management Test Suite', () => {
 
     it('should not reset the workspace if the user does not confirm', async () => {
       const mockCheckout = stub(DvcExecutor.prototype, 'checkout').resolves('')
-      const mockExecuteProcess = stubPrivatePrototypeMethod(
-        Cli,
-        'executeProcess'
-      )
 
       stubPrivatePrototypeMethod(WorkspaceRepositories, 'hasChanges').returns(
         true
@@ -274,7 +269,6 @@ suite('Source Control Management Test Suite', () => {
 
       expect(mockShowWarningMessage).to.be.calledOnce
       expect(mockCheckout).not.to.be.called
-      expect(mockExecuteProcess).not.to.be.called
     })
 
     it('should reset the workspace if the user confirms they want to', async () => {
@@ -302,13 +296,12 @@ suite('Source Control Management Test Suite', () => {
 
       expect(mockShowWarningMessage).to.be.calledOnce
       expect(mockCheckout).to.be.calledOnce
-      expect(mockExecuteProcess).to.be.calledTwice
-      expect(mockExecuteProcess).to.be.calledWith({
+      expect(mockExecuteProcess).to.be.calledWithExactly({
         args: ['reset', '--hard', 'HEAD'],
         cwd: dvcDemoPath,
         executable: 'git'
       })
-      expect(mockExecuteProcess).to.be.calledWith({
+      expect(mockExecuteProcess).to.be.calledWithExactly({
         args: ['clean', '-f', '-d', '-q'],
         cwd: dvcDemoPath,
         executable: 'git'
@@ -317,10 +310,6 @@ suite('Source Control Management Test Suite', () => {
 
     it('should not reset the workspace if there is another user initiated command running', async () => {
       const mockCheckout = stub(DvcExecutor.prototype, 'checkout').resolves('')
-      const mockExecuteProcess = stubPrivatePrototypeMethod(
-        Cli,
-        'executeProcess'
-      )
 
       stubPrivatePrototypeMethod(WorkspaceRepositories, 'hasChanges').returns(
         true
@@ -336,7 +325,6 @@ suite('Source Control Management Test Suite', () => {
       )
 
       expect(mockCheckout).not.to.be.called
-      expect(mockExecuteProcess).not.to.be.called
     })
   })
 })

--- a/extension/src/test/suite/repository/sourceControlManagement/index.test.ts
+++ b/extension/src/test/suite/repository/sourceControlManagement/index.test.ts
@@ -14,6 +14,7 @@ import {
 import { WorkspaceRepositories } from '../../../../repository/workspace'
 import { Cli } from '../../../../cli'
 import { GitCli } from '../../../../cli/git'
+import { GitExecutor } from '../../../../cli/git/executor'
 
 suite('Source Control Management Test Suite', () => {
   const disposable = Disposable.fn()
@@ -250,6 +251,10 @@ suite('Source Control Management Test Suite', () => {
 
     it('should not reset the workspace if the user does not confirm', async () => {
       const mockCheckout = stub(DvcExecutor.prototype, 'checkout').resolves('')
+      const mockResetWorkspace = stub(
+        GitExecutor.prototype,
+        'resetWorkspace'
+      ).resolves(undefined)
 
       stubPrivatePrototypeMethod(WorkspaceRepositories, 'hasChanges').returns(
         true
@@ -269,6 +274,7 @@ suite('Source Control Management Test Suite', () => {
 
       expect(mockShowWarningMessage).to.be.calledOnce
       expect(mockCheckout).not.to.be.called
+      expect(mockResetWorkspace).not.to.be.called
     })
 
     it('should reset the workspace if the user confirms they want to', async () => {
@@ -310,6 +316,10 @@ suite('Source Control Management Test Suite', () => {
 
     it('should not reset the workspace if there is another user initiated command running', async () => {
       const mockCheckout = stub(DvcExecutor.prototype, 'checkout').resolves('')
+      const mockResetWorkspace = stub(
+        GitExecutor.prototype,
+        'resetWorkspace'
+      ).resolves(undefined)
 
       stubPrivatePrototypeMethod(WorkspaceRepositories, 'hasChanges').returns(
         true
@@ -325,6 +335,7 @@ suite('Source Control Management Test Suite', () => {
       )
 
       expect(mockCheckout).not.to.be.called
+      expect(mockResetWorkspace).not.to.be.called
     })
   })
 })


### PR DESCRIPTION
We can no longer rely on a stub of `executeProcess` not being called inadvertently. This is because we have a process checking if the CLI has become available globally running in the background when the first setup fails.

This was the root cause of Windows failure here: https://github.com/iterative/vscode-dvc/actions/runs/3699529541/jobs/6267003237