### PR TITLE
Enable user to move from Global to Auto without reloading the window

### DIFF
--- a/extension/src/config.ts
+++ b/extension/src/config.ts
@@ -48,6 +48,12 @@ export class Config extends DeferredDisposable {
     return this.deferred.resolve()
   }
 
+  public async setPythonAndNotifyIfChanged() {
+    const oldPath = this.pythonBinPath
+    this.pythonBinPath = await this.getConfigOrExtensionPythonBinPath()
+    this.notifyIfChanged(oldPath, this.pythonBinPath)
+  }
+
   public unsetPythonBinPath() {
     this.pythonBinPath = undefined
   }
@@ -93,12 +99,6 @@ export class Config extends DeferredDisposable {
         }
       })
     )
-  }
-
-  private async setPythonAndNotifyIfChanged() {
-    const oldPath = this.pythonBinPath
-    this.pythonBinPath = await this.getConfigOrExtensionPythonBinPath()
-    this.notifyIfChanged(oldPath, this.pythonBinPath)
   }
 
   private notifyIfChanged(

--- a/extension/src/config.ts
+++ b/extension/src/config.ts
@@ -43,6 +43,11 @@ export class Config extends DeferredDisposable {
     return this.pythonBinPath
   }
 
+  public async setPythonBinPath() {
+    this.pythonBinPath = await this.getConfigOrExtensionPythonBinPath()
+    return this.deferred.resolve()
+  }
+
   public unsetPythonBinPath() {
     this.pythonBinPath = undefined
   }
@@ -53,11 +58,6 @@ export class Config extends DeferredDisposable {
 
   private async getConfigOrExtensionPythonBinPath() {
     return getConfigValue(ConfigKey.PYTHON_PATH) || (await getPythonBinPath())
-  }
-
-  private async setPythonBinPath() {
-    this.pythonBinPath = await this.getConfigOrExtensionPythonBinPath()
-    return this.deferred.resolve()
   }
 
   private async onDidChangePythonExecutionDetails() {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -338,7 +338,9 @@ export class Extension extends Disposable implements IExtension {
       const previousCliPath = this.config.getCliPath()
       const previousPythonPath = this.config.getPythonBinPath()
 
-      const completed = await setupWorkspace()
+      const completed = await setupWorkspace(() =>
+        this.config.setPythonBinPath()
+      )
       sendTelemetryEvent(
         RegisteredCommands.EXTENSION_SETUP_WORKSPACE,
         { completed },
@@ -507,8 +509,18 @@ export class Extension extends Disposable implements IExtension {
     return createFileSystemWatcher(
       disposable => this.dispose.track(disposable),
       '**/dvc{,.exe}',
-      path => {
-        if (path && (!this.cliAccessible || !this.cliCompatible)) {
+      async path => {
+        if (!path) {
+          return
+        }
+
+        const previousPythonBinPath = this.config.getPythonBinPath()
+        await this.config.setPythonBinPath()
+
+        const trySetupWithVenv =
+          previousPythonBinPath !== this.config.getPythonBinPath()
+
+        if (!this.cliAccessible || !this.cliCompatible || trySetupWithVenv) {
           setup(this)
         }
       }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -339,7 +339,7 @@ export class Extension extends Disposable implements IExtension {
       const previousPythonPath = this.config.getPythonBinPath()
 
       const completed = await setupWorkspace(() =>
-        this.config.setPythonBinPath()
+        this.config.setPythonAndNotifyIfChanged()
       )
       sendTelemetryEvent(
         RegisteredCommands.EXTENSION_SETUP_WORKSPACE,

--- a/extension/src/setup.test.ts
+++ b/extension/src/setup.test.ts
@@ -79,6 +79,8 @@ const mockedSetRoots = jest.fn()
 const mockedSetupWorkspace = jest.fn()
 const mockedUnsetPythonBinPath = jest.fn()
 
+const mockedSetConfigToUsePythonExtension = jest.fn()
+
 const mockedQuickPickYesOrNo = jest.mocked(quickPickYesOrNo)
 const mockedQuickPickValue = jest.mocked(quickPickValue)
 const mockedSetConfigValue = jest.mocked(setConfigValue)
@@ -105,7 +107,7 @@ describe('setupWorkspace', () => {
   it('should present two options if the python extension is installed (Auto & Global)', async () => {
     mockedQuickPickValue.mockResolvedValueOnce(undefined)
 
-    await setupWorkspace()
+    await setupWorkspace(mockedSetConfigToUsePythonExtension)
 
     expect(mockedQuickPickValue).toHaveBeenCalledTimes(1)
     expect(mockedQuickPickValue).toHaveBeenCalledWith(
@@ -123,7 +125,7 @@ describe('setupWorkspace', () => {
   it('should present two options if the python extension is NOT installed (Manual & Global)', async () => {
     mockedExtensions.all = []
 
-    await setupWorkspace()
+    await setupWorkspace(mockedSetConfigToUsePythonExtension)
 
     expect(mockedQuickPickValue).toHaveBeenCalledTimes(1)
     expect(mockedQuickPickValue).toHaveBeenCalledWith(
@@ -141,9 +143,10 @@ describe('setupWorkspace', () => {
   it('should set the dvc path and python path options to undefined if the CLI is being auto detected inside a virtual environment', async () => {
     mockedQuickPickValue.mockResolvedValueOnce(2)
 
-    await setupWorkspace()
+    await setupWorkspace(mockedSetConfigToUsePythonExtension)
 
     expect(mockedQuickPickValue).toHaveBeenCalledTimes(1)
+    expect(mockedSetConfigToUsePythonExtension).toHaveBeenCalledTimes(1)
     expect(mockedSetConfigValue).toHaveBeenCalledWith(
       ConfigKey.DVC_PATH,
       undefined
@@ -158,7 +161,7 @@ describe('setupWorkspace', () => {
     mockedQuickPickValue.mockResolvedValueOnce(1)
     mockedQuickPickOneOrInput.mockResolvedValueOnce(undefined)
 
-    await setupWorkspace()
+    await setupWorkspace(mockedSetConfigToUsePythonExtension)
 
     expect(mockedQuickPickValue).toHaveBeenCalledTimes(1)
     expect(mockedQuickPickOneOrInput).toHaveBeenCalledTimes(1)
@@ -173,8 +176,9 @@ describe('setupWorkspace', () => {
     mockedQuickPickOneOrInput.mockResolvedValueOnce('pick')
     mockedPickFile.mockResolvedValueOnce(mockedPythonPath)
 
-    await setupWorkspace()
+    await setupWorkspace(mockedSetConfigToUsePythonExtension)
 
+    expect(mockedSetConfigToUsePythonExtension).not.toHaveBeenCalled()
     expect(mockedQuickPickValue).toHaveBeenCalledTimes(1)
     expect(mockedQuickPickYesOrNo).toHaveBeenCalledTimes(2)
     expect(mockedQuickPickOneOrInput).toHaveBeenCalledTimes(1)
@@ -190,7 +194,7 @@ describe('setupWorkspace', () => {
   it('should return without setting any options if the dialog is cancelled at the virtual environment step', async () => {
     mockedQuickPickValue.mockResolvedValueOnce(undefined)
 
-    await setupWorkspace()
+    await setupWorkspace(mockedSetConfigToUsePythonExtension)
 
     expect(mockedQuickPickValue).toHaveBeenCalledTimes(1)
     expect(mockedSetConfigValue).not.toHaveBeenCalled()
@@ -208,7 +212,7 @@ describe('setupWorkspace', () => {
       .mockResolvedValueOnce(mockedPythonPath)
       .mockResolvedValueOnce(mockedDvcPath)
 
-    await setupWorkspace()
+    await setupWorkspace(mockedSetConfigToUsePythonExtension)
 
     expect(mockedQuickPickValue).toHaveBeenCalledTimes(1)
     expect(mockedQuickPickYesOrNo).toHaveBeenCalledTimes(2)
@@ -229,7 +233,7 @@ describe('setupWorkspace', () => {
     mockedQuickPickValue.mockResolvedValueOnce(1)
     mockedQuickPickOneOrInput.mockResolvedValueOnce(undefined)
 
-    await setupWorkspace()
+    await setupWorkspace(mockedSetConfigToUsePythonExtension)
 
     expect(mockedQuickPickValue).toHaveBeenCalledTimes(1)
     expect(mockedQuickPickYesOrNo).not.toHaveBeenCalled()
@@ -247,7 +251,7 @@ describe('setupWorkspace', () => {
     mockedQuickPickOneOrInput.mockResolvedValueOnce('pick')
     mockedPickFile.mockResolvedValueOnce(mockedDvcPath)
 
-    await setupWorkspace()
+    await setupWorkspace(mockedSetConfigToUsePythonExtension)
 
     expect(mockedQuickPickValue).toHaveBeenCalledTimes(1)
     expect(mockedQuickPickYesOrNo).toHaveBeenCalledTimes(2)


### PR DESCRIPTION
#2969 uncovered a bug where it was not possible/easy to move from having the extension set to locate the CLI globally to using the CLI in a virtual environment. This PR fixes that bug.

### Demo

https://user-images.githubusercontent.com/37993418/208552930-1be731fb-87d6-4b65-b0a5-d27dbaf87409.mov

https://user-images.githubusercontent.com/37993418/208561932-fd9ad7c7-1ff4-4d96-9d1c-6837894d20bc.mov
