### PR TITLE
GitHub actions update

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Set Variables
         id: set_variables
         run: |
-          echo "::set-output name=last_release_tag::$(git describe --tags --abbrev=0)"
-          echo "::set-output name=release_date::$(date --rfc-3339=date)"
+          echo "last_release_tag=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
+          echo "release_date=$(date --rfc-3339=date)" >> $GITHUB_OUTPUT
 
       - name: Build Changelog
         id: build_changelog
@@ -41,7 +41,7 @@ jobs:
         run: |
           OVERRIDE_VERSION=${{ github.event.inputs.override_version }}
           yarn workspace dvc version --new-version ${OVERRIDE_VERSION:-patch} --no-git-tag-version
-          echo "::set-output name=new_version::$(cat extension/package.json | jq -r .version)"
+          echo "new_version=$(cat extension/package.json | jq -r .version)" >> $GITHUB_OUTPUT
 
       - name: Update Changelog
         uses: stefanzweifel/changelog-updater-action@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set Variables
         id: set_variables
         run: |
-          echo "::set-output name=commit::$(git rev-parse HEAD)"
+          echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v3


### PR DESCRIPTION
Use the new output files for actions
https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/