### PR TITLE
Reinstate @typescript-eslint/no-unused-vars as error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -89,6 +89,7 @@ module.exports = {
     '@typescript-eslint/no-empty-function': 'off',
     '@typescript-eslint/no-explicit-any': 'error',
     '@typescript-eslint/no-extra-semi': 'off',
+    '@typescript-eslint/no-unused-vars': 'error',
     '@typescript-eslint/no-use-before-define': 'error',
     '@typescript-eslint/no-var-requires': 'off',
     '@typescript-eslint/prefer-optional-chain': 'error',

--- a/extension/src/config.ts
+++ b/extension/src/config.ts
@@ -1,7 +1,6 @@
 import { EventEmitter, Event, workspace } from 'vscode'
 import { Disposable } from '@hediet/std/disposable'
 import isEqual from 'lodash.isequal'
-import isEmpty from 'lodash.isempty'
 import {
   getOnDidChangePythonExecutionDetails,
   getPythonBinPath

--- a/extension/src/test/suite/extension.test.ts
+++ b/extension/src/test/suite/extension.test.ts
@@ -19,10 +19,7 @@ import { DvcReader } from '../../cli/dvc/reader'
 import expShowFixture from '../fixtures/expShow/base/output'
 import plotsDiffFixture from '../fixtures/plotsDiff/output'
 import * as Disposer from '../../util/disposable'
-import {
-  RegisteredCliCommands,
-  RegisteredCommands
-} from '../../commands/external'
+import { RegisteredCommands } from '../../commands/external'
 import * as Setup from '../../setup/runner'
 import * as Watcher from '../../fileSystem/watcher'
 import * as Telemetry from '../../telemetry'
@@ -30,8 +27,6 @@ import { EventName } from '../../telemetry/constants'
 import { OutputChannel } from '../../vscode/outputChannel'
 import { WorkspaceExperiments } from '../../experiments/workspace'
 import { QuickPickItemWithValue } from '../../vscode/quickPick'
-import * as WorkspaceFolders from '../../vscode/workspaceFolders'
-import { DvcExecutor } from '../../cli/dvc/executor'
 import { GitReader } from '../../cli/git/reader'
 import { Config } from '../../config'
 import {


### PR DESCRIPTION
I think this rule got downgraded to a warning when the package was updated. It's a good rule so let's bring it back as an error.