### PR TITLE
Fix filtering and add missing experiments on quick pick experiment selection

### DIFF
--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -593,7 +593,7 @@ export class Experiments extends BaseRepository<TableData> {
     }
 
     const experiment = await pickExperiment(
-      this.experiments.getExperiments(),
+      this.experiments.getAllExperiments(),
       Title.SELECT_BASE_EXPERIMENT
     )
 

--- a/extension/src/experiments/model/quickPick.test.ts
+++ b/extension/src/experiments/model/quickPick.test.ts
@@ -70,7 +70,8 @@ describe('pickExperiments', () => {
         }
       ],
       MAX_SELECTED_EXPERIMENTS,
-      Title.SELECT_EXPERIMENTS
+      Title.SELECT_EXPERIMENTS,
+      { matchOnDescription: true, matchOnDetail: true }
     )
   })
 
@@ -162,7 +163,8 @@ describe('pickExperiments', () => {
       ],
       [],
       MAX_SELECTED_EXPERIMENTS,
-      Title.SELECT_EXPERIMENTS
+      Title.SELECT_EXPERIMENTS,
+      { matchOnDescription: true, matchOnDetail: true }
     )
   })
 
@@ -250,7 +252,8 @@ describe('pickExperiments', () => {
       ],
       [getExpectedItem(selectedCheckpoint)],
       MAX_SELECTED_EXPERIMENTS,
-      Title.SELECT_EXPERIMENTS
+      Title.SELECT_EXPERIMENTS,
+      { matchOnDescription: true, matchOnDetail: true }
     )
   })
 })

--- a/extension/src/experiments/model/quickPicks.ts
+++ b/extension/src/experiments/model/quickPicks.ts
@@ -135,6 +135,7 @@ export const pickExperiments = (
     items,
     selectedItems,
     MAX_SELECTED_EXPERIMENTS,
-    Title.SELECT_EXPERIMENTS
+    Title.SELECT_EXPERIMENTS,
+    { matchOnDescription: true, matchOnDetail: true }
   )
 }

--- a/extension/src/experiments/quickPick.ts
+++ b/extension/src/experiments/quickPick.ts
@@ -21,7 +21,7 @@ export const pickExperiment = (
         label,
         value: { id, name: name || label }
       })),
-      { title }
+      { matchOnDescription: true, matchOnDetail: true, title }
     )
   }
 }

--- a/extension/src/test/suite/experiments/workspace.test.ts
+++ b/extension/src/test/suite/experiments/workspace.test.ts
@@ -530,6 +530,8 @@ suite('Workspace Experiments Test Suite', () => {
         ],
         {
           canPickMany: false,
+          matchOnDescription: true,
+          matchOnDetail: true,
           title: Title.SELECT_EXPERIMENT
         }
       )

--- a/extension/src/vscode/quickPick.ts
+++ b/extension/src/vscode/quickPick.ts
@@ -45,13 +45,21 @@ export const quickPickOne = (
 const createQuickPick = <T>(
   items: readonly QuickPickItemWithValue<T>[],
   selectedItems: readonly QuickPickItemWithValue<T>[] | undefined,
-  options: { canSelectMany: boolean; placeholder?: string; title: Title }
+  options: {
+    canSelectMany: boolean
+    placeholder?: string
+    title: Title
+    matchOnDescription?: boolean
+    matchOnDetail?: boolean
+  }
 ): QuickPick<QuickPickItemWithValue<T>> => {
   const quickPick = window.createQuickPick<QuickPickItemWithValue<T>>()
 
   quickPick.canSelectMany = options.canSelectMany
   quickPick.placeholder = options.placeholder
   quickPick.title = options.title
+  quickPick.matchOnDescription = options.matchOnDescription || false
+  quickPick.matchOnDetail = options.matchOnDetail || false
 
   quickPick.items = items
   if (selectedItems) {
@@ -181,12 +189,14 @@ export const quickPickLimitedValues = <T>(
   items: QuickPickItemWithValue<T>[],
   selectedItems: readonly QuickPickItemWithValue<T>[],
   maxSelectedItems: number,
-  title: Title
+  title: Title,
+  options?: { matchOnDescription?: boolean; matchOnDetail?: boolean }
 ): Promise<Exclude<T, undefined>[] | undefined> =>
   new Promise(resolve => {
     const quickPick = createQuickPick(items, selectedItems, {
       canSelectMany: true,
-      title
+      title,
+      ...options
     })
 
     limitSelected<T>(quickPick, maxSelectedItems)


### PR DESCRIPTION
* Allow filtering by description/detail on quick pick experiment selection
* Add missing experiments on "Modify Experiment Param(s) and ..." commands

## Demo

### Filtering

https://user-images.githubusercontent.com/43496356/210830190-95339af3-1356-4317-ba00-bebb5a322beb.mov

### Missing Experiments

https://user-images.githubusercontent.com/43496356/210850007-86f7f2ab-8cdf-4cb3-9684-219b7209807f.mov

Part of #3044