### PR TITLE
Split setup from extension

### DIFF
--- a/extension/src/cli/dvc/discovery.ts
+++ b/extension/src/cli/dvc/discovery.ts
@@ -4,7 +4,7 @@ import {
   MIN_CLI_VERSION
 } from './contract'
 import { CliCompatible, isVersionCompatible } from './version'
-import { IExtension } from '../../interfaces'
+import { IExtensionSetup } from '../../interfaces'
 import { Toast } from '../../vscode/toast'
 import { Response } from '../../vscode/response'
 import {
@@ -37,7 +37,7 @@ export const warnAheadOfLatestTested = (): void => {
 }
 
 const warnUserCLIInaccessible = async (
-  extension: IExtension,
+  extension: IExtensionSetup,
   warningText: string
 ): Promise<void> => {
   if (getConfigValue<boolean>(ConfigKey.DO_NOT_SHOW_CLI_UNAVAILABLE)) {
@@ -59,7 +59,7 @@ const warnUserCLIInaccessible = async (
 }
 
 const warnUserCLIInaccessibleAnywhere = async (
-  extension: IExtension,
+  extension: IExtensionSetup,
   globalDvcVersion: string | undefined
 ): Promise<void> => {
   const binPath = await getPythonBinPath()
@@ -73,7 +73,7 @@ const warnUserCLIInaccessibleAnywhere = async (
 }
 
 const warnUser = (
-  extension: IExtension,
+  extension: IExtensionSetup,
   cliCompatible: CliCompatible,
   version: string | undefined
 ): void => {
@@ -118,7 +118,7 @@ export const isCliCompatible = (
 }
 
 const getVersionDetails = async (
-  extension: IExtension,
+  extension: IExtensionSetup,
   cwd: string,
   tryGlobalCli?: true
 ): Promise<
@@ -134,7 +134,7 @@ const getVersionDetails = async (
 }
 
 const processVersionDetails = (
-  extension: IExtension,
+  extension: IExtensionSetup,
   cliCompatible: CliCompatible,
   version: string | undefined,
   isAvailable: boolean,
@@ -148,7 +148,7 @@ const processVersionDetails = (
 }
 
 const tryGlobalFallbackVersion = async (
-  extension: IExtension,
+  extension: IExtensionSetup,
   cwd: string
 ): Promise<CanRunCli> => {
   const tryGlobal = await getVersionDetails(extension, cwd, true)
@@ -172,7 +172,7 @@ const tryGlobalFallbackVersion = async (
 }
 
 const extensionCanAutoRunCli = async (
-  extension: IExtension,
+  extension: IExtensionSetup,
   cwd: string
 ): Promise<CanRunCli> => {
   const {
@@ -195,7 +195,7 @@ const extensionCanAutoRunCli = async (
 }
 
 export const extensionCanRunCli = async (
-  extension: IExtension,
+  extension: IExtensionSetup,
   cwd: string
 ): Promise<CanRunCli> => {
   if (await extension.isPythonExtensionUsed()) {
@@ -215,7 +215,7 @@ export const extensionCanRunCli = async (
 }
 
 export const recheckGlobal = async (
-  extension: IExtension,
+  extension: IExtensionSetup,
   setup: () => Promise<void[] | undefined>,
   recheckInterval: number
 ): Promise<void> => {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -182,18 +182,9 @@ export class Extension extends Disposable {
     this.internalCommands.registerExternalCommand(
       RegisteredCommands.EXPERIMENT_AND_PLOTS_SHOW,
       async (context: VsCodeContext) => {
-        await this.showExperiments(getDvcRootFromContext(context))
-        await this.plots.showWebview(
-          getDvcRootFromContext(context),
-          ViewColumn.Beside
-        )
-      }
-    )
-
-    this.internalCommands.registerExternalCommand(
-      RegisteredCommands.SETUP_SHOW,
-      async () => {
-        await this.setup.showWebview()
+        const dvcRoot = getDvcRootFromContext(context)
+        await this.experiments.showWebview(dvcRoot, ViewColumn.Active)
+        await this.plots.showWebview(dvcRoot, ViewColumn.Beside)
       }
     )
 
@@ -239,10 +230,6 @@ export class Extension extends Disposable {
     this.dispose.track(recommendRedHatExtensionOnce())
   }
 
-  public getRoots() {
-    return this.setup.getRoots()
-  }
-
   public async initialize() {
     this.resetMembers()
 
@@ -276,8 +263,8 @@ export class Extension extends Disposable {
     this.plots.reset()
   }
 
-  private async showExperiments(dvcRoot: string) {
-    return await this.experiments.showWebview(dvcRoot, ViewColumn.Active)
+  private getRoots() {
+    return this.setup.getRoots()
   }
 }
 

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -1,33 +1,21 @@
 import {
   commands,
   env,
-  Event,
   EventEmitter,
   ExtensionContext,
   ViewColumn
 } from 'vscode'
-import isEmpty from 'lodash.isempty'
 import { DvcExecutor } from './cli/dvc/executor'
 import { DvcRunner } from './cli/dvc/runner'
 import { DvcReader } from './cli/dvc/reader'
 import { Config } from './config'
 import { Context } from './context'
-import { isPythonExtensionInstalled } from './extensions/python'
 import { WorkspaceExperiments } from './experiments/workspace'
 import { registerExperimentCommands } from './experiments/commands/register'
 import { registerPlotsCommands } from './plots/commands/register'
-import {
-  findAbsoluteDvcRootPath,
-  findDvcRootPaths,
-  findSubRootPaths
-} from './fileSystem'
 import { RepositoriesTree } from './repository/model/tree'
-import { IExtension } from './interfaces'
 import { registerRepositoryCommands } from './repository/commands/register'
 import { ResourceLocator } from './resourceLocator'
-import { definedAndNonEmpty } from './util/array'
-import { setup, setupWithGlobalRecheck, setupWorkspace } from './setup'
-import { Status } from './status'
 import { reRegisterVsCodeCommands } from './vscode/commands'
 import { InternalCommands } from './commands/internal'
 import { ExperimentsColumnsTree } from './experiments/columns/tree'
@@ -36,22 +24,15 @@ import { ExperimentsTree } from './experiments/model/tree'
 import { ExperimentsFilterByTree } from './experiments/model/filterBy/tree'
 import {
   Context as VsCodeContext,
-  getDvcRootFromContext,
-  setContextValue
+  getDvcRootFromContext
 } from './vscode/context'
 import { OutputChannel } from './vscode/outputChannel'
-import {
-  getFirstWorkspaceFolder,
-  getWorkspaceFolderCount,
-  getWorkspaceFolders
-} from './vscode/workspaceFolders'
 import {
   getTelemetryReporter,
   sendTelemetryEvent,
   sendTelemetryEventAndThrow
 } from './telemetry'
-import { EventName } from './telemetry/constants'
-import { RegisteredCliCommands, RegisteredCommands } from './commands/external'
+import { RegisteredCommands } from './commands/external'
 import { StopWatch } from './util/time'
 import {
   registerWalkthroughCommands,
@@ -63,17 +44,14 @@ import { WorkspacePlots } from './plots/workspace'
 import { PlotsPathsTree } from './plots/paths/tree'
 import { Disposable } from './class/dispose'
 import { collectWorkspaceScale } from './telemetry/collect'
-import { createFileSystemWatcher } from './fileSystem/watcher'
 import { GitExecutor } from './cli/git/executor'
 import { GitReader } from './cli/git/reader'
 import { Setup } from './setup/index'
 
-export class Extension extends Disposable implements IExtension {
+export class Extension extends Disposable {
   protected readonly internalCommands: InternalCommands
 
   private readonly resourceLocator: ResourceLocator
-  private readonly config: Config
-  private dvcRoots: string[] = []
   private readonly repositories: WorkspaceRepositories
   private readonly experiments: WorkspaceExperiments
   private readonly plots: WorkspacePlots
@@ -84,20 +62,10 @@ export class Extension extends Disposable implements IExtension {
   private readonly dvcRunner: DvcRunner
   private readonly gitExecutor: GitExecutor
   private readonly gitReader: GitReader
-  private readonly status: Status
-  private cliAccessible = false
-  private cliCompatible: boolean | undefined
-
-  private readonly workspaceChanged: EventEmitter<void> = this.dispose.track(
-    new EventEmitter()
-  )
 
   private updatesPaused: EventEmitter<boolean> = this.dispose.track(
     new EventEmitter<boolean>()
   )
-
-  private readonly onDidChangeWorkspace: Event<void> =
-    this.workspaceChanged.event
 
   constructor(context: ExtensionContext) {
     super()
@@ -106,18 +74,15 @@ export class Extension extends Disposable implements IExtension {
 
     this.dispose.track(getTelemetryReporter())
 
-    this.setCommandsAvailability(false)
-    this.setProjectAvailability()
-
     this.resourceLocator = this.dispose.track(
       new ResourceLocator(context.extensionUri)
     )
 
-    this.config = this.dispose.track(new Config())
+    const config = this.dispose.track(new Config())
 
-    this.dvcExecutor = this.dispose.track(new DvcExecutor(this.config))
-    this.dvcReader = this.dispose.track(new DvcReader(this.config))
-    this.dvcRunner = this.dispose.track(new DvcRunner(this.config))
+    this.dvcExecutor = this.dispose.track(new DvcExecutor(config))
+    this.dvcReader = this.dispose.track(new DvcReader(config))
+    this.dvcRunner = this.dispose.track(new DvcRunner(config))
 
     this.gitExecutor = this.dispose.track(new GitExecutor())
     this.gitReader = this.dispose.track(new GitReader())
@@ -138,17 +103,6 @@ export class Extension extends Disposable implements IExtension {
       new InternalCommands(outputChannel, ...clis)
     )
 
-    this.status = this.dispose.track(
-      new Status(
-        this.config,
-        this.dvcExecutor,
-        this.dvcReader,
-        this.dvcRunner,
-        this.gitExecutor,
-        this.gitReader
-      )
-    )
-
     this.experiments = this.dispose.track(
       new WorkspaceExperiments(
         this.internalCommands,
@@ -157,31 +111,8 @@ export class Extension extends Disposable implements IExtension {
       )
     )
 
-    const onDidChangeHasData = this.experiments.columnsChanged.event
-    this.dispose.track(
-      onDidChangeHasData(() => {
-        this.changeSetupStep()
-        setContextValue('dvc.project.hasData', this.experiments.getHasData())
-      })
-    )
-
     this.plots = this.dispose.track(
       new WorkspacePlots(this.internalCommands, context.workspaceState)
-    )
-
-    this.setup = this.dispose.track(
-      new Setup(
-        '',
-        this.resourceLocator.dvcIcon,
-        () => this.initializeDvc(),
-        () => this.initializeGit(),
-        () => this.showExperiments(this.dvcRoots[0]),
-        () => this.getCliCompatible(),
-        () => this.needsGitInit(),
-        needsGitInit => this.canGitInitialize(needsGitInit),
-        () => this.hasRoots(),
-        () => this.experiments.getHasData()
-      )
     )
 
     this.repositories = this.dispose.track(
@@ -222,50 +153,28 @@ export class Extension extends Disposable implements IExtension {
       new RepositoriesTree(this.internalCommands, this.repositories)
     )
 
-    setupWithGlobalRecheck(this)
-      .then(async () => {
-        sendTelemetryEvent(
-          EventName.EXTENSION_LOAD,
-          await this.getEventProperties(),
-          { duration: stopWatch.getElapsedTime() }
-        )
-      })
-      .catch(async error =>
-        sendTelemetryEventAndThrow(
-          EventName.EXTENSION_LOAD,
-          error,
-          stopWatch.getElapsedTime(),
-          await this.getEventProperties()
-        )
+    this.setup = this.dispose.track(
+      new Setup(
+        stopWatch,
+        config,
+        this.dvcExecutor,
+        this.dvcReader,
+        this.dvcRunner,
+        this.gitExecutor,
+        this.gitReader,
+        () => this.initialize(),
+        () => this.resetMembers(),
+        this.experiments,
+        this.internalCommands,
+        this.resourceLocator.dvcIcon,
+        () =>
+          collectWorkspaceScale(
+            this.getRoots(),
+            this.experiments,
+            this.plots,
+            this.repositories
+          )
       )
-
-    this.dispose.track(
-      this.onDidChangeWorkspace(() => {
-        setup(this)
-      })
-    )
-
-    this.dispose.track(
-      this.config.onDidChangeExecutionDetails(async () => {
-        const stopWatch = new StopWatch()
-        try {
-          this.changeSetupStep()
-          await setup(this)
-
-          return sendTelemetryEvent(
-            EventName.EXTENSION_EXECUTION_DETAILS_CHANGED,
-            await this.getEventProperties(),
-            { duration: stopWatch.getElapsedTime() }
-          )
-        } catch (error: unknown) {
-          return sendTelemetryEventAndThrow(
-            EventName.EXTENSION_EXECUTION_DETAILS_CHANGED,
-            error as Error,
-            stopWatch.getElapsedTime(),
-            await this.getEventProperties()
-          )
-        }
-      })
     )
 
     registerExperimentCommands(this.experiments, this.internalCommands)
@@ -313,18 +222,8 @@ export class Extension extends Disposable implements IExtension {
     )
 
     this.internalCommands.registerExternalCommand(
-      RegisteredCommands.EXTENSION_CHECK_CLI_COMPATIBLE,
-      () => setup(this)
-    )
-
-    this.internalCommands.registerExternalCommand(
       RegisteredCommands.EXTENSION_SHOW_OUTPUT,
       () => outputChannel.show()
-    )
-
-    this.internalCommands.registerExternalCliCommand(
-      RegisteredCliCommands.INIT,
-      () => this.initializeDvc()
     )
 
     registerRepositoryCommands(this.repositories, this.internalCommands)
@@ -336,73 +235,28 @@ export class Extension extends Disposable implements IExtension {
       context.extension.packageJSON.contributes.walkthroughs[0].id
     )
 
-    this.dispose.track(
-      commands.registerCommand(
-        RegisteredCommands.EXTENSION_SETUP_WORKSPACE,
-        () => this.setupWorkspace()
-      )
-    )
-
     showWalkthroughOnFirstUse(env.isNewAppInstall)
     this.dispose.track(recommendRedHatExtensionOnce())
-
-    this.watchForVenvChanges()
-  }
-
-  public async showSetup() {
-    return await this.setup.showWebview()
-  }
-
-  public shouldWarnUserIfCLIUnavailable() {
-    return this.hasRoots() && !this.setup.isFocused()
-  }
-
-  public async isPythonExtensionUsed() {
-    await this.config.isReady()
-    return !!this.config.isPythonExtensionUsed()
-  }
-
-  public async getCliVersion(cwd: string, tryGlobalCli?: true) {
-    await this.config.isReady()
-    try {
-      return await this.dvcReader.version(cwd, tryGlobalCli)
-    } catch {}
-  }
-
-  public unsetPythonBinPath() {
-    this.config.unsetPythonBinPath()
-  }
-
-  public async setRoots() {
-    const nestedRoots = await Promise.all(
-      getWorkspaceFolders().map(workspaceFolder =>
-        this.findDvcRoots(workspaceFolder)
-      )
-    )
-    this.dvcRoots = nestedRoots.flat().sort()
-
-    this.changeSetupStep()
-    return this.setProjectAvailability()
   }
 
   public getRoots() {
-    return this.dvcRoots
+    return this.setup.getRoots()
   }
 
   public async initialize() {
     this.resetMembers()
 
     await Promise.all([
-      this.repositories.create(this.dvcRoots, this.updatesPaused),
-      this.repositoriesTree.initialize(this.dvcRoots),
+      this.repositories.create(this.getRoots(), this.updatesPaused),
+      this.repositoriesTree.initialize(this.getRoots()),
       this.experiments.create(
-        this.dvcRoots,
+        this.getRoots(),
         this.updatesPaused,
         this.resourceLocator
       )
     ])
     this.plots.create(
-      this.dvcRoots,
+      this.getRoots(),
       this.updatesPaused,
       this.resourceLocator,
       this.experiments
@@ -415,10 +269,6 @@ export class Extension extends Disposable implements IExtension {
     ])
   }
 
-  public hasRoots() {
-    return definedAndNonEmpty(this.dvcRoots)
-  }
-
   public resetMembers() {
     this.repositories.reset()
     this.repositoriesTree.initialize([])
@@ -426,176 +276,8 @@ export class Extension extends Disposable implements IExtension {
     this.plots.reset()
   }
 
-  public setCliCompatible(compatible: boolean | undefined) {
-    this.cliCompatible = compatible
-    const incompatible = compatible === undefined ? undefined : !compatible
-    setContextValue('dvc.cli.incompatible', incompatible)
-  }
-
-  public setAvailable(available: boolean) {
-    this.status.setAvailability(available)
-    this.setCommandsAvailability(available)
-    this.cliAccessible = available
-    this.changeSetupStep()
-    return available
-  }
-
-  public getAvailable() {
-    return this.cliAccessible
-  }
-
-  public async initializeDvc() {
-    const root = getFirstWorkspaceFolder()
-    if (root) {
-      await this.dvcExecutor.init(root)
-      this.workspaceChanged.fire()
-    }
-  }
-
   private async showExperiments(dvcRoot: string) {
     return await this.experiments.showWebview(dvcRoot, ViewColumn.Active)
-  }
-
-  private setCommandsAvailability(available: boolean) {
-    setContextValue('dvc.commands.available', available)
-  }
-
-  private async setupWorkspace() {
-    const stopWatch = new StopWatch()
-    try {
-      const previousCliPath = this.config.getCliPath()
-      const previousPythonPath = this.config.getPythonBinPath()
-
-      const completed = await setupWorkspace(() =>
-        this.config.setPythonAndNotifyIfChanged()
-      )
-      sendTelemetryEvent(
-        RegisteredCommands.EXTENSION_SETUP_WORKSPACE,
-        { completed },
-        {
-          duration: stopWatch.getElapsedTime()
-        }
-      )
-
-      const executionDetailsUnchanged =
-        this.config.getCliPath() === previousPythonPath &&
-        this.config.getPythonBinPath() === previousCliPath
-
-      if (completed && !this.cliAccessible && executionDetailsUnchanged) {
-        this.workspaceChanged.fire()
-      }
-
-      return completed
-    } catch (error: unknown) {
-      return sendTelemetryEventAndThrow(
-        RegisteredCommands.EXTENSION_SETUP_WORKSPACE,
-        error as Error,
-        stopWatch.getElapsedTime()
-      )
-    }
-  }
-
-  private setProjectAvailability() {
-    const available = this.hasRoots()
-    setContextValue('dvc.project.available', available)
-  }
-
-  private async findDvcRoots(cwd: string): Promise<string[]> {
-    const dvcRoots = await findDvcRootPaths(cwd)
-    if (definedAndNonEmpty(dvcRoots)) {
-      return dvcRoots
-    }
-
-    await this.config.isReady()
-    return findAbsoluteDvcRootPath(cwd, this.dvcReader.root(cwd))
-  }
-
-  private async getEventProperties() {
-    return {
-      ...(this.cliAccessible
-        ? await collectWorkspaceScale(
-            this.dvcRoots,
-            this.experiments,
-            this.plots,
-            this.repositories
-          )
-        : {}),
-      cliAccessible: this.cliAccessible,
-      dvcPathUsed: !!this.config.getCliPath(),
-      dvcRootCount: this.dvcRoots.length,
-      msPythonInstalled: isPythonExtensionInstalled(),
-      msPythonUsed: this.config.isPythonExtensionUsed(),
-      pythonPathUsed: !!this.config.getPythonBinPath(),
-      workspaceFolderCount: getWorkspaceFolderCount()
-    }
-  }
-
-  private watchForVenvChanges() {
-    return createFileSystemWatcher(
-      disposable => this.dispose.track(disposable),
-      '**/dvc{,.exe}',
-      async path => {
-        if (!path) {
-          return
-        }
-
-        const previousPythonBinPath = this.config.getPythonBinPath()
-        await this.config.setPythonBinPath()
-
-        const trySetupWithVenv =
-          previousPythonBinPath !== this.config.getPythonBinPath()
-
-        if (!this.cliAccessible || !this.cliCompatible || trySetupWithVenv) {
-          setup(this)
-        }
-      }
-    )
-  }
-
-  private getCliCompatible() {
-    return this.cliCompatible
-  }
-
-  private initializeGit() {
-    const cwd = getFirstWorkspaceFolder()
-    if (cwd) {
-      this.gitExecutor.init(cwd)
-      this.workspaceChanged.fire()
-    }
-  }
-
-  private async canGitInitialize(needsGitInit: boolean) {
-    if (!needsGitInit) {
-      return false
-    }
-    const nestedRoots = await Promise.all(
-      getWorkspaceFolders().map(workspaceFolder =>
-        findSubRootPaths(workspaceFolder, '.git')
-      )
-    )
-
-    return isEmpty(nestedRoots.flat())
-  }
-
-  private async needsGitInit() {
-    if (this.hasRoots()) {
-      return false
-    }
-
-    const cwd = getFirstWorkspaceFolder()
-    if (!cwd) {
-      return undefined
-    }
-
-    try {
-      return !(await this.gitExecutor.getGitRepositoryRoot(cwd))
-    } catch {
-      return true
-    }
-  }
-
-  private changeSetupStep() {
-    this.setup.sendDataToWebview()
   }
 }
 

--- a/extension/src/interfaces.ts
+++ b/extension/src/interfaces.ts
@@ -1,4 +1,4 @@
-export interface IExtension {
+export interface IExtensionSetup {
   getCliVersion: (
     cwd: string,
     isCliGlobal?: true

--- a/extension/src/setup.test.ts
+++ b/extension/src/setup.test.ts
@@ -271,7 +271,7 @@ describe('setupWorkspace', () => {
 })
 
 describe('setup', () => {
-  const extension = {
+  const extensionSetup = {
     getAvailable: mockedGetAvailable,
     getCliVersion: mockedGetCliVersion,
     getRoots: mockedGetRoots,
@@ -290,7 +290,7 @@ describe('setup', () => {
   it('should do nothing if there is no workspace folder', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(undefined)
 
-    await setup(extension)
+    await setup(extensionSetup)
 
     expect(mockedGetCliVersion).not.toHaveBeenCalled()
     expect(mockedInitialize).not.toHaveBeenCalled()
@@ -301,7 +301,7 @@ describe('setup', () => {
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(false)
     mockedGetCliVersion.mockResolvedValueOnce(false)
 
-    await setup(extension)
+    await setup(extensionSetup)
 
     expect(mockedSetRoots).toHaveBeenCalledTimes(1)
   })
@@ -312,7 +312,7 @@ describe('setup', () => {
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(false)
     mockedGetCliVersion.mockResolvedValueOnce(undefined)
 
-    await setup(extension)
+    await setup(extensionSetup)
     expect(mockedSetRoots).toHaveBeenCalledTimes(1)
     expect(mockedGetConfigValue).not.toHaveBeenCalled()
     expect(mockedWarnWithOptions).not.toHaveBeenCalled()
@@ -331,7 +331,7 @@ describe('setup', () => {
       .mockResolvedValueOnce(undefined)
     mockedGetConfigValue.mockReturnValueOnce(true)
 
-    await setup(extension)
+    await setup(extensionSetup)
     expect(mockedSetRoots).toHaveBeenCalledTimes(1)
     expect(mockedGetConfigValue).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).not.toHaveBeenCalled()
@@ -355,7 +355,7 @@ describe('setup', () => {
     mockedReady.mockResolvedValue(true)
     mockedGetExtension.mockReturnValue(mockedVscodePython)
 
-    await setup(extension)
+    await setup(extensionSetup)
     await flushPromises()
     expect(mockedSetRoots).toHaveBeenCalledTimes(1)
     expect(mockedGetConfigValue).toHaveBeenCalledTimes(1)
@@ -378,7 +378,7 @@ describe('setup', () => {
     mockedReady.mockResolvedValue(true)
     mockedGetExtension.mockReturnValue(mockedVscodePython)
 
-    await setup(extension)
+    await setup(extensionSetup)
     await flushPromises()
     expect(mockedSetRoots).toHaveBeenCalledTimes(1)
     expect(mockedGetConfigValue).toHaveBeenCalledTimes(1)
@@ -402,7 +402,7 @@ describe('setup', () => {
     mockedReady.mockResolvedValue(true)
     mockedGetExtension.mockReturnValue(mockedVscodePython)
 
-    await setup(extension)
+    await setup(extensionSetup)
     await flushPromises()
     expect(mockedSetRoots).toHaveBeenCalledTimes(1)
     expect(mockedGetConfigValue).toHaveBeenCalledTimes(1)
@@ -421,7 +421,7 @@ describe('setup', () => {
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(false)
     mockedGetCliVersion.mockResolvedValueOnce(MIN_CLI_VERSION)
 
-    await setup(extension)
+    await setup(extensionSetup)
     expect(mockedSetRoots).toHaveBeenCalledTimes(1)
     expect(mockedResetMembers).toHaveBeenCalledTimes(1)
     expect(mockedSetAvailable).not.toHaveBeenCalledWith(false)
@@ -435,7 +435,7 @@ describe('setup', () => {
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
     mockedGetCliVersion.mockResolvedValueOnce(MIN_CLI_VERSION)
 
-    await setup(extension)
+    await setup(extensionSetup)
     expect(mockedResetMembers).not.toHaveBeenCalled()
     expect(mockedInitialize).toHaveBeenCalledTimes(1)
   })
@@ -449,7 +449,7 @@ describe('setup', () => {
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(MIN_CLI_VERSION)
 
-    await setup(extension)
+    await setup(extensionSetup)
     expect(mockedGetCliVersion).toHaveBeenCalledTimes(2)
     expect(mockedResetMembers).not.toHaveBeenCalled()
     expect(mockedInitialize).toHaveBeenCalledTimes(1)
@@ -468,7 +468,7 @@ describe('setup', () => {
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(belowMinVersion)
 
-    await setup(extension)
+    await setup(extensionSetup)
     await flushPromises()
     expect(mockedWarnWithOptions).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).toHaveBeenCalledWith(
@@ -495,7 +495,7 @@ describe('setup', () => {
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce([major, minor + 1, patch].join('.'))
 
-    await setup(extension)
+    await setup(extensionSetup)
     await flushPromises()
     expect(mockedWarnWithOptions).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).toHaveBeenCalledWith(
@@ -513,7 +513,7 @@ describe('setup', () => {
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(false)
     mockedGetCliVersion.mockResolvedValueOnce(undefined)
 
-    await setup(extension)
+    await setup(extensionSetup)
     await flushPromises()
     expect(mockedWarnWithOptions).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).toHaveBeenCalledWith(
@@ -535,7 +535,7 @@ describe('setup', () => {
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
     mockedGetCliVersion.mockResolvedValueOnce(MajorAhead)
 
-    await setup(extension)
+    await setup(extensionSetup)
     await flushPromises()
     expect(mockedWarnWithOptions).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).toHaveBeenCalledWith(
@@ -560,7 +560,7 @@ describe('setup', () => {
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(undefined)
 
-    await setup(extension)
+    await setup(extensionSetup)
     await flushPromises()
     expect(mockedWarnWithOptions).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).toHaveBeenCalledWith(
@@ -579,7 +579,7 @@ describe('setup', () => {
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(false)
     mockedGetCliVersion.mockResolvedValueOnce(false)
 
-    await setup(extension)
+    await setup(extensionSetup)
     expect(mockedGetCliVersion).toHaveBeenCalledTimes(1)
   })
 
@@ -591,7 +591,7 @@ describe('setup', () => {
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
     mockedGetCliVersion.mockResolvedValueOnce(behind)
 
-    await setup(extension)
+    await setup(extensionSetup)
     expect(mockedGetCliVersion).toHaveBeenCalledTimes(1)
   })
 
@@ -601,14 +601,14 @@ describe('setup', () => {
     mockedShouldWarnUserIfCLIUnavailable.mockReturnValueOnce(true)
     mockedGetCliVersion.mockResolvedValueOnce(false)
 
-    await setup(extension)
+    await setup(extensionSetup)
     expect(mockedResetMembers).toHaveBeenCalledTimes(1)
     expect(mockedInitialize).not.toHaveBeenCalled()
   })
 })
 
 describe('setupWithGlobalRecheck', () => {
-  const extension = {
+  const extensionSetup = {
     getAvailable: mockedGetAvailable,
     getCliVersion: mockedGetCliVersion,
     getRoots: mockedGetRoots,
@@ -640,7 +640,7 @@ describe('setupWithGlobalRecheck', () => {
       .mockResolvedValueOnce(LATEST_TESTED_CLI_VERSION)
       .mockResolvedValueOnce(LATEST_TESTED_CLI_VERSION)
 
-    await setupWithGlobalRecheck(extension, mockedRecheckInterval)
+    await setupWithGlobalRecheck(extensionSetup, mockedRecheckInterval)
 
     expect(mockedGetCliVersion).toHaveBeenCalledTimes(1)
     expect(mockedGetAvailable).toHaveBeenCalledTimes(1)
@@ -668,7 +668,7 @@ describe('setupWithGlobalRecheck', () => {
 
     mockedGetCliVersion.mockResolvedValueOnce(LATEST_TESTED_CLI_VERSION)
 
-    await setupWithGlobalRecheck(extension, 0)
+    await setupWithGlobalRecheck(extensionSetup, 0)
 
     expect(mockedGetCliVersion).toHaveBeenCalledTimes(1)
     expect(mockedGetAvailable).toHaveBeenCalledTimes(1)
@@ -690,7 +690,7 @@ describe('setupWithGlobalRecheck', () => {
     mockedGetAvailable.mockReturnValueOnce(false).mockReturnValueOnce(true)
     mockedGetCliVersion.mockResolvedValueOnce(undefined)
 
-    await setupWithGlobalRecheck(extension, 0)
+    await setupWithGlobalRecheck(extensionSetup, 0)
 
     expect(mockedGetCliVersion).toHaveBeenCalledTimes(1)
     expect(mockedGetAvailable).toHaveBeenCalledTimes(1)

--- a/extension/src/setup.ts
+++ b/extension/src/setup.ts
@@ -1,4 +1,4 @@
-import { IExtension } from './interfaces'
+import { IExtensionSetup } from './interfaces'
 import {
   quickPickOneOrInput,
   quickPickValue,
@@ -176,7 +176,7 @@ export const setupWorkspace = async (
 }
 
 export const checkAvailable = async (
-  extension: IExtension,
+  extension: IExtensionSetup,
   dvcRootOrFirstFolder: string
 ) => {
   const { isAvailable, isCompatible } = await extensionCanRunCli(
@@ -194,7 +194,7 @@ export const checkAvailable = async (
   extension.resetMembers()
 }
 
-export const setup = async (extension: IExtension) => {
+export const setup = async (extension: IExtensionSetup) => {
   const cwd = getFirstWorkspaceFolder()
   if (!cwd) {
     return
@@ -209,7 +209,7 @@ export const setup = async (extension: IExtension) => {
 }
 
 export const setupWithGlobalRecheck = async (
-  extension: IExtension,
+  extension: IExtensionSetup,
   recheckInterval = 5000
 ): Promise<void> => {
   await setup(extension)

--- a/extension/src/setup/webview/contract.ts
+++ b/extension/src/setup/webview/contract.ts
@@ -1,9 +1,9 @@
 export type SetupData = {
   canGitInitialize: boolean
   cliCompatible: boolean | undefined
-  projectInitialized: boolean
   hasData: boolean | undefined
   isPythonExtensionInstalled: boolean
   needsGitInitialized: boolean | undefined
+  projectInitialized: boolean
   pythonBinPath: string | undefined
 }

--- a/extension/src/test/suite/setup/index.test.ts
+++ b/extension/src/test/suite/setup/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, it, suite } from 'mocha'
 import { expect } from 'chai'
-import { restore, spy } from 'sinon'
+import { restore, spy, stub } from 'sinon'
 import { buildSetup } from './util'
 import { closeAllEditors, getMessageReceivedEmitter } from '../util'
 import { WEBVIEW_TEST_TIMEOUT } from '../timeouts'
@@ -25,10 +25,7 @@ suite('Setup Test Suite', () => {
 
   describe('Setup', () => {
     it('should handle an initialize git message from the webview', async () => {
-      const { messageSpy, setup, mockInitializeGit } = buildSetup(
-        disposable,
-        true
-      )
+      const { messageSpy, setup, mockInitializeGit } = buildSetup(disposable)
 
       const webview = await setup.showWebview()
       await webview.isReady()
@@ -44,10 +41,7 @@ suite('Setup Test Suite', () => {
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should handle an initialize project message from the webview', async () => {
-      const { messageSpy, setup, mockInitializeDvc } = buildSetup(
-        disposable,
-        true
-      )
+      const { messageSpy, setup, mockInitializeDvc } = buildSetup(disposable)
 
       const webview = await setup.showWebview()
       await webview.isReady()
@@ -134,17 +128,16 @@ suite('Setup Test Suite', () => {
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should close the webview and open the experiments when the setup is done', async () => {
-      const { setup, mockOpenExperiments } = buildSetup(
-        disposable,
-        true,
-        true,
-        true
-      )
+      const { setup, mockOpenExperiments } = buildSetup(disposable, true)
 
       const closeWebviewSpy = spy(BaseWebview.prototype, 'dispose')
 
       const webview = await setup.showWebview()
       await webview.isReady()
+
+      stub(setup, 'hasRoots').returns(true)
+      setup.setCliCompatible(true)
+      setup.setAvailable(true)
 
       expect(closeWebviewSpy).to.be.calledOnce
       expect(mockOpenExperiments).to.be.calledOnce

--- a/extension/src/test/suite/setup/index.test.ts
+++ b/extension/src/test/suite/setup/index.test.ts
@@ -142,5 +142,118 @@ suite('Setup Test Suite', () => {
       expect(closeWebviewSpy).to.be.calledOnce
       expect(mockOpenExperiments).to.be.calledOnce
     }).timeout(WEBVIEW_TEST_TIMEOUT)
+
+    it('should send the expected message to the webview when there is no CLI available', async () => {
+      const { config, setup, messageSpy } = buildSetup(disposable)
+
+      await config.isReady()
+
+      setup.setCliCompatible(undefined)
+      setup.setAvailable(false)
+      await setup.setRoots()
+
+      messageSpy.restore()
+      const mockSendMessage = stub(BaseWebview.prototype, 'show')
+
+      const messageSent = new Promise(resolve =>
+        mockSendMessage.callsFake(data => {
+          resolve(undefined)
+          return mockSendMessage.wrappedMethod(data)
+        })
+      )
+
+      const webview = await setup.showWebview()
+      await webview.isReady()
+
+      await messageSent
+
+      expect(mockSendMessage).to.be.calledOnce
+      expect(mockSendMessage).to.be.calledWithExactly({
+        canGitInitialize: true,
+        cliCompatible: undefined,
+        hasData: false,
+        isPythonExtensionInstalled: false,
+        needsGitInitialized: true,
+        projectInitialized: false,
+        pythonBinPath: undefined
+      })
+    }).timeout(WEBVIEW_TEST_TIMEOUT)
+
+    it('should send the expected message to the webview when there is no Git repository in the workspace', async () => {
+      const { config, setup, messageSpy } = buildSetup(disposable)
+
+      await config.isReady()
+
+      setup.setCliCompatible(true)
+      setup.setAvailable(true)
+      await setup.setRoots()
+
+      messageSpy.restore()
+      const mockSendMessage = stub(BaseWebview.prototype, 'show')
+
+      const messageSent = new Promise(resolve =>
+        mockSendMessage.callsFake(data => {
+          resolve(undefined)
+          return mockSendMessage.wrappedMethod(data)
+        })
+      )
+
+      const webview = await setup.showWebview()
+      await webview.isReady()
+
+      await messageSent
+
+      expect(mockSendMessage).to.be.calledOnce
+      expect(mockSendMessage).to.be.calledWithExactly({
+        canGitInitialize: true,
+        cliCompatible: true,
+        hasData: false,
+        isPythonExtensionInstalled: false,
+        needsGitInitialized: true,
+        projectInitialized: false,
+        pythonBinPath: undefined
+      })
+    }).timeout(WEBVIEW_TEST_TIMEOUT)
+
+    it('should send the expected message to the webview when there is no DVC project in the workspace', async () => {
+      const { config, setup, messageSpy } = buildSetup(
+        disposable,
+        false,
+        true,
+        false
+      )
+
+      await config.isReady()
+
+      setup.setCliCompatible(true)
+      setup.setAvailable(true)
+      await setup.setRoots()
+
+      messageSpy.restore()
+      const mockSendMessage = stub(BaseWebview.prototype, 'show')
+
+      const messageSent = new Promise(resolve =>
+        mockSendMessage.callsFake(data => {
+          resolve(undefined)
+          return mockSendMessage.wrappedMethod(data)
+        })
+      )
+
+      const webview = await setup.showWebview()
+      await webview.isReady()
+
+      await messageSent
+
+      expect(mockSendMessage).to.be.calledOnce
+      expect(mockSendMessage).to.be.calledWithExactly({
+        canGitInitialize: false,
+        cliCompatible: true,
+        hasData: false,
+        isPythonExtensionInstalled: false,
+        needsGitInitialized: false,
+        projectInitialized: false,
+        pythonBinPath: undefined
+      })
+    }).timeout(WEBVIEW_TEST_TIMEOUT)
   })
 })

--- a/extension/src/test/suite/setup/util.ts
+++ b/extension/src/test/suite/setup/util.ts
@@ -1,19 +1,24 @@
-import { commands } from 'vscode'
+import { EventEmitter, commands } from 'vscode'
 import { Disposer } from '@hediet/std/disposable'
 import { fake, stub } from 'sinon'
 import { Setup } from '../../../setup/index'
-import { buildDependencies } from '../util'
+import { buildDependencies, mockDisposable } from '../util'
 import * as AutoInstall from '../../../setup/autoInstall'
+import { DvcReader } from '../../../cli/dvc/reader'
+import { DvcExecutor } from '../../../cli/dvc/executor'
+import { GitReader } from '../../../cli/git/reader'
+import { GitExecutor } from '../../../cli/git/executor'
+import { InternalCommands } from '../../../commands/internal'
+import { WorkspaceExperiments } from '../../../experiments/workspace'
+import { DvcRunner } from '../../../cli/dvc/runner'
+import { StopWatch } from '../../../util/time'
+import { WorkspaceScale } from '../../../telemetry/collect'
 
-export const buildSetup = (
-  disposer: Disposer,
-  cliCompatible: boolean | undefined = undefined,
-  dvcInit = false,
-  hasData = false,
-  gitInit = Promise.resolve(true),
-  canGitInit = Promise.resolve(false)
-) => {
-  const { messageSpy, resourceLocator } = buildDependencies(disposer)
+export const buildSetup = (disposer: Disposer, hasData = false) => {
+  const { config, messageSpy, resourceLocator } = buildDependencies(disposer)
+
+  const mockEmitter = disposer.track(new EventEmitter())
+  const mockEvent = mockEmitter.event
 
   const mockInitializeDvc = fake()
   const mockInitializeGit = fake()
@@ -22,19 +27,47 @@ export const buildSetup = (
   const mockExecuteCommand = stub(commands, 'executeCommand')
 
   const mockAutoInstallDvc = stub(AutoInstall, 'autoInstallDvc')
+  stub(commands, 'registerCommand').returns(mockDisposable)
 
   const setup = disposer.track(
     new Setup(
-      '',
+      new StopWatch(),
+      config,
+      {
+        init: mockInitializeDvc,
+        onDidCompleteProcess: mockEvent,
+        onDidStartProcess: mockEvent
+      } as unknown as DvcExecutor,
+      {
+        onDidCompleteProcess: mockEvent,
+        onDidStartProcess: mockEvent
+      } as DvcReader,
+      {
+        onDidCompleteProcess: mockEvent,
+        onDidStartProcess: mockEvent
+      } as DvcRunner,
+      {
+        init: mockInitializeGit,
+        onDidCompleteProcess: mockEvent,
+        onDidStartProcess: mockEvent
+      } as unknown as GitExecutor,
+      {
+        onDidCompleteProcess: mockEvent,
+        onDidStartProcess: mockEvent
+      } as GitReader,
+      () => Promise.resolve([undefined]),
+      () => Promise.resolve(undefined),
+      {
+        columnsChanged: mockEmitter,
+        getHasData: () => hasData,
+        showWebview: mockOpenExperiments
+      } as unknown as WorkspaceExperiments,
+      {
+        registerExternalCliCommand: stub(),
+        registerExternalCommand: stub()
+      } as unknown as InternalCommands,
       resourceLocator.dvcIcon,
-      mockInitializeDvc,
-      mockInitializeGit,
-      mockOpenExperiments,
-      () => cliCompatible,
-      () => gitInit,
-      () => canGitInit,
-      () => dvcInit,
-      () => hasData
+      () => Promise.resolve({} as WorkspaceScale)
     )
   )
 

--- a/extension/src/test/suite/util.ts
+++ b/extension/src/test/suite/util.ts
@@ -154,7 +154,14 @@ export const buildInternalCommands = (disposer: Disposer) => {
     )
   )
 
-  return { dvcExecutor, dvcReader, dvcRunner, gitReader, internalCommands }
+  return {
+    config,
+    dvcExecutor,
+    dvcReader,
+    dvcRunner,
+    gitReader,
+    internalCommands
+  }
 }
 
 export const buildMockData = <T extends ExperimentsData | FileSystemData>() =>
@@ -168,8 +175,14 @@ export const buildDependencies = (
   expShow = expShowFixture,
   plotsDiff = plotsDiffFixture
 ) => {
-  const { dvcExecutor, dvcReader, dvcRunner, gitReader, internalCommands } =
-    buildInternalCommands(disposer)
+  const {
+    config,
+    dvcExecutor,
+    dvcReader,
+    dvcRunner,
+    gitReader,
+    internalCommands
+  } = buildInternalCommands(disposer)
 
   const mockCreateFileSystemWatcher = stub(
     Watcher,
@@ -193,6 +206,7 @@ export const buildDependencies = (
   const messageSpy = spy(BaseWebview.prototype, 'show')
 
   return {
+    config,
     dvcExecutor,
     dvcReader,
     dvcRunner,


### PR DESCRIPTION
# 2/3 `main` <- #3002 <- this <- #3018 

This PR moves all of the setup/initialization logic out of the extension and into `Setup`