### PR TITLE
Add step into setup the workspace which reveals the current interpreter

### DIFF
--- a/extension/src/extensions/python.ts
+++ b/extension/src/extensions/python.ts
@@ -1,6 +1,9 @@
+import { relative } from 'path'
 import { commands, Event, Uri } from 'vscode'
 import { executeProcess } from '../processExecution'
 import { getExtensionAPI, isInstalled } from '../vscode/extensions'
+import { getFirstWorkspaceFolder } from '../vscode/workspaceFolders'
+import { isSameOrChild } from '../fileSystem'
 
 const PYTHON_EXTENSION_ID = 'ms-python.python'
 
@@ -46,6 +49,25 @@ export const getPythonBinPath = async (): Promise<string | undefined> => {
       })
     } catch {}
   }
+}
+
+export const getPythonInterpreterStr = async (): Promise<
+  string | undefined
+> => {
+  const pythonBinPath = await getPythonBinPath()
+
+  const firstWorkspaceFolder = getFirstWorkspaceFolder()
+
+  if (
+    !(
+      firstWorkspaceFolder &&
+      pythonBinPath &&
+      isSameOrChild(firstWorkspaceFolder, pythonBinPath)
+    )
+  ) {
+    return pythonBinPath
+  }
+  return relative(firstWorkspaceFolder, pythonBinPath)
 }
 
 export const getOnDidChangePythonExecutionDetails = async () => {


### PR DESCRIPTION
Related to #2944 & #2925

This PR adds a step in "Setup the Workspace" (which we might remove shortly) that shows the user which environment is currently selected when they choose to use the Python extension for auto-location of the virtual environment. They can then decide whether to stick with that environment or select another one.

### Demo

https://user-images.githubusercontent.com/37993418/208025159-615498d4-3948-4e28-9141-c29efba18607.mov

