### PR TITLE
Add project selection quick pick

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -353,6 +353,11 @@
         "category": "DVC"
       },
       {
+        "title": "%command.selectFocusedProjects%",
+        "command": "dvc.selectFocusedProjects",
+        "category": "DVC"
+      },
+      {
         "title": "%command.setupWorkspace%",
         "command": "dvc.setupWorkspace",
         "category": "DVC"
@@ -775,6 +780,10 @@
         {
           "command": "dvc.selectForCompare",
           "when": "false"
+        },
+        {
+          "command": "dvc.selectFocusedProjects",
+          "when": "dvc.commands.available && dvc.project.available && dvc.multiple.projects"
         },
         {
           "command": "dvc.showCommands",

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -47,6 +47,7 @@
   "command.startExperimentsQueue": "Start the Experiments Queue",
   "command.resetAndRunCheckpointExperiment": "Run Experiment",
   "command.selectForCompare": "Select for Compare",
+  "command.selectFocusedProjects": "Select Projects to Focus",
   "command.setupWorkspace": "Setup The Workspace",
   "command.shareExperimentAsBranch": "Share Experiment as Branch",
   "command.shareExperimentAsCommit": "Commit and Share Experiment",

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -47,7 +47,7 @@
   "command.startExperimentsQueue": "Start the Experiments Queue",
   "command.resetAndRunCheckpointExperiment": "Run Experiment",
   "command.selectForCompare": "Select for Compare",
-  "command.selectFocusedProjects": "Select Projects to Focus",
+  "command.selectFocusedProjects": "Select Project(s) to Focus (set dvc.focusedProjects)",
   "command.setupWorkspace": "Setup The Workspace",
   "command.shareExperimentAsBranch": "Share Experiment as Branch",
   "command.shareExperimentAsCommit": "Commit and Share Experiment",

--- a/extension/src/commands/external.ts
+++ b/extension/src/commands/external.ts
@@ -92,5 +92,6 @@ export enum RegisteredCommands {
   TRACKED_EXPLORER_OPEN_TO_THE_SIDE = 'dvc.openToTheSide',
   TRACKED_EXPLORER_SELECT_FOR_COMPARE = 'dvc.selectForCompare',
 
-  SETUP_SHOW = 'dvc.showSetup'
+  SETUP_SHOW = 'dvc.showSetup',
+  SELECT_FOCUSED_PROJECTS = 'dvc.selectFocusedProjects'
 }

--- a/extension/src/config.ts
+++ b/extension/src/config.ts
@@ -6,7 +6,7 @@ import {
   getOnDidChangePythonExecutionDetails,
   getPythonBinPath
 } from './extensions/python'
-import { ConfigKey, getConfigValue } from './vscode/config'
+import { ConfigKey, getConfigValue, setConfigValue } from './vscode/config'
 import { DeferredDisposable } from './class/deferred'
 import { getOnDidChangeExtensions } from './vscode/extensions'
 import { standardizePath } from './fileSystem/path'
@@ -69,6 +69,10 @@ export class Config extends DeferredDisposable {
 
   public unsetPythonBinPath() {
     this.pythonBinPath = undefined
+  }
+
+  public setFocusedProjectsOption(focusedProjects: string[]) {
+    setConfigValue(ConfigKey.FOCUSED_PROJECTS, focusedProjects)
   }
 
   public isPythonExtensionUsed() {

--- a/extension/src/setup/index.ts
+++ b/extension/src/setup/index.ts
@@ -190,7 +190,7 @@ export class Setup
   }
 
   public async setRoots() {
-    const nestedRoots = await this.findDvcRoots()
+    const nestedRoots = await this.findWorkspaceDvcRoots()
     this.dvcRoots =
       this.config.getFocusedProjects() || nestedRoots.flat().sort()
 
@@ -271,11 +271,11 @@ export class Setup
     return webviewMessages
   }
 
-  private async findDvcRoots(): Promise<string[]> {
+  private async findWorkspaceDvcRoots(): Promise<string[]> {
     const dvcRoots: string[] = []
 
-    for (const cwd of getWorkspaceFolders()) {
-      const workspaceFolderRoots = await findDvcRootPaths(cwd)
+    for (const workspaceFolder of getWorkspaceFolders()) {
+      const workspaceFolderRoots = await findDvcRootPaths(workspaceFolder)
       if (definedAndNonEmpty(workspaceFolderRoots)) {
         dvcRoots.push(...workspaceFolderRoots)
         continue
@@ -283,8 +283,8 @@ export class Setup
 
       await this.config.isReady()
       const absoluteRoot = await findAbsoluteDvcRootPath(
-        cwd,
-        this.dvcReader.root(cwd)
+        workspaceFolder,
+        this.dvcReader.root(workspaceFolder)
       )
       if (absoluteRoot) {
         dvcRoots.push(...absoluteRoot)
@@ -382,7 +382,7 @@ export class Setup
     internalCommands.registerExternalCommand(
       RegisteredCommands.SELECT_FOCUSED_PROJECTS,
       async () => {
-        const dvcRoots = await this.findDvcRoots()
+        const dvcRoots = await this.findWorkspaceDvcRoots()
         const focusedProjects = await pickFocusedProjects(
           dvcRoots,
           this.dvcRoots

--- a/extension/src/setup/index.ts
+++ b/extension/src/setup/index.ts
@@ -45,7 +45,6 @@ import { EventName } from '../telemetry/constants'
 import { WorkspaceScale } from '../telemetry/collect'
 import { gitPath } from '../cli/git/constants'
 import { DOT_DVC } from '../cli/dvc/constants'
-import { ConfigKey, setConfigValue } from '../vscode/config'
 
 export type SetupWebviewWebview = BaseWebview<TSetupData>
 
@@ -388,7 +387,7 @@ export class Setup
           this.dvcRoots
         )
         if (focusedProjects) {
-          setConfigValue(ConfigKey.FOCUSED_PROJECTS, focusedProjects)
+          this.config.setFocusedProjectsOption(focusedProjects)
         }
       }
     )

--- a/extension/src/setup/index.ts
+++ b/extension/src/setup/index.ts
@@ -5,6 +5,7 @@ import { SetupData as TSetupData } from './webview/contract'
 import { WebviewMessages } from './webview/messages'
 import { findPythonBinForInstall } from './autoInstall'
 import { run, runWithGlobalRecheck, runWorkspace } from './runner'
+import { pickFocusedProjects } from './quickPick'
 import { BaseWebview } from '../webview'
 import { ViewKey } from '../webview/constants'
 import { BaseRepository } from '../webview/repository'
@@ -44,6 +45,7 @@ import { EventName } from '../telemetry/constants'
 import { WorkspaceScale } from '../telemetry/collect'
 import { gitPath } from '../cli/git/constants'
 import { DOT_DVC } from '../cli/dvc/constants'
+import { ConfigKey, setConfigValue } from '../vscode/config'
 
 export type SetupWebviewWebview = BaseWebview<TSetupData>
 
@@ -188,12 +190,9 @@ export class Setup
   }
 
   public async setRoots() {
-    const nestedRoots = await Promise.all(
-      getWorkspaceFolders().map(workspaceFolder =>
-        this.findDvcRoots(workspaceFolder)
-      )
-    )
-    this.dvcRoots = nestedRoots.flat().sort()
+    const nestedRoots = await this.findDvcRoots()
+    this.dvcRoots =
+      this.config.getFocusedProjects() || nestedRoots.flat().sort()
 
     this.sendDataToWebview()
     return this.setProjectAvailability()
@@ -272,15 +271,30 @@ export class Setup
     return webviewMessages
   }
 
-  private async findDvcRoots(cwd: string): Promise<string[]> {
-    const dvcRoots =
-      this.config.getFocusedProjects() || (await findDvcRootPaths(cwd))
-    if (definedAndNonEmpty(dvcRoots)) {
-      return dvcRoots
+  private async findDvcRoots(): Promise<string[]> {
+    const dvcRoots: string[] = []
+
+    for (const cwd of getWorkspaceFolders()) {
+      const workspaceFolderRoots = await findDvcRootPaths(cwd)
+      if (definedAndNonEmpty(workspaceFolderRoots)) {
+        dvcRoots.push(...workspaceFolderRoots)
+        continue
+      }
+
+      await this.config.isReady()
+      const absoluteRoot = await findAbsoluteDvcRootPath(
+        cwd,
+        this.dvcReader.root(cwd)
+      )
+      if (absoluteRoot) {
+        dvcRoots.push(...absoluteRoot)
+      }
     }
 
-    await this.config.isReady()
-    return findAbsoluteDvcRootPath(cwd, this.dvcReader.root(cwd))
+    const hasMultipleRoots = dvcRoots.length > 1
+    setContextValue('dvc.multiple.projects', hasMultipleRoots)
+
+    return dvcRoots
   }
 
   private setCommandsAvailability(available: boolean) {
@@ -362,6 +376,20 @@ export class Setup
       RegisteredCommands.SETUP_SHOW,
       async () => {
         await this.showSetup()
+      }
+    )
+
+    internalCommands.registerExternalCommand(
+      RegisteredCommands.SELECT_FOCUSED_PROJECTS,
+      async () => {
+        const dvcRoots = await this.findDvcRoots()
+        const focusedProjects = await pickFocusedProjects(
+          dvcRoots,
+          this.dvcRoots
+        )
+        if (focusedProjects) {
+          setConfigValue(ConfigKey.FOCUSED_PROJECTS, focusedProjects)
+        }
       }
     )
   }

--- a/extension/src/setup/quickPick.test.ts
+++ b/extension/src/setup/quickPick.test.ts
@@ -1,0 +1,57 @@
+import { join } from 'path'
+import { pickFocusedProjects } from './quickPick'
+import { quickPickManyValues } from '../vscode/quickPick'
+import { Toast } from '../vscode/toast'
+import { Title } from '../vscode/title'
+
+jest.mock('../vscode/quickPick')
+
+const mockedQuickPickManyValues = jest.mocked(quickPickManyValues)
+
+const mockedToast = jest.mocked(Toast)
+const mockedShowError = jest.fn()
+mockedToast.showError = mockedShowError
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('pickFocusedProjects', () => {
+  const mockedRoots = [join('root', 'a'), join('root', 'b'), join('root', 'c')]
+
+  it('should return undefined and not show a toast message if the user cancels the dialog', async () => {
+    mockedQuickPickManyValues.mockResolvedValueOnce(undefined)
+    const focusedProjects = await pickFocusedProjects(mockedRoots, mockedRoots)
+    expect(mockedShowError).not.toHaveBeenCalled()
+    expect(focusedProjects).toBeUndefined()
+  })
+
+  it('should return undefined and show a toast message if the user selects no projects', async () => {
+    mockedQuickPickManyValues.mockResolvedValueOnce([])
+    const focusedProjects = await pickFocusedProjects(mockedRoots, mockedRoots)
+    expect(mockedShowError).toHaveBeenCalledTimes(1)
+    expect(focusedProjects).toBeUndefined()
+  })
+
+  it('should return the selected roots', async () => {
+    const selectedRoots = mockedRoots.slice(0, 2)
+    mockedQuickPickManyValues.mockResolvedValueOnce(selectedRoots)
+    const focusedProjects = await pickFocusedProjects(mockedRoots, mockedRoots)
+    expect(mockedShowError).not.toHaveBeenCalled()
+    expect(focusedProjects).toStrictEqual(selectedRoots)
+  })
+
+  it('should mark the currently selected roots as picked', async () => {
+    const selectedRoots = mockedRoots.slice(0, 2)
+    mockedQuickPickManyValues.mockResolvedValueOnce(selectedRoots)
+    await pickFocusedProjects(mockedRoots, selectedRoots)
+    expect(mockedQuickPickManyValues).toHaveBeenCalledWith(
+      [
+        { label: mockedRoots[0], picked: true, value: mockedRoots[0] },
+        { label: mockedRoots[1], picked: true, value: mockedRoots[1] },
+        { label: mockedRoots[2], picked: false, value: mockedRoots[2] }
+      ],
+      { title: Title.SELECT_FOCUSED_PROJECTS }
+    )
+  })
+})

--- a/extension/src/setup/quickPick.ts
+++ b/extension/src/setup/quickPick.ts
@@ -22,5 +22,5 @@ export const pickFocusedProjects = async (
     Toast.showError('Cannot select 0 projects.')
     return
   }
-  return values
+  return values.sort()
 }

--- a/extension/src/setup/quickPick.ts
+++ b/extension/src/setup/quickPick.ts
@@ -1,0 +1,26 @@
+import { quickPickManyValues } from '../vscode/quickPick'
+import { Title } from '../vscode/title'
+import { Toast } from '../vscode/toast'
+
+export const pickFocusedProjects = async (
+  projects: string[],
+  currentProjects: string[]
+): Promise<string[] | undefined> => {
+  const values = await quickPickManyValues(
+    projects.map(path => ({
+      label: path,
+      picked: currentProjects.includes(path),
+      value: path
+    })),
+    { title: Title.SELECT_FOCUSED_PROJECTS }
+  )
+  if (!values) {
+    return
+  }
+
+  if (values.length === 0) {
+    Toast.showError('Please select at least one projects to focused.')
+    return
+  }
+  return values
+}

--- a/extension/src/setup/quickPick.ts
+++ b/extension/src/setup/quickPick.ts
@@ -19,7 +19,7 @@ export const pickFocusedProjects = async (
   }
 
   if (values.length === 0) {
-    Toast.showError('Please select at least one projects to focused.')
+    Toast.showError('Cannot select 0 projects.')
     return
   }
   return values

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -267,4 +267,5 @@ export interface IEventNamePropertyMapping {
   [EventName.VIEWS_SETUP_INSTALL_DVC]: undefined
 
   [EventName.SETUP_SHOW]: undefined
+  [EventName.SELECT_FOCUSED_PROJECTS]: undefined
 }

--- a/extension/src/vscode/title.ts
+++ b/extension/src/vscode/title.ts
@@ -11,7 +11,7 @@ export enum Title {
   SELECT_EXPERIMENT = 'Select an Experiment',
   SELECT_EXPERIMENTS = 'Select up to 7 Experiments to Display in Plots',
   SELECT_FILTERS_TO_REMOVE = 'Select Filter(s) to Remove',
-  SELECT_FOCUSED_PROJECTS = 'Select Project(s) to Focus (sets dvc.focusedProjects)',
+  SELECT_FOCUSED_PROJECTS = 'Select Project(s) to Focus (set dvc.focusedProjects)',
   SELECT_OPERATOR = 'Select an Operator',
   SELECT_PARAM_OR_METRIC_FILTER = 'Select a Param or Metric to Filter by',
   SELECT_PARAM_OR_METRIC_SORT = 'Select a Param or Metric to Sort by',

--- a/extension/src/vscode/title.ts
+++ b/extension/src/vscode/title.ts
@@ -11,7 +11,7 @@ export enum Title {
   SELECT_EXPERIMENT = 'Select an Experiment',
   SELECT_EXPERIMENTS = 'Select up to 7 Experiments to Display in Plots',
   SELECT_FILTERS_TO_REMOVE = 'Select Filter(s) to Remove',
-  SELECT_FOCUSED_PROJECTS = 'Select Projects to Focus',
+  SELECT_FOCUSED_PROJECTS = 'Select Project(s) to Focus (sets dvc.focusedProjects)',
   SELECT_OPERATOR = 'Select an Operator',
   SELECT_PARAM_OR_METRIC_FILTER = 'Select a Param or Metric to Filter by',
   SELECT_PARAM_OR_METRIC_SORT = 'Select a Param or Metric to Sort by',

--- a/extension/src/vscode/title.ts
+++ b/extension/src/vscode/title.ts
@@ -11,6 +11,7 @@ export enum Title {
   SELECT_EXPERIMENT = 'Select an Experiment',
   SELECT_EXPERIMENTS = 'Select up to 7 Experiments to Display in Plots',
   SELECT_FILTERS_TO_REMOVE = 'Select Filter(s) to Remove',
+  SELECT_FOCUSED_PROJECTS = 'Select Projects to Focus',
   SELECT_OPERATOR = 'Select an Operator',
   SELECT_PARAM_OR_METRIC_FILTER = 'Select a Param or Metric to Filter by',
   SELECT_PARAM_OR_METRIC_SORT = 'Select a Param or Metric to Sort by',


### PR DESCRIPTION
Follow up from #3030

This PR adds a quick pick that can be used to focus on particular projects in the current workspace. This quick pick is only made available when there is > 1 project in the workspace.

### Demo

https://user-images.githubusercontent.com/37993418/210293160-01e5f040-217e-498a-835a-f3326def5054.mov


