### PR TITLE
Patch CLI incompatible path for onboarding

### DIFF
--- a/extension/src/cli/dvc/constants.ts
+++ b/extension/src/cli/dvc/constants.ts
@@ -1,9 +1,5 @@
 import { join } from 'path'
 
-export const MIN_CLI_VERSION = '2.30.0'
-export const LATEST_TESTED_CLI_VERSION = '2.38.0'
-export const MAX_CLI_VERSION = '3'
-
 export const UNEXPECTED_ERROR_CODE = 255
 
 export const TEMP_PLOTS_DIR = join('.dvc', 'tmp', 'plots')

--- a/extension/src/cli/dvc/contract.ts
+++ b/extension/src/cli/dvc/contract.ts
@@ -1,5 +1,9 @@
 import { Plot } from '../../plots/webview/contract'
 
+export const MIN_CLI_VERSION = '2.30.0'
+export const LATEST_TESTED_CLI_VERSION = '2.38.0'
+export const MAX_CLI_VERSION = '3'
+
 type ErrorContents = { type: string; msg: string }
 
 export type DvcError = { error: ErrorContents }

--- a/extension/src/cli/dvc/discovery.ts
+++ b/extension/src/cli/dvc/discovery.ts
@@ -2,7 +2,7 @@ import {
   LATEST_TESTED_CLI_VERSION,
   MAX_CLI_VERSION,
   MIN_CLI_VERSION
-} from './constants'
+} from './contract'
 import { CliCompatible, isVersionCompatible } from './version'
 import { IExtension } from '../../interfaces'
 import { Toast } from '../../vscode/toast'

--- a/extension/src/cli/dvc/version.test.ts
+++ b/extension/src/cli/dvc/version.test.ts
@@ -4,10 +4,10 @@ import {
   ParsedSemver,
   CliCompatible
 } from './version'
-import { MIN_CLI_VERSION, LATEST_TESTED_CLI_VERSION } from './constants'
+import { MIN_CLI_VERSION, LATEST_TESTED_CLI_VERSION } from './contract'
 
-jest.mock('./constants', () => ({
-  ...jest.requireActual('./constants'),
+jest.mock('./contract', () => ({
+  ...jest.requireActual('./contract'),
   LATEST_TESTED_CLI_VERSION: '2.11.1',
   MIN_CLI_VERSION: '2.9.4'
 }))

--- a/extension/src/cli/dvc/version.ts
+++ b/extension/src/cli/dvc/version.ts
@@ -2,7 +2,7 @@ import {
   MAX_CLI_VERSION,
   LATEST_TESTED_CLI_VERSION,
   MIN_CLI_VERSION
-} from './constants'
+} from './contract'
 
 export enum CliCompatible {
   NO_BEHIND_MIN_VERSION = 'no-behind-min-version',

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -170,7 +170,7 @@ export class Extension extends Disposable implements IExtension {
         this.resourceLocator.dvcIcon,
         () => this.initProject(),
         () => this.showExperiments(this.dvcRoots[0]),
-        () => this.getAvailable(),
+        () => this.getCliCompatible(),
         () => this.hasRoots(),
         () => this.experiments.getHasData()
       )
@@ -542,6 +542,10 @@ export class Extension extends Disposable implements IExtension {
         }
       }
     )
+  }
+
+  private getCliCompatible() {
+    return this.cliCompatible
   }
 
   private changeSetupStep() {

--- a/extension/src/setup.test.ts
+++ b/extension/src/setup.test.ts
@@ -23,7 +23,7 @@ import {
   LATEST_TESTED_CLI_VERSION,
   MAX_CLI_VERSION,
   MIN_CLI_VERSION
-} from './cli/dvc/constants'
+} from './cli/dvc/contract'
 import { extractSemver, ParsedSemver } from './cli/dvc/version'
 import { delay } from './util/time'
 import { Title } from './vscode/title'

