### PR TITLE
Simplify Setup the Workspace by removing manual option when Python extension is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,15 +146,15 @@ These are the VS Code [settings] available for the Extension:
 
 [settings]: https://code.visualstudio.com/docs/getstarted/settings
 
-| **Option**                             | **Description**                                                                                                                                      |
-| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dvc.dvcPath`                          | Path or shell command to the DVC binary. Required unless Microsoft's [Python extension] is installed and the `dvc` package found in its environment. |
-| `dvc.pythonPath`                       | Path to the desired Python interpreter to use with DVC. Required when using a virtual environment.                                                   |
-| `dvc.experimentsTableHeadMaxHeight`    | Maximum height of experiment table head rows.                                                                                                        |
-| `dvc.doNotShowWalkthroughAfterInstall` | Do not prompt to show the Get Started page after installing. Useful for pre-configured development environments                                      |
-| `dvc.doNotRecommendRedHatExtension`    | Do not prompt to install the Red Hat YAML extension, which helps with DVC YAML schema validation (`dvc.yaml` and `.dvc` files).                      |
-| `dvc.doNotShowCliUnavailable`          | Do not warn when the workspace contains a DVC project but the DVC binary is unavailable.                                                             |
-| `dvc.doNotShowUnableToFilter`          | Do not warn before disabling auto-apply filters when these would result in too many experiments being selected.                                      |
+| **Option**                             | **Description**                                                                                                                                          |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dvc.dvcPath`                          | Path or shell command to the DVC binary. Required unless Microsoft's [Python extension] is installed and the `dvc` package found in its environment.     |
+| `dvc.pythonPath`                       | Path to the desired Python interpreter to use with DVC. Should only be utilized when using a virtual environment without Microsoft's [Python extension]. |
+| `dvc.experimentsTableHeadMaxHeight`    | Maximum height of experiment table head rows.                                                                                                            |
+| `dvc.doNotShowWalkthroughAfterInstall` | Do not prompt to show the Get Started page after installing. Useful for pre-configured development environments                                          |
+| `dvc.doNotRecommendRedHatExtension`    | Do not prompt to install the Red Hat YAML extension, which helps with DVC YAML schema validation (`dvc.yaml` and `.dvc` files).                          |
+| `dvc.doNotShowCliUnavailable`          | Do not warn when the workspace contains a DVC project but the DVC binary is unavailable.                                                                 |
+| `dvc.doNotShowUnableToFilter`          | Do not warn before disabling auto-apply filters when these would result in too many experiments being selected.                                          |
 
 > **Note** that the `Setup The Workspace` command helps you set up the basic
 > ones at the [Workspace level] (saved to `.vscode/setting.json`).

--- a/extension/src/setup.test.ts
+++ b/extension/src/setup.test.ts
@@ -384,30 +384,6 @@ describe('setup', () => {
     expect(mockedInitialize).not.toHaveBeenCalled()
   })
 
