### PR TITLE
Fix stop button

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -802,7 +802,7 @@
         },
         {
           "command": "dvc.stopRunningExperiment",
-          "when": "dvc.commands.available && dvc.project.available && dvc.experiment.running"
+          "when": "dvc.commands.available && dvc.project.available && dvc.experiment.stoppable"
         },
         {
           "command": "dvc.views.experimentsColumnsTree.selectColumns",
@@ -975,7 +975,7 @@
         {
           "command": "dvc.stopRunningExperiment",
           "group": "navigation@0",
-          "when": "dvc.experiment.running && dvc.commands.available"
+          "when": "dvc.experiment.stoppable && dvc.commands.available"
         },
         {
           "command": "dvc.resetAndRunCheckpointExperiment",
@@ -1193,12 +1193,12 @@
         },
         {
           "command": "dvc.stopRunningExperiment",
-          "when": "view == dvc.views.experimentsTree && !dvc.experiments.webviewActive && dvc.experiment.running",
+          "when": "view == dvc.views.experimentsTree && !dvc.experiments.webviewActive && dvc.experiment.stoppable",
           "group": "1_run@1"
         },
         {
           "command": "dvc.stopRunningExperiment",
-          "when": "view == dvc.views.experimentsTree && dvc.experiments.webviewActive && dvc.experiment.running",
+          "when": "view == dvc.views.experimentsTree && dvc.experiments.webviewActive && dvc.experiment.stoppable",
           "group": "navigation@1"
         },
         {

--- a/extension/src/context.ts
+++ b/extension/src/context.ts
@@ -54,10 +54,11 @@ export class Context extends Disposable {
     )
   }
 
-  private setIsExperimentRunning(repositories: Experiments[] = []) {
+  private async setIsExperimentRunning(repositories: Experiments[] = []) {
     const contextKey = 'dvc.experiment.running'
     if (this.dvcRunner.isExperimentRunning()) {
       setContextValue(contextKey, true)
+      setContextValue('dvc.experiment.stoppable', true)
       return
     }
 
@@ -65,6 +66,11 @@ export class Context extends Disposable {
       contextKey,
       repositories,
       (experiments: Experiments) => experiments.hasRunningExperiment()
+    )
+
+    setContextValue(
+      'dvc.experiment.stoppable',
+      await this.experiments.hasDvcLiveOnlyExperimentRunning()
     )
   }
 

--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -11,6 +11,7 @@ import { BaseWorkspaceWebviews } from '../webview/workspace'
 import { Title } from '../vscode/title'
 import { setContextValue } from '../vscode/context'
 import { getPidFromSignalFile } from '../fileSystem'
+import { definedAndNonEmpty } from '../util/array'
 
 export class WorkspaceExperiments extends BaseWorkspaceWebviews<
   Experiments,
@@ -344,6 +345,10 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
     }
 
     return allLoading
+  }
+
+  public async hasDvcLiveOnlyExperimentRunning() {
+    return definedAndNonEmpty(await this.getDvcLiveOnlyPids())
   }
 
   public async getDvcLiveOnlyPids() {

--- a/extension/src/fileSystem/index.ts
+++ b/extension/src/fileSystem/index.ts
@@ -155,9 +155,11 @@ export const writeJson = <T extends Record<string, unknown>>(
   return writeFileSync(path, JSON.stringify(obj))
 }
 
-export const checkSignalFile = async (path: string): Promise<boolean> => {
+export const getPidFromSignalFile = async (
+  path: string
+): Promise<number | undefined> => {
   if (!exists(path)) {
-    return false
+    return
   }
 
   const contents = readFileSync(path).toString()
@@ -165,10 +167,13 @@ export const checkSignalFile = async (path: string): Promise<boolean> => {
 
   if (!pid || !(await processExists(pid))) {
     removeSync(path)
-    return false
+    return
   }
+  return pid
+}
 
-  return true
+export const checkSignalFile = async (path: string): Promise<boolean> => {
+  return !!(await getPidFromSignalFile(path))
 }
 
 export const getBinDisplayText = (

--- a/extension/src/processExecution.ts
+++ b/extension/src/processExecution.ts
@@ -4,6 +4,7 @@ import { Event, EventEmitter } from 'vscode'
 import { Disposable } from '@hediet/std/disposable'
 import execa from 'execa'
 import doesProcessExists from 'process-exists'
+import kill from 'tree-kill'
 
 interface RunningProcess extends ChildProcess {
   all?: Readable
@@ -46,8 +47,7 @@ export const createProcess = ({
 
   return Object.assign(process, {
     dispose: () => {
-      const kill = require('tree-kill')
-      kill(process.pid, 'SIGINT', () => disposed.fire(true))
+      kill(process.pid as number, 'SIGINT', () => disposed.fire(true))
     },
     onDidDispose: disposed.event
   })
@@ -62,3 +62,15 @@ export const executeProcess = async (
 
 export const processExists = (pid: number): Promise<boolean> =>
   doesProcessExists(pid)
+
+export const stopProcesses = (pids: number[]): boolean => {
+  let allKilled = true
+  for (const pid of pids) {
+    if (!processExists(pid)) {
+      allKilled = false
+      continue
+    }
+    kill(pid)
+  }
+  return allKilled
+}


### PR DESCRIPTION
# 1/2 `main` <- this <- #3041

Part of #3021

This PR fixes the stop experiment button by: 

 - Allowing users to stop experiments that are running in the DVCLive-only context. 
 - Hitting the button when we cannot stop the experiment (we don't have any reference to the process).

### Demo

https://user-images.githubusercontent.com/37993418/209922611-1d7d6ed1-e639-472f-bed8-970e99955a9a.mov



https://user-images.githubusercontent.com/37993418/210297560-e69f3563-d55c-4775-a072-2a04f3dfad41.mov

