### PR TITLE
Left align code block text on the no data setup screen

### DIFF
--- a/webview/src/shared/components/codeBlock/styles.module.scss
+++ b/webview/src/shared/components/codeBlock/styles.module.scss
@@ -1,4 +1,5 @@
 .codeBlock {
+  text-align: left;
   padding: 10px;
   width: max-content;
   min-width: 500px;

--- a/webview/src/shared/components/codeSlider/styles.module.scss
+++ b/webview/src/shared/components/codeSlider/styles.module.scss
@@ -9,8 +9,3 @@
     margin: 0 auto;
   }
 }
-
-.codeBlock {
-  text-align: left;
-  margin-top: 20px;
-}

--- a/webview/src/stories/NoData.stories.tsx
+++ b/webview/src/stories/NoData.stories.tsx
@@ -1,0 +1,20 @@
+import { Story, Meta } from '@storybook/react/types-6-0'
+import React from 'react'
+import { NoData as SetupNoData } from '../getStarted/components/NoData'
+
+import './test-vscode-styles.scss'
+import '../shared/style.scss'
+
+export default {
+  args: {
+    data: {}
+  },
+  component: SetupNoData,
+  title: 'Setup'
+} as Meta
+
+const Template: Story = () => {
+  return <SetupNoData />
+}
+
+export const NoData = Template.bind({})


### PR DESCRIPTION
Ended up on this screen when working through #2944 (a bug that I have created). Alignment seems to be off inside of the code blocks.

### Before 

<img width="672" alt="image" src="https://user-images.githubusercontent.com/37993418/208579139-48467ed9-991e-4d1f-aad8-2bd7ad767921.png">

### After

<img width="644" alt="image" src="https://user-images.githubusercontent.com/37993418/208579217-f54f1725-42a9-4f3c-9764-add734ff3e73.png">