-  it('should try to select the python interpreter if the workspace contains a DVC project, the cli cannot be found and the user decides to select the python interpreter', async () => {
-    mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
-    mockedHasRoots.mockReturnValueOnce(true)
-    mockedIsPythonExtensionUsed.mockResolvedValueOnce(false)
-    mockedGetCliVersion.mockResolvedValueOnce(undefined)
-    mockedWarnWithOptions.mockResolvedValueOnce(Response.SELECT_INTERPRETER)
-    mockedExecuteProcess.mockImplementation(({ executable }) =>
-      Promise.resolve(executable)
-    )
-    mockedReady.mockResolvedValue(true)
-    mockedGetExtension.mockReturnValue(mockedVscodePython)
-
-    await setup(extension)
-    await flushPromises()
-    expect(mockedSetRoots).toHaveBeenCalledTimes(1)
-    expect(mockedGetConfigValue).toHaveBeenCalledTimes(1)
-    expect(mockedWarnWithOptions).toHaveBeenCalledTimes(1)
-    expect(mockedSetupWorkspace).toHaveBeenCalledTimes(0)
-    expect(mockedExecuteCommand).toHaveBeenCalledTimes(1)
-    expect(mockedSetUserConfigValue).not.toHaveBeenCalled()
-    expect(mockedResetMembers).toHaveBeenCalledTimes(1)
-    expect(mockedInitialize).not.toHaveBeenCalled()
-  })
-
   it('should set a user config option if the workspace contains a DVC project, the cli cannot be found and the user selects never', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
     mockedHasRoots.mockReturnValueOnce(true)
@@ -495,7 +471,6 @@ describe('setup', () => {
     expect(mockedWarnWithOptions).toHaveBeenCalledWith(
       `The extension is unable to initialize. The CLI was not located using the interpreter provided by the Python extension. ${belowMinVersion} is installed globally. For auto Python environment activation, ensure the correct interpreter is set. Active Python interpreter: ${mockedPythonPath}.`,
       Response.SETUP_WORKSPACE,
-      Response.SELECT_INTERPRETER,
       Response.NEVER
     )
     expect(mockedGetCliVersion).toHaveBeenCalledTimes(2)
@@ -586,7 +561,6 @@ describe('setup', () => {
     expect(mockedWarnWithOptions).toHaveBeenCalledWith(
       `The extension is unable to initialize. The CLI was not located using the interpreter provided by the Python extension. The CLI is also not installed globally. For auto Python environment activation, ensure the correct interpreter is set. Active Python interpreter: ${mockedPythonPath}.`,
       Response.SETUP_WORKSPACE,
-      Response.SELECT_INTERPRETER,
       Response.NEVER
     )
     expect(mockedGetCliVersion).toHaveBeenCalledTimes(2)

--- a/extension/src/setup.ts
+++ b/extension/src/setup.ts
@@ -8,7 +8,10 @@ import { ConfigKey, setConfigValue } from './vscode/config'
 import { pickFile } from './vscode/resourcePicker'
 import { getFirstWorkspaceFolder } from './vscode/workspaceFolders'
 import { getSelectTitle, Title } from './vscode/title'
-import { isPythonExtensionInstalled } from './extensions/python'
+import {
+  isPythonExtensionInstalled,
+  selectPythonInterpreter
+} from './extensions/python'
 import { extensionCanRunCli, recheckGlobal } from './cli/dvc/discovery'
 
 const setConfigPath = async (
@@ -102,16 +105,19 @@ const pickVenvOptions = async () => {
 const quickPickVenvOption = () => {
   const options = [
     {
-      description: '• Let me select the virtual environment manually',
-      label: 'Manual',
-      value: 1
-    },
-    {
       description: '• DVC is available globally (e.g. installed as a binary)',
       label: 'Global',
       value: 0
     }
   ]
+  if (!isPythonExtensionInstalled()) {
+    options.unshift({
+      description: '• Let me select the virtual environment manually',
+      label: 'Manual',
+      value: 1
+    })
+  }
+
   if (isPythonExtensionInstalled()) {
     options.unshift({
       description:
@@ -127,12 +133,18 @@ const quickPickVenvOption = () => {
   })
 }
 
-const quickPickOrUnsetPythonInterpreter = (usesVenv: number) => {
+const selectInterpreter = async (usesVenv: number) => {
   if (usesVenv === 1) {
     return enterPathOrPickFile(ConfigKey.PYTHON_PATH, 'Python Interpreter')
   }
 
-  return setConfigPath(ConfigKey.PYTHON_PATH, undefined)
+  await Promise.all([
+    setConfigPath(ConfigKey.PYTHON_PATH, undefined),
+    setConfigPath(ConfigKey.DVC_PATH, undefined)
+  ])
+
+  selectPythonInterpreter()
+  return false
 }
 
 export const setupWorkspace = async (): Promise<boolean> => {
@@ -143,11 +155,7 @@ export const setupWorkspace = async (): Promise<boolean> => {
   }
 
   if (usesVenv) {
-    if (!(await quickPickOrUnsetPythonInterpreter(usesVenv))) {
-      return false
-    }
-
-    return pickVenvOptions()
+    return (await selectInterpreter(usesVenv)) ? pickVenvOptions() : false
   }
 
   return pickCliPath()

--- a/extension/src/setup.ts
+++ b/extension/src/setup.ts
@@ -104,28 +104,24 @@ const pickVenvOptions = async () => {
 
 const quickPickVenvOption = () => {
   const options = [
+    isPythonExtensionInstalled()
+      ? {
+          description:
+            '• Use the virtual environment detected automatically by the Python extension',
+          label: 'Auto',
+          value: 2
+        }
+      : {
+          description: '• Let me select the virtual environment manually',
+          label: 'Manual',
+          value: 1
+        },
     {
       description: '• DVC is available globally (e.g. installed as a binary)',
       label: 'Global',
       value: 0
     }
   ]
-  if (!isPythonExtensionInstalled()) {
-    options.unshift({
-      description: '• Let me select the virtual environment manually',
-      label: 'Manual',
-      value: 1
-    })
-  }
-
-  if (isPythonExtensionInstalled()) {
-    options.unshift({
-      description:
-        '• Use the virtual environment detected automatically by the Python extension',
-      label: 'Auto',
-      value: 2
-    })
-  }
 
   return quickPickValue<number>(options, {
     placeHolder: 'Select an environment where DVC is installed',

--- a/extension/src/setup.ts
+++ b/extension/src/setup.ts
@@ -107,12 +107,12 @@ const quickPickVenvOption = () => {
     isPythonExtensionInstalled()
       ? {
           description:
-            '• Use the virtual environment detected automatically by the Python extension',
+            '• Use the virtual environment detected by the Python extension',
           label: 'Auto',
           value: 2
         }
       : {
-          description: '• Let me select the virtual environment manually',
+          description: '• Select the virtual environment',
           label: 'Manual',
           value: 1
         },

--- a/extension/src/vscode/response.ts
+++ b/extension/src/vscode/response.ts
@@ -7,7 +7,6 @@ export enum Response {
   NEVER = "Don't Show Again",
   NO = 'No',
   SELECT_MOST_RECENT = 'Select Most Recent',
-  SELECT_INTERPRETER = 'Select Python Interpreter',
   SETUP_WORKSPACE = 'Setup The Workspace',
   SHOW = 'Show',
   TURN_OFF = 'Turn Off',


### PR DESCRIPTION
Related to #2944, #2793 & #2925

This PR simplifies "Setup the Workspace" by removing the "Manual" option when `ms-python.python` is installed. It also diverts the user to `Python: Select Interpreter` when they select "Auto". Showing the select interpreter dialog does two things:

1. Confirms the environment that they are using.
2. Allows them to choose another if they want to.

### Demo

https://user-images.githubusercontent.com/37993418/208332027-ccc2f249-0dc0-4293-8ea4-7a17b595e753.mov

There are no longer further options after "Auto". If the user wishes to select a "Global" DVC then they should choose that option.


https://user-images.githubusercontent.com/37993418/208332783-0f79a9ea-9086-4aac-b245-bf0c36c6c8bc.mov


