### PR TITLE
Rename original setup file to runner

### DIFF
--- a/extension/src/cli/dvc/discovery.ts
+++ b/extension/src/cli/dvc/discovery.ts
@@ -37,7 +37,7 @@ export const warnAheadOfLatestTested = (): void => {
 }
 
 const warnUserCLIInaccessible = async (
-  extension: IExtensionSetup,
+  setup: IExtensionSetup,
   warningText: string
 ): Promise<void> => {
   if (getConfigValue<boolean>(ConfigKey.DO_NOT_SHOW_CLI_UNAVAILABLE)) {
@@ -52,20 +52,20 @@ const warnUserCLIInaccessible = async (
 
   switch (response) {
     case Response.SHOW_SETUP:
-      return extension.showSetup()
+      return setup.showSetup()
     case Response.NEVER:
       return setUserConfigValue(ConfigKey.DO_NOT_SHOW_CLI_UNAVAILABLE, true)
   }
 }
 
 const warnUserCLIInaccessibleAnywhere = async (
-  extension: IExtensionSetup,
+  setup: IExtensionSetup,
   globalDvcVersion: string | undefined
 ): Promise<void> => {
   const binPath = await getPythonBinPath()
 
   return warnUserCLIInaccessible(
-    extension,
+    setup,
     `The extension is unable to initialize. The CLI was not located using the interpreter provided by the Python extension. ${
       globalDvcVersion ? globalDvcVersion + ' is' : 'The CLI is also not'
     } installed globally. For auto Python environment activation, ensure the correct interpreter is set. Active Python interpreter: ${binPath}.`
@@ -73,11 +73,11 @@ const warnUserCLIInaccessibleAnywhere = async (
 }
 
 const warnUser = (
-  extension: IExtensionSetup,
+  setup: IExtensionSetup,
   cliCompatible: CliCompatible,
   version: string | undefined
 ): void => {
-  if (!extension.shouldWarnUserIfCLIUnavailable()) {
+  if (!setup.shouldWarnUserIfCLIUnavailable()) {
     return
   }
   switch (cliCompatible) {
@@ -90,7 +90,7 @@ const warnUser = (
       return warnVersionIncompatible(version as string, 'extension')
     case CliCompatible.NO_NOT_FOUND:
       warnUserCLIInaccessible(
-        extension,
+        setup,
         'An error was thrown when trying to access the CLI.'
       )
       return
@@ -118,7 +118,7 @@ export const isCliCompatible = (
 }
 
 const getVersionDetails = async (
-  extension: IExtensionSetup,
+  setup: IExtensionSetup,
   cwd: string,
   tryGlobalCli?: true
 ): Promise<
@@ -127,20 +127,20 @@ const getVersionDetails = async (
     version: string | undefined
   }
 > => {
-  const version = await extension.getCliVersion(cwd, tryGlobalCli)
+  const version = await setup.getCliVersion(cwd, tryGlobalCli)
   const cliCompatible = isVersionCompatible(version)
   const isCompatible = isCliCompatible(cliCompatible)
   return { cliCompatible, isAvailable: !!isCompatible, isCompatible, version }
 }
 
 const processVersionDetails = (
-  extension: IExtensionSetup,
+  setup: IExtensionSetup,
   cliCompatible: CliCompatible,
   version: string | undefined,
   isAvailable: boolean,
   isCompatible: boolean | undefined
 ): CanRunCli => {
-  warnUser(extension, cliCompatible, version)
+  warnUser(setup, cliCompatible, version)
   return {
     isAvailable,
     isCompatible
@@ -148,31 +148,31 @@ const processVersionDetails = (
 }
 
 const tryGlobalFallbackVersion = async (
-  extension: IExtensionSetup,
+  setup: IExtensionSetup,
   cwd: string
 ): Promise<CanRunCli> => {
-  const tryGlobal = await getVersionDetails(extension, cwd, true)
+  const tryGlobal = await getVersionDetails(setup, cwd, true)
   const { cliCompatible, isAvailable, isCompatible, version } = tryGlobal
 
-  if (extension.shouldWarnUserIfCLIUnavailable() && !isCompatible) {
-    warnUserCLIInaccessibleAnywhere(extension, version)
+  if (setup.shouldWarnUserIfCLIUnavailable() && !isCompatible) {
+    warnUserCLIInaccessibleAnywhere(setup, version)
   }
   if (
-    extension.shouldWarnUserIfCLIUnavailable() &&
+    setup.shouldWarnUserIfCLIUnavailable() &&
     cliCompatible === CliCompatible.YES_MINOR_VERSION_AHEAD_OF_TESTED
   ) {
     warnAheadOfLatestTested()
   }
 
   if (isCompatible) {
-    extension.unsetPythonBinPath()
+    setup.unsetPythonBinPath()
   }
 
   return { isAvailable, isCompatible }
 }
 
 const extensionCanAutoRunCli = async (
-  extension: IExtensionSetup,
+  setup: IExtensionSetup,
   cwd: string
 ): Promise<CanRunCli> => {
   const {
@@ -180,13 +180,13 @@ const extensionCanAutoRunCli = async (
     isAvailable: pythonVersionIsAvailable,
     isCompatible: pythonVersionIsCompatible,
     version: pythonVersion
-  } = await getVersionDetails(extension, cwd)
+  } = await getVersionDetails(setup, cwd)
 
   if (pythonCliCompatible === CliCompatible.NO_NOT_FOUND) {
-    return tryGlobalFallbackVersion(extension, cwd)
+    return tryGlobalFallbackVersion(setup, cwd)
   }
   return processVersionDetails(
-    extension,
+    setup,
     pythonCliCompatible,
     pythonVersion,
     pythonVersionIsAvailable,
@@ -195,18 +195,18 @@ const extensionCanAutoRunCli = async (
 }
 
 export const extensionCanRunCli = async (
-  extension: IExtensionSetup,
+  setup: IExtensionSetup,
   cwd: string
 ): Promise<CanRunCli> => {
-  if (await extension.isPythonExtensionUsed()) {
-    return extensionCanAutoRunCli(extension, cwd)
+  if (await setup.isPythonExtensionUsed()) {
+    return extensionCanAutoRunCli(setup, cwd)
   }
 
   const { cliCompatible, isAvailable, isCompatible, version } =
-    await getVersionDetails(extension, cwd)
+    await getVersionDetails(setup, cwd)
 
   return processVersionDetails(
-    extension,
+    setup,
     cliCompatible,
     version,
     isAvailable,
@@ -215,25 +215,25 @@ export const extensionCanRunCli = async (
 }
 
 export const recheckGlobal = async (
-  extension: IExtensionSetup,
-  setup: () => Promise<void[] | undefined>,
+  setup: IExtensionSetup,
+  run: () => Promise<void[] | undefined>,
   recheckInterval: number
 ): Promise<void> => {
   await delay(recheckInterval)
-  const roots = extension.getRoots()
+  const roots = setup.getRoots()
   const cwd = roots.length > 0 ? roots[0] : getFirstWorkspaceFolder()
 
-  if (!cwd || extension.getAvailable()) {
+  if (!cwd || setup.getAvailable()) {
     return
   }
 
-  const version = await extension.getCliVersion(cwd, true)
+  const version = await setup.getCliVersion(cwd, true)
   const cliCompatible = isVersionCompatible(version)
   const isCompatible = isCliCompatible(cliCompatible)
 
   if (!isCompatible) {
-    return recheckGlobal(extension, setup, recheckInterval)
+    return recheckGlobal(setup, run, recheckInterval)
   }
 
-  setup()
+  run()
 }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -46,7 +46,7 @@ import { Disposable } from './class/dispose'
 import { collectWorkspaceScale } from './telemetry/collect'
 import { GitExecutor } from './cli/git/executor'
 import { GitReader } from './cli/git/reader'
-import { Setup } from './setup/index'
+import { Setup } from './setup'
 
 export class Extension extends Disposable {
   protected readonly internalCommands: InternalCommands

--- a/extension/src/setup/index.ts
+++ b/extension/src/setup/index.ts
@@ -3,7 +3,7 @@ import isEmpty from 'lodash.isempty'
 import { SetupData as TSetupData } from './webview/contract'
 import { WebviewMessages } from './webview/messages'
 import { findPythonBinForInstall } from './autoInstall'
-import { setup, setupWithGlobalRecheck, setupWorkspace } from '../setup'
+import { run, runWithGlobalRecheck, runWorkspace } from './runner'
 import { BaseWebview } from '../webview'
 import { ViewKey } from '../webview/constants'
 import { BaseRepository } from '../webview/repository'
@@ -138,7 +138,7 @@ export class Setup
 
     this.dispose.track(
       this.onDidChangeWorkspace(() => {
-        setup(this)
+        run(this)
       })
     )
     this.watchForVenvChanges()
@@ -336,7 +336,7 @@ export class Setup
 
     internalCommands.registerExternalCommand(
       RegisteredCommands.EXTENSION_CHECK_CLI_COMPATIBLE,
-      () => setup(this)
+      () => run(this)
     )
 
     this.dispose.track(
@@ -360,7 +360,7 @@ export class Setup
       const previousCliPath = this.config.getCliPath()
       const previousPythonPath = this.config.getPythonBinPath()
 
-      const completed = await setupWorkspace(() =>
+      const completed = await runWorkspace(() =>
         this.config.setPythonAndNotifyIfChanged()
       )
       sendTelemetryEvent(
@@ -395,7 +395,7 @@ export class Setup
         const stopWatch = new StopWatch()
         try {
           this.sendDataToWebview()
-          await setup(this)
+          await run(this)
 
           return sendTelemetryEvent(
             EventName.EXTENSION_EXECUTION_DETAILS_CHANGED,
@@ -415,7 +415,7 @@ export class Setup
   }
 
   private watchPathForChanges(stopWatch: StopWatch) {
-    setupWithGlobalRecheck(this)
+    runWithGlobalRecheck(this)
       .then(async () => {
         sendTelemetryEvent(
           EventName.EXTENSION_LOAD,
@@ -449,7 +449,7 @@ export class Setup
           previousPythonBinPath !== this.config.getPythonBinPath()
 
         if (!this.cliAccessible || !this.cliCompatible || trySetupWithVenv) {
-          setup(this)
+          run(this)
         }
       }
     )

--- a/extension/src/setup/runner.test.ts
+++ b/extension/src/setup/runner.test.ts
@@ -271,7 +271,7 @@ describe('runWorkspace', () => {
 })
 
 describe('run', () => {
-  const extensionSetup = {
+  const setup = {
     getAvailable: mockedGetAvailable,
     getCliVersion: mockedGetCliVersion,
     getRoots: mockedGetRoots,
@@ -290,7 +290,7 @@ describe('run', () => {
   it('should do nothing if there is no workspace folder', async () => {
     mockedGetFirstWorkspaceFolder.mockReturnValueOnce(undefined)
 
-    await run(extensionSetup)
+    await run(setup)
 
     expect(mockedGetCliVersion).not.toHaveBeenCalled()
     expect(mockedInitialize).not.toHaveBeenCalled()
@@ -301,7 +301,7 @@ describe('run', () => {
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(false)
     mockedGetCliVersion.mockResolvedValueOnce(false)
 
-    await run(extensionSetup)
+    await run(setup)
 
     expect(mockedSetRoots).toHaveBeenCalledTimes(1)
   })
@@ -312,7 +312,7 @@ describe('run', () => {
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(false)
     mockedGetCliVersion.mockResolvedValueOnce(undefined)
 
-    await run(extensionSetup)
+    await run(setup)
     expect(mockedSetRoots).toHaveBeenCalledTimes(1)
     expect(mockedGetConfigValue).not.toHaveBeenCalled()
     expect(mockedWarnWithOptions).not.toHaveBeenCalled()
@@ -331,7 +331,7 @@ describe('run', () => {
       .mockResolvedValueOnce(undefined)
     mockedGetConfigValue.mockReturnValueOnce(true)
 
-    await run(extensionSetup)
+    await run(setup)
     expect(mockedSetRoots).toHaveBeenCalledTimes(1)
     expect(mockedGetConfigValue).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).not.toHaveBeenCalled()
@@ -355,7 +355,7 @@ describe('run', () => {
     mockedReady.mockResolvedValue(true)
     mockedGetExtension.mockReturnValue(mockedVscodePython)
 
-    await run(extensionSetup)
+    await run(setup)
     await flushPromises()
     expect(mockedSetRoots).toHaveBeenCalledTimes(1)
     expect(mockedGetConfigValue).toHaveBeenCalledTimes(1)
@@ -378,7 +378,7 @@ describe('run', () => {
     mockedReady.mockResolvedValue(true)
     mockedGetExtension.mockReturnValue(mockedVscodePython)
 
-    await run(extensionSetup)
+    await run(setup)
     await flushPromises()
     expect(mockedSetRoots).toHaveBeenCalledTimes(1)
     expect(mockedGetConfigValue).toHaveBeenCalledTimes(1)
@@ -402,7 +402,7 @@ describe('run', () => {
     mockedReady.mockResolvedValue(true)
     mockedGetExtension.mockReturnValue(mockedVscodePython)
 
-    await run(extensionSetup)
+    await run(setup)
     await flushPromises()
     expect(mockedSetRoots).toHaveBeenCalledTimes(1)
     expect(mockedGetConfigValue).toHaveBeenCalledTimes(1)
@@ -421,7 +421,7 @@ describe('run', () => {
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(false)
     mockedGetCliVersion.mockResolvedValueOnce(MIN_CLI_VERSION)
 
-    await run(extensionSetup)
+    await run(setup)
     expect(mockedSetRoots).toHaveBeenCalledTimes(1)
     expect(mockedResetMembers).toHaveBeenCalledTimes(1)
     expect(mockedSetAvailable).not.toHaveBeenCalledWith(false)
@@ -435,7 +435,7 @@ describe('run', () => {
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
     mockedGetCliVersion.mockResolvedValueOnce(MIN_CLI_VERSION)
 
-    await run(extensionSetup)
+    await run(setup)
     expect(mockedResetMembers).not.toHaveBeenCalled()
     expect(mockedInitialize).toHaveBeenCalledTimes(1)
   })
@@ -449,7 +449,7 @@ describe('run', () => {
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(MIN_CLI_VERSION)
 
-    await run(extensionSetup)
+    await run(setup)
     expect(mockedGetCliVersion).toHaveBeenCalledTimes(2)
     expect(mockedResetMembers).not.toHaveBeenCalled()
     expect(mockedInitialize).toHaveBeenCalledTimes(1)
@@ -468,7 +468,7 @@ describe('run', () => {
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(belowMinVersion)
 
-    await run(extensionSetup)
+    await run(setup)
     await flushPromises()
     expect(mockedWarnWithOptions).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).toHaveBeenCalledWith(
@@ -495,7 +495,7 @@ describe('run', () => {
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce([major, minor + 1, patch].join('.'))
 
-    await run(extensionSetup)
+    await run(setup)
     await flushPromises()
     expect(mockedWarnWithOptions).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).toHaveBeenCalledWith(
@@ -513,7 +513,7 @@ describe('run', () => {
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(false)
     mockedGetCliVersion.mockResolvedValueOnce(undefined)
 
-    await run(extensionSetup)
+    await run(setup)
     await flushPromises()
     expect(mockedWarnWithOptions).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).toHaveBeenCalledWith(
@@ -535,7 +535,7 @@ describe('run', () => {
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
     mockedGetCliVersion.mockResolvedValueOnce(MajorAhead)
 
-    await run(extensionSetup)
+    await run(setup)
     await flushPromises()
     expect(mockedWarnWithOptions).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).toHaveBeenCalledWith(
@@ -560,7 +560,7 @@ describe('run', () => {
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(undefined)
 
-    await run(extensionSetup)
+    await run(setup)
     await flushPromises()
     expect(mockedWarnWithOptions).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).toHaveBeenCalledWith(
@@ -579,7 +579,7 @@ describe('run', () => {
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(false)
     mockedGetCliVersion.mockResolvedValueOnce(false)
 
-    await run(extensionSetup)
+    await run(setup)
     expect(mockedGetCliVersion).toHaveBeenCalledTimes(1)
   })
 
@@ -591,7 +591,7 @@ describe('run', () => {
     mockedIsPythonExtensionUsed.mockResolvedValueOnce(true)
     mockedGetCliVersion.mockResolvedValueOnce(behind)
 
-    await run(extensionSetup)
+    await run(setup)
     expect(mockedGetCliVersion).toHaveBeenCalledTimes(1)
   })
 
@@ -601,14 +601,14 @@ describe('run', () => {
     mockedShouldWarnUserIfCLIUnavailable.mockReturnValueOnce(true)
     mockedGetCliVersion.mockResolvedValueOnce(false)
 
-    await run(extensionSetup)
+    await run(setup)
     expect(mockedResetMembers).toHaveBeenCalledTimes(1)
     expect(mockedInitialize).not.toHaveBeenCalled()
   })
 })
 
 describe('runWithGlobalRecheck', () => {
-  const extensionSetup = {
+  const setup = {
     getAvailable: mockedGetAvailable,
     getCliVersion: mockedGetCliVersion,
     getRoots: mockedGetRoots,
@@ -640,7 +640,7 @@ describe('runWithGlobalRecheck', () => {
       .mockResolvedValueOnce(LATEST_TESTED_CLI_VERSION)
       .mockResolvedValueOnce(LATEST_TESTED_CLI_VERSION)
 
-    await runWithGlobalRecheck(extensionSetup, mockedRecheckInterval)
+    await runWithGlobalRecheck(setup, mockedRecheckInterval)
 
     expect(mockedGetCliVersion).toHaveBeenCalledTimes(1)
     expect(mockedGetAvailable).toHaveBeenCalledTimes(1)
@@ -668,7 +668,7 @@ describe('runWithGlobalRecheck', () => {
 
     mockedGetCliVersion.mockResolvedValueOnce(LATEST_TESTED_CLI_VERSION)
 
-    await runWithGlobalRecheck(extensionSetup, 0)
+    await runWithGlobalRecheck(setup, 0)
 
     expect(mockedGetCliVersion).toHaveBeenCalledTimes(1)
     expect(mockedGetAvailable).toHaveBeenCalledTimes(1)
@@ -690,7 +690,7 @@ describe('runWithGlobalRecheck', () => {
     mockedGetAvailable.mockReturnValueOnce(false).mockReturnValueOnce(true)
     mockedGetCliVersion.mockResolvedValueOnce(undefined)
 
-    await runWithGlobalRecheck(extensionSetup, 0)
+    await runWithGlobalRecheck(setup, 0)
 
     expect(mockedGetCliVersion).toHaveBeenCalledTimes(1)
     expect(mockedGetAvailable).toHaveBeenCalledTimes(1)

--- a/extension/src/setup/runner.ts
+++ b/extension/src/setup/runner.ts
@@ -1,18 +1,18 @@
-import { IExtensionSetup } from './interfaces'
+import { IExtensionSetup } from '../interfaces'
 import {
   quickPickOneOrInput,
   quickPickValue,
   quickPickYesOrNo
-} from './vscode/quickPick'
-import { ConfigKey, setConfigValue } from './vscode/config'
-import { pickFile } from './vscode/resourcePicker'
-import { getFirstWorkspaceFolder } from './vscode/workspaceFolders'
-import { getSelectTitle, Title } from './vscode/title'
+} from '../vscode/quickPick'
+import { ConfigKey, setConfigValue } from '../vscode/config'
+import { pickFile } from '../vscode/resourcePicker'
+import { getFirstWorkspaceFolder } from '../vscode/workspaceFolders'
+import { getSelectTitle, Title } from '../vscode/title'
 import {
   isPythonExtensionInstalled,
   selectPythonInterpreter
-} from './extensions/python'
-import { extensionCanRunCli, recheckGlobal } from './cli/dvc/discovery'
+} from '../extensions/python'
+import { extensionCanRunCli, recheckGlobal } from '../cli/dvc/discovery'
 
 const setConfigPath = async (
   option: ConfigKey,
@@ -159,7 +159,7 @@ const selectInterpreter = async (
   return true
 }
 
-export const setupWorkspace = async (
+export const runWorkspace = async (
   setConfigToUsePythonExtension: () => Promise<void>
 ): Promise<boolean> => {
   const usesVenv = await quickPickVenvOption()
@@ -176,45 +176,45 @@ export const setupWorkspace = async (
 }
 
 export const checkAvailable = async (
-  extension: IExtensionSetup,
+  setup: IExtensionSetup,
   dvcRootOrFirstFolder: string
 ) => {
   const { isAvailable, isCompatible } = await extensionCanRunCli(
-    extension,
+    setup,
     dvcRootOrFirstFolder
   )
 
-  extension.setCliCompatible(isCompatible)
-  extension.setAvailable(isAvailable)
+  setup.setCliCompatible(isCompatible)
+  setup.setAvailable(isAvailable)
 
-  if (extension.hasRoots() && isAvailable) {
-    return extension.initialize()
+  if (setup.hasRoots() && isAvailable) {
+    return setup.initialize()
   }
 
-  extension.resetMembers()
+  setup.resetMembers()
 }
 
-export const setup = async (extension: IExtensionSetup) => {
+export const run = async (setup: IExtensionSetup) => {
   const cwd = getFirstWorkspaceFolder()
   if (!cwd) {
     return
   }
 
-  await extension.setRoots()
+  await setup.setRoots()
 
-  const roots = extension.getRoots()
+  const roots = setup.getRoots()
   const dvcRootOrFirstFolder = roots.length > 0 ? roots[0] : cwd
 
-  return checkAvailable(extension, dvcRootOrFirstFolder)
+  return checkAvailable(setup, dvcRootOrFirstFolder)
 }
 
-export const setupWithGlobalRecheck = async (
-  extension: IExtensionSetup,
+export const runWithGlobalRecheck = async (
+  setup: IExtensionSetup,
   recheckInterval = 5000
 ): Promise<void> => {
-  await setup(extension)
+  await run(setup)
 
-  if (!extension.getAvailable()) {
-    recheckGlobal(extension, () => setup(extension), recheckInterval)
+  if (!setup.getAvailable()) {
+    recheckGlobal(setup, () => run(setup), recheckInterval)
   }
 }

--- a/extension/src/test/suite/extension.test.ts
+++ b/extension/src/test/suite/extension.test.ts
@@ -23,7 +23,7 @@ import {
   RegisteredCliCommands,
   RegisteredCommands
 } from '../../commands/external'
-import * as Setup from '../../setup'
+import * as Setup from '../../setup/runner'
 import * as Watcher from '../../fileSystem/watcher'
 import * as Telemetry from '../../telemetry'
 import { EventName } from '../../telemetry/constants'
@@ -306,7 +306,7 @@ suite('Extension Test Suite', () => {
       mockDuration(0)
 
       const mockErrorMessage = 'NOPE'
-      stub(Setup, 'setupWorkspace').rejects(new Error(mockErrorMessage))
+      stub(Setup, 'runWorkspace').rejects(new Error(mockErrorMessage))
       const mockSendTelemetryEvent = stub(Telemetry, 'sendTelemetryEvent')
 
       await expect(
@@ -346,7 +346,7 @@ suite('Extension Test Suite', () => {
   describe('dvc.init', () => {
     it('should be able to run dvc.init without error', async () => {
       const mockInit = stub(DvcExecutor.prototype, 'init').resolves('')
-      const mockSetup = stub(Setup, 'setup')
+      const mockSetup = stub(Setup, 'run')
       const mockSetupCalled = new Promise(resolve =>
         mockSetup.callsFake(() => {
           resolve(undefined)
@@ -388,7 +388,7 @@ suite('Extension Test Suite', () => {
 
   describe('dvc.checkCLICompatible', () => {
     it('should call setup', async () => {
-      const mockSetup = stub(Setup, 'setup').resolves(undefined)
+      const mockSetup = stub(Setup, 'run').resolves(undefined)
       await commands.executeCommand(
         RegisteredCommands.EXTENSION_CHECK_CLI_COMPATIBLE
       )

--- a/extension/src/test/suite/setup/util.ts
+++ b/extension/src/test/suite/setup/util.ts
@@ -2,8 +2,8 @@ import { EventEmitter, commands } from 'vscode'
 import { Disposer } from '@hediet/std/disposable'
 import { fake, stub } from 'sinon'
 import * as FileSystem from '../../../fileSystem'
-import { Setup } from '../../../setup/index'
-import * as RunSetup from '../../../setup'
+import { Setup } from '../../../setup'
+import * as Runner from '../../../setup/runner'
 import { buildDependencies, mockDisposable } from '../util'
 import * as AutoInstall from '../../../setup/autoInstall'
 import { DvcReader } from '../../../cli/dvc/reader'
@@ -45,8 +45,8 @@ export const buildSetup = (
   const mockAutoInstallDvc = stub(AutoInstall, 'autoInstallDvc')
   stub(AutoInstall, 'findPythonBinForInstall').resolves(undefined)
   stub(commands, 'registerCommand').returns(mockDisposable)
-  stub(RunSetup, 'setup').resolves(undefined)
-  stub(RunSetup, 'setupWithGlobalRecheck').resolves(undefined)
+  stub(Runner, 'run').resolves(undefined)
+  stub(Runner, 'runWithGlobalRecheck').resolves(undefined)
 
   const setup = disposer.track(
     new Setup(


### PR DESCRIPTION
# 3/3 `main` <- #3002 <- #3017 <- this

This PR renames the original `./extension/setup` file to `./extension/setup/runner` (so we don't have `./extension/setup` & `./extension/setup/index`)