### PR TITLE
Add environment selection information to the DVC status bar item

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -134,13 +134,14 @@ export class Extension extends Disposable implements IExtension {
     )
 
     this.status = this.dispose.track(
-      new Status([
+      new Status(
+        this.config,
         this.dvcExecutor,
         this.dvcReader,
         this.dvcRunner,
         this.gitExecutor,
         this.gitReader
-      ])
+      )
     )
 
     this.experiments = this.dispose.track(

--- a/extension/src/status.ts
+++ b/extension/src/status.ts
@@ -14,7 +14,6 @@ export class Status extends Disposable {
 
   private workers = 0
   private available = false
-  private textSuffix = 'DVC'
 
   constructor(config: Config, ...cliInteractors: ICli[]) {
     super()
@@ -43,26 +42,26 @@ export class Status extends Disposable {
   public async setAvailability(available: boolean) {
     this.available = available
     await this.config.isReady()
-    const { text, tooltip } = this.getEnvDetails()
-
-    this.textSuffix = text ? `DVC ${text}` : 'DVC'
-
-    this.statusBarItem.tooltip = tooltip
     this.setState(!!this.workers)
   }
 
-  private getText(isWorking: boolean) {
+  private getText(isWorking: boolean, envIndicator?: string) {
+    const suffix = envIndicator ? `DVC ${envIndicator}` : 'DVC'
+
     if (!this.available) {
-      return `$(circle-slash) ${this.textSuffix}`
+      return `$(circle-slash) ${suffix}`
     }
     if (isWorking) {
-      return `$(loading~spin) ${this.textSuffix}`
+      return `$(loading~spin) ${suffix}`
     }
-    return `$(circle-large-outline) ${this.textSuffix}`
+    return `$(circle-large-outline) ${suffix}`
   }
 
   private setState(isWorking: boolean) {
-    this.statusBarItem.text = this.getText(isWorking)
+    const { indicator, tooltip } = this.getEnvDetails()
+    this.statusBarItem.text = this.getText(isWorking, indicator)
+    this.statusBarItem.tooltip = tooltip
+
     this.statusBarItem.color = this.getColor()
 
     this.statusBarItem.command = this.getCommand()
@@ -100,18 +99,21 @@ export class Status extends Disposable {
   private getEnvDetails() {
     const dvcPath = this.config.getCliPath()
     if (dvcPath) {
-      return { text: '(Global)', tooltip: dvcPath }
+      return { indicator: '(Global)', tooltip: dvcPath }
     }
 
     if (this.config.isPythonExtensionUsed()) {
-      return { text: '(Auto)', tooltip: 'Interpreter set by Python extension' }
+      return {
+        indicator: '(Auto)',
+        tooltip: 'Interpreter set by Python extension'
+      }
     }
 
     const pythonBinPath = this.config.getPythonBinPath()
     if (pythonBinPath) {
-      return { text: '(Manual)', tooltip: pythonBinPath }
+      return { indicator: '(Manual)', tooltip: pythonBinPath }
     }
 
-    return { text: '(Global)', tooltip: 'dvc' }
+    return { indicator: '(Global)', tooltip: 'dvc' }
   }
 }

--- a/extension/src/status.ts
+++ b/extension/src/status.ts
@@ -3,21 +3,27 @@ import { Disposable } from './class/dispose'
 import { ICli } from './cli'
 import { RegisteredCommands } from './commands/external'
 import { Title } from './vscode/title'
+import { Config } from './config'
 
 export class Status extends Disposable {
   private readonly statusBarItem: StatusBarItem = this.dispose.track(
     window.createStatusBarItem()
   )
 
+  private readonly config: Config
+
   private workers = 0
   private available = false
+  private textSuffix = 'DVC'
 
-  constructor(cliInteractors: ICli[]) {
+  constructor(config: Config, ...cliInteractors: ICli[]) {
     super()
 
     this.statusBarItem.text = this.getText(false)
     this.statusBarItem.show()
     this.statusBarItem.tooltip = 'DVC Extension Status'
+
+    this.config = config
 
     for (const cli of cliInteractors) {
       this.dispose.track(
@@ -34,34 +40,40 @@ export class Status extends Disposable {
     }
   }
 
-  public setAvailability = (available: boolean) => {
+  public async setAvailability(available: boolean) {
     this.available = available
+    await this.config.isReady()
+    const { text, tooltip } = this.getEnvDetails()
+
+    this.textSuffix = text ? `DVC ${text}` : 'DVC'
+
+    this.statusBarItem.tooltip = tooltip
     this.setState(!!this.workers)
   }
 
-  private getText = (isWorking: boolean) => {
+  private getText(isWorking: boolean) {
     if (!this.available) {
-      return '$(circle-slash) DVC'
+      return `$(circle-slash) ${this.textSuffix}`
     }
     if (isWorking) {
-      return '$(loading~spin) DVC'
+      return `$(loading~spin) ${this.textSuffix}`
     }
-    return '$(circle-large-outline) DVC'
+    return `$(circle-large-outline) ${this.textSuffix}`
   }
 
-  private setState = (isWorking: boolean) => {
+  private setState(isWorking: boolean) {
     this.statusBarItem.text = this.getText(isWorking)
     this.statusBarItem.color = this.getColor()
 
     this.statusBarItem.command = this.getCommand()
   }
 
-  private addWorker = () => {
+  private addWorker() {
     this.workers = this.workers + 1
     this.setState(true)
   }
 
-  private removeWorker = () => {
+  private removeWorker() {
     this.workers = Math.max(this.workers - 1, 0)
     if (!this.workers) {
       this.setState(false)
@@ -83,5 +95,23 @@ export class Status extends Disposable {
       command: RegisteredCommands.EXTENSION_SETUP_WORKSPACE,
       title: Title.SETUP_WORKSPACE
     }
+  }
+
+  private getEnvDetails() {
+    const dvcPath = this.config.getCliPath()
+    if (dvcPath) {
+      return { text: '(Global)', tooltip: dvcPath }
+    }
+
+    if (this.config.isPythonExtensionUsed()) {
+      return { text: '(Auto)', tooltip: 'Interpreter set by Python extension' }
+    }
+
+    const pythonBinPath = this.config.getPythonBinPath()
+    if (pythonBinPath) {
+      return { text: '(Manual)', tooltip: pythonBinPath }
+    }
+
+    return { text: '(Global)', tooltip: 'dvc' }
   }
 }

--- a/extension/src/test/suite/status.test.ts
+++ b/extension/src/test/suite/status.test.ts
@@ -11,10 +11,9 @@ import { DvcCli } from '../../cli/dvc'
 import { Config } from '../../config'
 import { RegisteredCommands } from '../../commands/external'
 import { Title } from '../../vscode/title'
+import { ConfigKey } from '../../vscode/config'
 
 suite('Status Test Suite', () => {
-  const dvcPathOption = 'dvc.dvcPath'
-
   const disposable = Disposable.fn()
 
   beforeEach(() => {
@@ -23,7 +22,9 @@ suite('Status Test Suite', () => {
 
   afterEach(async () => {
     disposable.dispose()
-    await workspace.getConfiguration().update(dvcPathOption, undefined, false)
+    await workspace
+      .getConfiguration()
+      .update(ConfigKey.DVC_PATH, undefined, false)
     return closeAllEditors()
   })
 


### PR DESCRIPTION
From the discussion in #2967.

This PR adds environment selection information matching the "Setup the Workspace" command into our status bar item. It also adds a tooltip to the status bar item that includes the path to the environment.

### Demo

https://user-images.githubusercontent.com/37993418/208393609-48882338-867f-4143-b7d6-055735daa9f6.mov

