### PR TITLE
Get closer to theme inside of code blocks shown on no experiments data screen

### DIFF
--- a/webview/src/shared/components/codeBlock/CodeBlock.tsx
+++ b/webview/src/shared/components/codeBlock/CodeBlock.tsx
@@ -9,13 +9,45 @@ export interface CodeBlockProps {
   inline?: boolean
 }
 
+const editorBackground = 'var(--vscode-textCodeBlock-background)'
+const editorForeground = 'var(--vscode-editor-foreground)'
+const tokenHighlight = 'var(--vscode-editorInfo-foreground)'
+
+const approximateTheme = {
+  plain: {
+    backgroundColor: editorBackground,
+    color: editorForeground
+  },
+  styles: [
+    {
+      style: {
+        color: tokenHighlight
+      },
+      types: [
+        'char',
+        'function',
+        'keyword',
+        'operator',
+        'punctuation',
+        'string',
+        'variable'
+      ]
+    }
+  ]
+}
+
 export const CodeBlock: React.FC<CodeBlockProps> = ({
   language,
   children,
   inline
 }) => {
   return (
-    <Highlight {...defaultProps} code={children} language={language}>
+    <Highlight
+      {...defaultProps}
+      code={children}
+      language={language}
+      theme={approximateTheme}
+    >
       {({ className, style, tokens, getLineProps, getTokenProps }) => (
         <pre
           className={cx(className, styles.codeBlock, {


### PR DESCRIPTION
Tried very hard to get access to the editor token colors but we cannot access them via the normal CSS API (or anywhere else that I can see). Docs for both are here: 

- https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide
- https://code.visualstudio.com/api/references/theme-color

Please take a look and LMK if I have missed anything.

I have created an approximate theme for the code-blocks using a few of the colors that are available to us. Take a look at the Storybook and LMK what you think. Although not perfect I think there is an improvement here (for everything outside of the Dive Bar theme).

Edit: investigated relying on CSS values created by `generateTokensCSSForColorMap` in VS code. That gamble would be too risky for the reward IMO.