### PR TITLE
Direct users to setup webview from warning popups

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1355,7 +1355,7 @@
       },
       {
         "view": "dvc.views.webviews",
-        "contents": "[Show Experiments](command:dvc.showSetupWebview)\n[Show Plots](command:dvc.showSetupdWebview)\n[Show Experiments and Plots](command:dvc.showSetupWebview)",
+        "contents": "[Show Experiments](command:dvc.showSetup)\n[Show Plots](command:dvc.showSetupdWebview)\n[Show Experiments and Plots](command:dvc.showSetup)",
         "when": "!dvc.commands.available || !dvc.project.available || !dvc.project.hasData"
       },
       {

--- a/extension/package.json
+++ b/extension/package.json
@@ -1355,7 +1355,7 @@
       },
       {
         "view": "dvc.views.webviews",
-        "contents": "[Show Experiments](command:dvc.showSetup)\n[Show Plots](command:dvc.showSetupdWebview)\n[Show Experiments and Plots](command:dvc.showSetup)",
+        "contents": "[Show Experiments](command:dvc.showSetup)\n[Show Plots](command:dvc.showSetup)\n[Show Experiments and Plots](command:dvc.showSetup)",
         "when": "!dvc.commands.available || !dvc.project.available || !dvc.project.hasData"
       },
       {

--- a/extension/src/cli/dvc/discovery.ts
+++ b/extension/src/cli/dvc/discovery.ts
@@ -46,13 +46,13 @@ const warnUserCLIInaccessible = async (
 
   const response = await Toast.warnWithOptions(
     warningText,
-    Response.SETUP_WORKSPACE,
+    Response.SHOW_SETUP,
     Response.NEVER
   )
 
   switch (response) {
-    case Response.SETUP_WORKSPACE:
-      return extension.setupWorkspace()
+    case Response.SHOW_SETUP:
+      return extension.showSetup()
     case Response.NEVER:
       return setUserConfigValue(ConfigKey.DO_NOT_SHOW_CLI_UNAVAILABLE, true)
   }
@@ -77,7 +77,7 @@ const warnUser = (
   cliCompatible: CliCompatible,
   version: string | undefined
 ): void => {
-  if (!extension.hasRoots()) {
+  if (!extension.shouldWarnUserIfCLIUnavailable()) {
     return
   }
   switch (cliCompatible) {
@@ -154,11 +154,11 @@ const tryGlobalFallbackVersion = async (
   const tryGlobal = await getVersionDetails(extension, cwd, true)
   const { cliCompatible, isAvailable, isCompatible, version } = tryGlobal
 
-  if (extension.hasRoots() && !isCompatible) {
+  if (extension.shouldWarnUserIfCLIUnavailable() && !isCompatible) {
     warnUserCLIInaccessibleAnywhere(extension, version)
   }
   if (
-    extension.hasRoots() &&
+    extension.shouldWarnUserIfCLIUnavailable() &&
     cliCompatible === CliCompatible.YES_MINOR_VERSION_AHEAD_OF_TESTED
   ) {
     warnAheadOfLatestTested()

--- a/extension/src/commands/external.ts
+++ b/extension/src/commands/external.ts
@@ -92,5 +92,5 @@ export enum RegisteredCommands {
   TRACKED_EXPLORER_OPEN_TO_THE_SIDE = 'dvc.openToTheSide',
   TRACKED_EXPLORER_SELECT_FOR_COMPARE = 'dvc.selectForCompare',
 
-  SETUP_WEBVIEW_SHOW = 'dvc.showSetupWebview'
+  SETUP_SHOW = 'dvc.showSetup'
 }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -274,7 +274,7 @@ export class Extension extends Disposable implements IExtension {
     )
 
     this.internalCommands.registerExternalCommand(
-      RegisteredCommands.SETUP_WEBVIEW_SHOW,
+      RegisteredCommands.SETUP_SHOW,
       async () => {
         await this.setup.showWebview()
       }
@@ -341,39 +341,12 @@ export class Extension extends Disposable implements IExtension {
     this.watchForVenvChanges()
   }
 
-  public async setupWorkspace() {
-    const stopWatch = new StopWatch()
-    try {
-      const previousCliPath = this.config.getCliPath()
-      const previousPythonPath = this.config.getPythonBinPath()
+  public async showSetup() {
+    return await this.setup.showWebview()
+  }
 
-      const completed = await setupWorkspace(() =>
-        this.config.setPythonAndNotifyIfChanged()
-      )
-      sendTelemetryEvent(
-        RegisteredCommands.EXTENSION_SETUP_WORKSPACE,
-        { completed },
-        {
-          duration: stopWatch.getElapsedTime()
-        }
-      )
-
-      const executionDetailsUnchanged =
-        this.config.getCliPath() === previousPythonPath &&
-        this.config.getPythonBinPath() === previousCliPath
-
-      if (completed && !this.cliAccessible && executionDetailsUnchanged) {
-        this.workspaceChanged.fire()
-      }
-
-      return completed
-    } catch (error: unknown) {
-      return sendTelemetryEventAndThrow(
-        RegisteredCommands.EXTENSION_SETUP_WORKSPACE,
-        error as Error,
-        stopWatch.getElapsedTime()
-      )
-    }
+  public shouldWarnUserIfCLIUnavailable() {
+    return this.hasRoots() && !this.setup.isFocused()
   }
 
   public async isPythonExtensionUsed() {
@@ -477,6 +450,41 @@ export class Extension extends Disposable implements IExtension {
 
   private setCommandsAvailability(available: boolean) {
     setContextValue('dvc.commands.available', available)
+  }
+
+  private async setupWorkspace() {
+    const stopWatch = new StopWatch()
+    try {
+      const previousCliPath = this.config.getCliPath()
+      const previousPythonPath = this.config.getPythonBinPath()
+
+      const completed = await setupWorkspace(() =>
+        this.config.setPythonAndNotifyIfChanged()
+      )
+      sendTelemetryEvent(
+        RegisteredCommands.EXTENSION_SETUP_WORKSPACE,
+        { completed },
+        {
+          duration: stopWatch.getElapsedTime()
+        }
+      )
+
+      const executionDetailsUnchanged =
+        this.config.getCliPath() === previousPythonPath &&
+        this.config.getPythonBinPath() === previousCliPath
+
+      if (completed && !this.cliAccessible && executionDetailsUnchanged) {
+        this.workspaceChanged.fire()
+      }
+
+      return completed
+    } catch (error: unknown) {
+      return sendTelemetryEventAndThrow(
+        RegisteredCommands.EXTENSION_SETUP_WORKSPACE,
+        error as Error,
+        stopWatch.getElapsedTime()
+      )
+    }
   }
 
   private setProjectAvailability() {

--- a/extension/src/interfaces.ts
+++ b/extension/src/interfaces.ts
@@ -7,7 +7,8 @@ export interface IExtension {
   hasRoots: () => boolean
   isPythonExtensionUsed: () => Promise<boolean>
 
-  setupWorkspace: () => void
+  showSetup: () => void
+  shouldWarnUserIfCLIUnavailable: () => boolean
 
   initialize: () => Promise<void[]>
   resetMembers: () => void

--- a/extension/src/setup.test.ts
+++ b/extension/src/setup.test.ts
@@ -76,7 +76,8 @@ const mockedResetMembers = jest.fn()
 const mockedSetAvailable = jest.fn()
 const mockedSetCliCompatible = jest.fn()
 const mockedSetRoots = jest.fn()
-const mockedSetupWorkspace = jest.fn()
+const mockedShowSetup = jest.fn()
+const mockedShouldWarnUserIfCLIUnavailable = jest.fn()
 const mockedUnsetPythonBinPath = jest.fn()
 
 const mockedSetConfigToUsePythonExtension = jest.fn()
@@ -281,7 +282,8 @@ describe('setup', () => {
     setAvailable: mockedSetAvailable,
     setCliCompatible: mockedSetCliCompatible,
     setRoots: mockedSetRoots,
-    setupWorkspace: mockedSetupWorkspace,
+    shouldWarnUserIfCLIUnavailable: mockedShouldWarnUserIfCLIUnavailable,
+    showSetup: mockedShowSetup,
     unsetPythonBinPath: mockedUnsetPythonBinPath
   }
 
@@ -314,7 +316,7 @@ describe('setup', () => {
     expect(mockedSetRoots).toHaveBeenCalledTimes(1)
     expect(mockedGetConfigValue).not.toHaveBeenCalled()
     expect(mockedWarnWithOptions).not.toHaveBeenCalled()
-    expect(mockedSetupWorkspace).not.toHaveBeenCalled()
+    expect(mockedShowSetup).not.toHaveBeenCalled()
     expect(mockedSetUserConfigValue).not.toHaveBeenCalled()
     expect(mockedResetMembers).toHaveBeenCalledTimes(1)
     expect(mockedInitialize).not.toHaveBeenCalled()
@@ -322,7 +324,7 @@ describe('setup', () => {
 
   it('should not alert the user if the workspace contains a DVC project, the cli cannot be found and the do not show option is set', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
-    mockedHasRoots.mockReturnValueOnce(true)
+    mockedShouldWarnUserIfCLIUnavailable.mockReturnValueOnce(true)
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
     mockedGetCliVersion
       .mockResolvedValueOnce(undefined)
@@ -333,7 +335,7 @@ describe('setup', () => {
     expect(mockedSetRoots).toHaveBeenCalledTimes(1)
     expect(mockedGetConfigValue).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).not.toHaveBeenCalled()
-    expect(mockedSetupWorkspace).not.toHaveBeenCalled()
+    expect(mockedShowSetup).not.toHaveBeenCalled()
     expect(mockedSetUserConfigValue).not.toHaveBeenCalled()
     expect(mockedResetMembers).toHaveBeenCalledTimes(1)
     expect(mockedInitialize).not.toHaveBeenCalled()
@@ -341,7 +343,7 @@ describe('setup', () => {
 
   it('should alert the user if the workspace contains a DVC project and the cli cannot be found', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
-    mockedHasRoots.mockReturnValueOnce(true)
+    mockedShouldWarnUserIfCLIUnavailable.mockReturnValueOnce(true)
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
     mockedGetCliVersion
       .mockResolvedValueOnce(undefined)
@@ -362,14 +364,14 @@ describe('setup', () => {
     expect(mockedInitialize).not.toHaveBeenCalled()
   })
 
-  it('should try to setup the workspace if the workspace contains a DVC project, the cli cannot be found and the user selects setup the workspace', async () => {
+  it('should show the setup webview if the workspace contains a DVC project, the cli cannot be found and the user selects setup', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
-    mockedHasRoots.mockReturnValueOnce(true)
+    mockedShouldWarnUserIfCLIUnavailable.mockReturnValueOnce(true)
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
     mockedGetCliVersion
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(undefined)
-    mockedWarnWithOptions.mockResolvedValueOnce(Response.SETUP_WORKSPACE)
+    mockedWarnWithOptions.mockResolvedValueOnce(Response.SHOW_SETUP)
     mockedExecuteProcess.mockImplementation(({ executable }) =>
       Promise.resolve(executable)
     )
@@ -381,7 +383,7 @@ describe('setup', () => {
     expect(mockedSetRoots).toHaveBeenCalledTimes(1)
     expect(mockedGetConfigValue).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).toHaveBeenCalledTimes(1)
-    expect(mockedSetupWorkspace).toHaveBeenCalledTimes(1)
+    expect(mockedShowSetup).toHaveBeenCalledTimes(1)
     expect(mockedExecuteCommand).not.toHaveBeenCalled()
     expect(mockedSetUserConfigValue).not.toHaveBeenCalled()
     expect(mockedResetMembers).toHaveBeenCalledTimes(1)
@@ -390,7 +392,7 @@ describe('setup', () => {
 
   it('should set a user config option if the workspace contains a DVC project, the cli cannot be found and the user selects never', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
-    mockedHasRoots.mockReturnValueOnce(true)
+    mockedShouldWarnUserIfCLIUnavailable.mockReturnValueOnce(true)
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(false)
     mockedGetCliVersion.mockResolvedValueOnce(undefined)
     mockedWarnWithOptions.mockResolvedValueOnce(Response.NEVER)
@@ -405,7 +407,7 @@ describe('setup', () => {
     expect(mockedSetRoots).toHaveBeenCalledTimes(1)
     expect(mockedGetConfigValue).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).toHaveBeenCalledTimes(1)
-    expect(mockedSetupWorkspace).not.toHaveBeenCalled()
+    expect(mockedShowSetup).not.toHaveBeenCalled()
     expect(mockedExecuteCommand).not.toHaveBeenCalled()
     expect(mockedSetUserConfigValue).toHaveBeenCalledTimes(1)
     expect(mockedResetMembers).toHaveBeenCalledTimes(1)
@@ -414,7 +416,8 @@ describe('setup', () => {
 
   it('should not send telemetry or set the cli as unavailable or run initialization if roots have not been found but the cli can be run', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
-    mockedHasRoots.mockReturnValueOnce(false).mockReturnValueOnce(false)
+    mockedShouldWarnUserIfCLIUnavailable.mockReturnValueOnce(false)
+    mockedHasRoots.mockReturnValueOnce(false)
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(false)
     mockedGetCliVersion.mockResolvedValueOnce(MIN_CLI_VERSION)
 
@@ -427,7 +430,8 @@ describe('setup', () => {
 
   it('should run initialization if roots have been found and the cli can be run', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
-    mockedHasRoots.mockReturnValueOnce(true).mockReturnValueOnce(true)
+    mockedShouldWarnUserIfCLIUnavailable.mockReturnValueOnce(true)
+    mockedHasRoots.mockReturnValueOnce(true)
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
     mockedGetCliVersion.mockResolvedValueOnce(MIN_CLI_VERSION)
 
@@ -438,10 +442,8 @@ describe('setup', () => {
 
   it('should call the cli to see if it is available from path if the Python extension is being used and the first call fails', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
-    mockedHasRoots
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(true)
+    mockedHasRoots.mockReturnValueOnce(true)
+    mockedShouldWarnUserIfCLIUnavailable.mockReturnValueOnce(true)
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
     mockedGetCliVersion
       .mockResolvedValueOnce(undefined)
@@ -456,10 +458,7 @@ describe('setup', () => {
   it('should send a specific message to the user if the Python extension is being used, the CLI is not available in the virtual environment and the global CLI is not compatible', async () => {
     const belowMinVersion = '2.0.0'
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
-    mockedHasRoots
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(true)
+    mockedShouldWarnUserIfCLIUnavailable.mockReturnValueOnce(true)
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
     mockedExecuteProcess.mockImplementation(({ executable }) =>
       Promise.resolve(executable)
@@ -474,7 +473,7 @@ describe('setup', () => {
     expect(mockedWarnWithOptions).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).toHaveBeenCalledWith(
       `The extension is unable to initialize. The CLI was not located using the interpreter provided by the Python extension. ${belowMinVersion} is installed globally. For auto Python environment activation, ensure the correct interpreter is set. Active Python interpreter: ${mockedPythonPath}.`,
-      Response.SETUP_WORKSPACE,
+      Response.SHOW_SETUP,
       Response.NEVER
     )
     expect(mockedGetCliVersion).toHaveBeenCalledTimes(2)
@@ -487,8 +486,8 @@ describe('setup', () => {
       LATEST_TESTED_CLI_VERSION
     ) as ParsedSemver
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
-    mockedHasRoots
-      .mockReturnValueOnce(true)
+    mockedHasRoots.mockReturnValueOnce(true)
+    mockedShouldWarnUserIfCLIUnavailable
       .mockReturnValueOnce(true)
       .mockReturnValueOnce(true)
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
@@ -509,7 +508,7 @@ describe('setup', () => {
 
   it('should send a specific message to the user if the Python extension is not being used and the CLI is not available', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
-    mockedHasRoots.mockReturnValueOnce(true)
+    mockedShouldWarnUserIfCLIUnavailable.mockReturnValueOnce(true)
     mockedExtensions.all = []
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(false)
     mockedGetCliVersion.mockResolvedValueOnce(undefined)
@@ -519,7 +518,7 @@ describe('setup', () => {
     expect(mockedWarnWithOptions).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).toHaveBeenCalledWith(
       'An error was thrown when trying to access the CLI.',
-      Response.SETUP_WORKSPACE,
+      Response.SHOW_SETUP,
       Response.NEVER
     )
     expect(mockedGetCliVersion).toHaveBeenCalledTimes(1)
@@ -532,7 +531,7 @@ describe('setup', () => {
       .map(num => Number(num) + 100)
       .join('.')
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
-    mockedHasRoots.mockReturnValueOnce(true)
+    mockedShouldWarnUserIfCLIUnavailable.mockReturnValueOnce(true)
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
     mockedGetCliVersion.mockResolvedValueOnce(MajorAhead)
 
@@ -550,6 +549,8 @@ describe('setup', () => {
   it('should send a specific message to the user if the Python extension is being used, the CLI is not available in the virtual environment and no cli is found globally', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
     mockedHasRoots.mockReturnValueOnce(true)
+    mockedShouldWarnUserIfCLIUnavailable.mockReturnValueOnce(true)
+    mockedShouldWarnUserIfCLIUnavailable.mockReturnValueOnce(true)
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
     mockedExecuteProcess.mockImplementation(({ executable }) =>
       Promise.resolve(executable)
@@ -564,7 +565,7 @@ describe('setup', () => {
     expect(mockedWarnWithOptions).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).toHaveBeenCalledWith(
       `The extension is unable to initialize. The CLI was not located using the interpreter provided by the Python extension. The CLI is also not installed globally. For auto Python environment activation, ensure the correct interpreter is set. Active Python interpreter: ${mockedPythonPath}.`,
-      Response.SETUP_WORKSPACE,
+      Response.SHOW_SETUP,
       Response.NEVER
     )
     expect(mockedGetCliVersion).toHaveBeenCalledTimes(2)
@@ -586,7 +587,7 @@ describe('setup', () => {
     const [major] = MIN_CLI_VERSION.split('.')
     const behind = [major, 0, 0].join('.')
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
-    mockedHasRoots.mockReturnValueOnce(true)
+    mockedShouldWarnUserIfCLIUnavailable.mockReturnValueOnce(true)
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
     mockedGetCliVersion.mockResolvedValueOnce(behind)
 
@@ -597,7 +598,7 @@ describe('setup', () => {
   it('should run reset if the cli cannot be run and there is a workspace folder open', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(mockedCwd)
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
-    mockedHasRoots.mockReturnValueOnce(true)
+    mockedShouldWarnUserIfCLIUnavailable.mockReturnValueOnce(true)
     mockedGetCliVersion.mockResolvedValueOnce(false)
 
     await setup(extension)
@@ -618,7 +619,8 @@ describe('setupWithGlobalRecheck', () => {
     setAvailable: mockedSetAvailable,
     setCliCompatible: mockedSetCliCompatible,
     setRoots: mockedSetRoots,
-    setupWorkspace: mockedSetupWorkspace,
+    shouldWarnUserIfCLIUnavailable: mockedShouldWarnUserIfCLIUnavailable,
+    showSetup: mockedShowSetup,
     unsetPythonBinPath: mockedUnsetPythonBinPath
   }
 

--- a/extension/src/setup/index.ts
+++ b/extension/src/setup/index.ts
@@ -41,6 +41,10 @@ export class Setup extends BaseRepository<TSetupData> {
     this.getHasData = getHasData
   }
 
+  public isFocused() {
+    return !!this.webview?.isActive
+  }
+
   public sendInitialWebviewData() {
     return this.sendDataToWebview()
   }

--- a/extension/src/status.ts
+++ b/extension/src/status.ts
@@ -91,8 +91,8 @@ export class Status extends Disposable {
       return
     }
     return {
-      command: RegisteredCommands.EXTENSION_SETUP_WORKSPACE,
-      title: Title.SETUP_WORKSPACE
+      command: RegisteredCommands.SETUP_SHOW,
+      title: Title.SHOW_SETUP
     }
   }
 

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -266,5 +266,5 @@ export interface IEventNamePropertyMapping {
   [EventName.VIEWS_SETUP_SELECT_PYTHON_INTERPRETER]: undefined
   [EventName.VIEWS_SETUP_INSTALL_DVC]: undefined
 
-  [EventName.SETUP_WEBVIEW_SHOW]: undefined
+  [EventName.SETUP_SHOW]: undefined
 }

--- a/extension/src/test/suite/status.test.ts
+++ b/extension/src/test/suite/status.test.ts
@@ -119,8 +119,8 @@ suite('Status Test Suite', () => {
 
       expect(mockStatusBarItem.text).to.equal(disabledText)
       expect(mockStatusBarItem.command).to.deep.equal({
-        command: RegisteredCommands.EXTENSION_SETUP_WORKSPACE,
-        title: Title.SETUP_WORKSPACE
+        command: RegisteredCommands.SETUP_SHOW,
+        title: Title.SHOW_SETUP
       })
     })
 

--- a/extension/src/vscode/response.ts
+++ b/extension/src/vscode/response.ts
@@ -7,7 +7,7 @@ export enum Response {
   NEVER = "Don't Show Again",
   NO = 'No',
   SELECT_MOST_RECENT = 'Select Most Recent',
-  SETUP_WORKSPACE = 'Setup The Workspace',
+  SHOW_SETUP = 'Setup',
   SHOW = 'Show',
   TURN_OFF = 'Turn Off',
   YES = 'Yes'

--- a/extension/src/vscode/title.ts
+++ b/extension/src/vscode/title.ts
@@ -5,6 +5,7 @@ export enum Title {
   ENTER_FILTER_VALUE = 'Enter a Filter Value',
   ENTER_RELATIVE_DESTINATION = 'Enter a Destination Relative to the Root',
   GARBAGE_COLLECT_EXPERIMENTS = 'Garbage Collect Experiments',
+  SHOW_SETUP = 'Show Setup',
   SELECT_BASE_EXPERIMENT = 'Select an Experiment to Use as a Base',
   SELECT_COLUMNS = 'Select Columns to Display in the Experiments Table',
   SELECT_EXPERIMENT = 'Select an Experiment',


### PR DESCRIPTION
# 2/2 `main` <- #2944 <- this

This is the first step in integrating the Setup webview with existing user flows. We are now: 

1. Suppressing warning toast messages whenever the webview is open.
3. Directing users to the webview from the toast messages.

### Demo

https://user-images.githubusercontent.com/37993418/209039258-6347c813-6d05-4011-85b9-3ec4c2a497f9.mov

(no stray toast)


https://user-images.githubusercontent.com/37993418/209039397-25976d88-2168-4319-bc42-65d48a3f4eab.mov




