### PR TITLE
Use cml to create release PR

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -61,12 +61,9 @@ jobs:
           echo "Please close and reopen this PR to run the required workflows (Required statuses must pass before merging).\n" >> pr-body.md
           echo "**The \`publish\` workflow will run automatically when this PR is merged.**" >> pr-body.md
 
-          new_pr=$(cml pr create \
+          cml pr create \
             --token="${{ secrets.GITHUB_TOKEN }}" \
             --message="Update version and CHANGELOG for release" \
             --title="Update version and CHANGELOG for release" \
-            --body="$(cat ./pr-body.md)")
+            --body="$(cat ./pr-body.md)"
           
-          gh pr edit $(echo "$new_pr" | awk -F / '{print $NF}') --add-label "make release go now"
-
-          echo "$new_pr"

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -54,16 +54,14 @@ jobs:
           release-date: ${{ steps.set_variables.outputs.release_date }}
 
       - name: Create Pull Request
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "This PR updates the extension version and CHANGELOG.md.\n" >> pr-body.md
-          echo "Please close and reopen this PR to run the required workflows (Required statuses must pass before merging).\n" >> pr-body.md
-          echo "**The \`publish\` workflow will run automatically when this PR is merged.**" >> pr-body.md
+          echo "This PR updates the extension version and CHANGELOG.md.\n" >> body.log
+          echo "Please close and reopen this PR to run the required workflows (Required statuses must pass before merging).\n" >> body.log
+          echo "**The \`publish\` workflow will run automatically when this PR is merged.**" >> body.log
 
           cml pr create \
             --token="${{ secrets.GITHUB_TOKEN }}" \
             --message="Update version and CHANGELOG for release" \
             --title="Update version and CHANGELOG for release" \
-            --body="$(cat ./pr-body.md)"
+            --body="$(cat ./body.log)" .
           

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup CML
+        uses: iterative/setup-cml@v1
+
       - name: Set Variables
         id: set_variables
         run: |
@@ -51,16 +54,19 @@ jobs:
           release-date: ${{ steps.set_variables.outputs.release_date }}
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
-        with:
-          base: main
-          body: |
-            This PR updates the extension version and CHANGELOG.md.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "This PR updates the extension version and CHANGELOG.md.\n" >> pr-body.md
+          echo "Please close and reopen this PR to run the required workflows (Required statuses must pass before merging).\n" >> pr-body.md
+          echo "**The \`publish\` workflow will run automatically when this PR is merged.**" >> pr-body.md
 
-            Please close and reopen this PR to run the required workflows (Required statuses must pass before merging).
+          new_pr=$(cml pr create \
+            --token="${{ secrets.GITHUB_TOKEN }}" \
+            --message="Update version and CHANGELOG for release" \
+            --title="Update version and CHANGELOG for release" \
+            --body="$(cat ./pr-body.md)")
+          
+          gh pr edit $(echo "$new_pr" | awk -F / '{print $NF}') --add-label "make release go now"
 
-            **The `publish` workflow will run automatically when this PR is merged.**
-          commit-message: 'Update version and CHANGELOG for release'
-          title: 'Update version and CHANGELOG for release'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: make release go now
+          echo "$new_pr"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,6 @@ jobs:
   deploy:
     if: |
       github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'make release go now') && 
       github.event.pull_request.title == 'Update version and CHANGELOG for release'
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
Part of an effort to use our own tools more/where appropriate.

This current state will replace what was present. However, `cml pr create` doesn't have an option for labels, so some additional bash script is required.

`cml pr create` output prints the pr URL like `https://github.com/iterative/vscode-dvc/pull/2998` and `awk -F / '{print $NF}'` splits on `/` and prints the last field being the pr # for gh to add the label.

---

cc @iterative/vs-code feel free to merge as is if this is acceptable to you, but I think its fine to hold out for a cml feature to support labels

---
cc @casperdcl I think a `--labels` option is an easy addition.

