### PR TITLE
Close setup webview when all actions have been completed

### DIFF
--- a/extension/src/getStarted/webview/messages.ts
+++ b/extension/src/getStarted/webview/messages.ts
@@ -36,6 +36,7 @@ export class WebviewMessages {
       return this.initializeProject()
     }
     if (message.type === MessageFromWebviewType.OPEN_EXPERIMENTS_WEBVIEW) {
+      this.getWebview()?.dispose()
       return this.openExperiments()
     }
     Logger.error(`Unexpected message: ${JSON.stringify(message)}`)

--- a/extension/src/test/suite/getStarted/index.test.ts
+++ b/extension/src/test/suite/getStarted/index.test.ts
@@ -57,6 +57,8 @@ suite('GetStarted Test Suite', () => {
         type: MessageFromWebviewType.OPEN_EXPERIMENTS_WEBVIEW
       })
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((webview as any).disposer.disposed).to.be.true
       expect(mockOpenExperiments).to.be.calledOnce
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 


### PR DESCRIPTION
This PR closes the setup aka get started webview once the user clicks on "Open Experiments". No further action can be completed in that flow so no need to leave the webview hanging around.

### Demo

https://user-images.githubusercontent.com/37993418/208379157-6b426ff0-0132-41dc-a9c2-4da69b0d30d7.mov