--- a/extension/src/setup/index.ts
+++ b/extension/src/setup/index.ts
@@ -15,7 +15,7 @@ export class Setup extends BaseRepository<TSetupData> {
 
   private webviewMessages: WebviewMessages
   private showExperiments: () => void
-  private getCliAccessible: () => boolean
+  private getCliCompatible: () => boolean | undefined
   private getHasRoots: () => boolean
   private getHasData: () => boolean | undefined
 
@@ -24,7 +24,7 @@ export class Setup extends BaseRepository<TSetupData> {
     webviewIcon: Resource,
     initProject: () => void,
     showExperiments: () => void,
-    getCliAccessible: () => boolean,
+    getCliCompatible: () => boolean | undefined,
     getHasRoots: () => boolean,
     getHasData: () => boolean | undefined
   ) {
@@ -36,7 +36,7 @@ export class Setup extends BaseRepository<TSetupData> {
       this.sendDataToWebview()
     }
     this.showExperiments = showExperiments
-    this.getCliAccessible = getCliAccessible
+    this.getCliCompatible = getCliCompatible
     this.getHasRoots = getHasRoots
     this.getHasData = getHasData
   }
@@ -50,13 +50,13 @@ export class Setup extends BaseRepository<TSetupData> {
   }
 
   public async sendDataToWebview() {
-    const cliAccessible = this.getCliAccessible()
+    const cliCompatible = this.getCliCompatible()
     const projectInitialized = this.getHasRoots()
     const hasData = this.getHasData()
 
     if (
       this.webview?.isVisible &&
-      cliAccessible &&
+      cliCompatible &&
       projectInitialized &&
       hasData
     ) {
@@ -68,7 +68,7 @@ export class Setup extends BaseRepository<TSetupData> {
     const pythonBinPath = await findPythonBinForInstall()
 
     this.webviewMessages.sendWebviewMessage(
-      cliAccessible,
+      cliCompatible,
       projectInitialized,
       isPythonExtensionInstalled(),
       getBinDisplayText(pythonBinPath),

--- a/extension/src/setup/webview/contract.ts
+++ b/extension/src/setup/webview/contract.ts
@@ -1,5 +1,5 @@
 export type SetupData = {
-  cliAccessible: boolean
+  cliCompatible: boolean | undefined
   hasData: boolean | undefined
   isPythonExtensionInstalled: boolean
   projectInitialized: boolean

--- a/extension/src/setup/webview/messages.ts
+++ b/extension/src/setup/webview/messages.ts
@@ -25,14 +25,14 @@ export class WebviewMessages {
   }
 
   public sendWebviewMessage(
-    cliAccessible: boolean,
+    cliCompatible: boolean | undefined,
     projectInitialized: boolean,
     isPythonExtensionInstalled: boolean,
     pythonBinPath: string | undefined,
     hasData: boolean | undefined
   ) {
     this.getWebview()?.show({
-      cliAccessible,
+      cliCompatible,
       hasData,
       isPythonExtensionInstalled,
       projectInitialized,

--- a/extension/src/test/suite/extension.test.ts
+++ b/extension/src/test/suite/extension.test.ts
@@ -30,12 +30,14 @@ import { EventName } from '../../telemetry/constants'
 import { OutputChannel } from '../../vscode/outputChannel'
 import { WorkspaceExperiments } from '../../experiments/workspace'
 import { QuickPickItemWithValue } from '../../vscode/quickPick'
-import { MIN_CLI_VERSION } from '../../cli/dvc/constants'
 import * as WorkspaceFolders from '../../vscode/workspaceFolders'
 import { DvcExecutor } from '../../cli/dvc/executor'
 import { GitReader } from '../../cli/git/reader'
 import { Config } from '../../config'
-import { EXPERIMENT_WORKSPACE_ID } from '../../cli/dvc/contract'
+import {
+  EXPERIMENT_WORKSPACE_ID,
+  MIN_CLI_VERSION
+} from '../../cli/dvc/contract'
 import { ConfigKey, setConfigValue } from '../../vscode/config'
 
 suite('Extension Test Suite', () => {

--- a/extension/src/test/suite/setup/util.ts
+++ b/extension/src/test/suite/setup/util.ts
@@ -7,7 +7,7 @@ import * as AutoInstall from '../../../setup/autoInstall'
 
 export const buildSetup = (
   disposer: Disposer,
-  dvInstalled = false,
+  cliCompatible: boolean | undefined = undefined,
   dvcInit = false,
   hasData = false
 ) => {
@@ -26,7 +26,7 @@ export const buildSetup = (
       resourceLocator.dvcIcon,
       mockInitializeProject,
       mockOpenExperiments,
-      () => dvInstalled,
+      () => cliCompatible,
       () => dvcInit,
       () => hasData
     )

--- a/webview/src/setup/components/App.test.tsx
+++ b/webview/src/setup/components/App.test.tsx
@@ -15,7 +15,7 @@ const { postMessage } = vsCodeApi
 const mockPostMessage = jest.mocked(postMessage)
 
 const setData = (
-  cliAccessible: boolean,
+  cliCompatible: boolean | undefined,
   hasData: boolean | undefined,
   isPythonExtensionInstalled: boolean,
   projectInitialized: boolean,
@@ -26,7 +26,7 @@ const setData = (
     new MessageEvent('message', {
       data: {
         data: {
-          cliAccessible,
+          cliCompatible,
           hasData,
           isPythonExtensionInstalled,
           projectInitialized,
@@ -47,16 +47,23 @@ describe('App', () => {
     expect(mockPostMessage).toHaveBeenCalledTimes(1)
   })
 
-  it('should show a screen saying that DVC is not installed if the cli is unavailable', () => {
+  it('should show a screen saying that DVC is incompatible if the cli version is unexpected', () => {
     render(<App />)
     setData(false, false, false, false, undefined)
+
+    expect(screen.getByText('DVC is incompatible')).toBeInTheDocument()
+  })
+
+  it('should show a screen saying that DVC is not installed if the cli is unavailable', () => {
+    render(<App />)
+    setData(undefined, false, false, false, undefined)
 
     expect(screen.getByText('DVC is currently unavailable')).toBeInTheDocument()
   })
 
   it('should tell the user they cannot install DVC without a Python interpreter', () => {
     render(<App />)
-    setData(false, false, false, false, undefined)
+    setData(undefined, false, false, false, undefined)
 
     expect(
       screen.getByText(
@@ -69,7 +76,7 @@ describe('App', () => {
   it('should tell the user they can auto-install DVC with a Python interpreter', () => {
     render(<App />)
     const defaultInterpreter = 'python'
-    setData(false, false, false, false, defaultInterpreter)
+    setData(undefined, false, false, false, defaultInterpreter)
 
     expect(
       screen.getByText(
@@ -81,7 +88,7 @@ describe('App', () => {
 
   it('should let the user find another Python interpreter to install DVC when the Python extension is not installed', () => {
     render(<App />)
-    setData(false, false, false, false, 'python')
+    setData(undefined, false, false, false, 'python')
 
     const button = screen.getByText('Setup The Workspace')
     fireEvent.click(button)
@@ -93,7 +100,7 @@ describe('App', () => {
 
   it('should let the user find another Python interpreter to install DVC when the Python extension is installed', () => {
     render(<App />)
-    setData(false, false, true, false, 'python')
+    setData(undefined, false, true, false, 'python')
 
     const button = screen.getByText('Select Python Interpreter')
     fireEvent.click(button)
@@ -105,7 +112,7 @@ describe('App', () => {
 
   it('should let the user auto-install DVC under the right conditions', () => {
     render(<App />)
-    setData(false, false, true, false, 'python')
+    setData(undefined, false, true, false, 'python')
 
     const button = screen.getByText('Install')
     fireEvent.click(button)

--- a/webview/src/setup/components/App.tsx
+++ b/webview/src/setup/components/App.tsx
@@ -4,6 +4,7 @@ import {
   MessageToWebview
 } from 'dvc/src/webview/contract'
 import React, { useCallback, useState } from 'react'
+import { CliIncompatible } from './CliIncompatible'
 import { CliUnavailable } from './CliUnavailable'
 import { ProjectUninitialized } from './ProjectUninitialized'
 import { NoData } from './NoData'
@@ -12,7 +13,9 @@ import { sendMessage } from '../../shared/vscode'
 import { EmptyState } from '../../shared/components/emptyState/EmptyState'
 
 export const App: React.FC = () => {
-  const [cliAvailable, setCliAvailable] = useState<boolean>(false)
+  const [cliCompatible, setCliCompatible] = useState<boolean | undefined>(
+    undefined
+  )
   const [projectInitialized, setProjectInitialized] = useState<boolean>(false)
   const [pythonBinPath, setPythonBinPath] = useState<string | undefined>(
     undefined
@@ -24,14 +27,14 @@ export const App: React.FC = () => {
   useVsCodeMessaging(
     useCallback(
       ({ data }: { data: MessageToWebview<SetupData> }) => {
-        setCliAvailable(data.data.cliAccessible)
+        setCliCompatible(data.data.cliCompatible)
         setIsPythonExtensionInstalled(data.data.isPythonExtensionInstalled)
         setProjectInitialized(data.data.projectInitialized)
         setPythonBinPath(data.data.pythonBinPath)
         setHasData(data.data.hasData)
       },
       [
-        setCliAvailable,
+        setCliCompatible,
         setIsPythonExtensionInstalled,
         setProjectInitialized,
         setPythonBinPath,
@@ -58,7 +61,11 @@ export const App: React.FC = () => {
     sendMessage({ type: MessageFromWebviewType.SETUP_WORKSPACE })
   }
 
-  if (!cliAvailable) {
+  if (cliCompatible === false) {
+    return <CliIncompatible />
+  }
+
+  if (cliCompatible === undefined) {
     return (
       <CliUnavailable
         installDvc={installDvc}

--- a/webview/src/setup/components/CliIncompatible.tsx
+++ b/webview/src/setup/components/CliIncompatible.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { MIN_CLI_VERSION } from 'dvc/src/cli/dvc/contract'
+import { EmptyState } from '../../shared/components/emptyState/EmptyState'
+
+export const CliIncompatible: React.FC = () => (
+  <EmptyState>
+    <div>
+      <h1>DVC is incompatible</h1>
+      <p>The located CLI is incompatible with the extension</p>
+      <p>The minimum version is {MIN_CLI_VERSION}</p>
+      <p>Please update your install and try again</p>
+    </div>
+  </EmptyState>
+)

--- a/webview/src/stories/CliIncompatible.stories.tsx
+++ b/webview/src/stories/CliIncompatible.stories.tsx
@@ -1,0 +1,20 @@
+import { Story, Meta } from '@storybook/react/types-6-0'
+import React from 'react'
+import { CliIncompatible } from '../setup/components/CliIncompatible'
+
+import './test-vscode-styles.scss'
+import '../shared/style.scss'
+
+export default {
+  args: {
+    data: {}
+  },
+  component: CliIncompatible,
+  title: 'Setup'
+} as Meta
+
+const Template: Story = () => {
+  return <CliIncompatible />
+}
+
+export const CliFoundButNotCompatible = Template.bind({})


### PR DESCRIPTION
# 3/3 `main` <- #2944 <- #2990 <- this

This PR patches an edge case where the onboarding process can be opened under the circumstances of the CLI being below the minimum version accepted by the extension. Under these circumstances, we direct the user to a new screen (see new story).

### Demo

https://user-images.githubusercontent.com/37993418/209054132-dc2590a3-a3fd-4a86-ae16-ad303ddb2c96.mov
