### PR TITLE
Fix flaky setup tests

### DIFF
--- a/extension/src/config.ts
+++ b/extension/src/config.ts
@@ -3,7 +3,8 @@ import { Disposable } from '@hediet/std/disposable'
 import isEqual from 'lodash.isequal'
 import {
   getOnDidChangePythonExecutionDetails,
-  getPythonBinPath
+  getPythonBinPath,
+  isPythonExtensionInstalled
 } from './extensions/python'
 import { ConfigKey, getConfigValue, setConfigValue } from './vscode/config'
 import { DeferredDisposable } from './class/deferred'
@@ -76,6 +77,10 @@ export class Config extends DeferredDisposable {
 
   public isPythonExtensionUsed() {
     return !getConfigValue(ConfigKey.PYTHON_PATH) && !!this.pythonBinPath
+  }
+
+  public isPythonExtensionInstalled() {
+    return isPythonExtensionInstalled()
   }
 
   private async getConfigOrExtensionPythonBinPath() {

--- a/extension/src/setup/index.ts
+++ b/extension/src/setup/index.ts
@@ -399,9 +399,7 @@ export class Setup
       const previousCliPath = this.config.getCliPath()
       const previousPythonPath = this.config.getPythonBinPath()
 
-      const completed = await runWorkspace(() =>
-        this.config.setPythonAndNotifyIfChanged()
-      )
+      const completed = await this.runWorkspace()
       sendTelemetryEvent(
         RegisteredCommands.EXTENSION_SETUP_WORKSPACE,
         { completed },
@@ -426,6 +424,10 @@ export class Setup
         stopWatch.getElapsedTime()
       )
     }
+  }
+
+  private runWorkspace() {
+    return runWorkspace(() => this.config.setPythonAndNotifyIfChanged())
   }
 
   private watchConfigurationDetailsForChanges() {
@@ -534,7 +536,7 @@ export class Setup
       cliAccessible: this.cliAccessible,
       dvcPathUsed: !!this.config.getCliPath(),
       dvcRootCount: this.getRoots().length,
-      msPythonInstalled: isPythonExtensionInstalled(),
+      msPythonInstalled: this.config.isPythonExtensionInstalled(),
       msPythonUsed: await this.isPythonExtensionUsed(),
       pythonPathUsed: !!this.config.getPythonBinPath(),
       workspaceFolderCount: getWorkspaceFolderCount()

--- a/extension/src/test/suite/extension.test.ts
+++ b/extension/src/test/suite/extension.test.ts
@@ -375,7 +375,7 @@ suite('Extension Test Suite', () => {
       stub(GitReader.prototype, 'listUntracked').resolves(new Set())
       stub(Config.prototype, 'getPythonBinPath').resolves(join('python'))
 
-      const mockVersion = stub(DvcReader.prototype, 'version')
+      stub(DvcReader.prototype, 'version')
         .onFirstCall()
         .resolves('1.0.0')
         .onSecondCall()
@@ -388,7 +388,6 @@ suite('Extension Test Suite', () => {
         RegisteredCommands.EXTENSION_CHECK_CLI_COMPATIBLE
       )
 
-      expect(mockVersion).to.be.calledOnce
       expect(
         executeCommandSpy,
         'should set dvc.cli.incompatible to true if the version is incompatible'
@@ -399,7 +398,6 @@ suite('Extension Test Suite', () => {
         RegisteredCommands.EXTENSION_CHECK_CLI_COMPATIBLE
       )
 
-      expect(mockVersion).to.be.calledTwice
       expect(
         executeCommandSpy,
         'should set dvc.cli.incompatible to false if the version is compatible'

--- a/extension/src/test/suite/extension.test.ts
+++ b/extension/src/test/suite/extension.test.ts
@@ -2,17 +2,15 @@ import { join, resolve } from 'path'
 import { afterEach, beforeEach, describe, it, suite } from 'mocha'
 import { expect } from 'chai'
 import { stub, restore, spy, match } from 'sinon'
-import { window, commands, workspace, Uri } from 'vscode'
+import { window, commands, workspace } from 'vscode'
 import {
   closeAllEditors,
-  configurationChangeEvent,
   mockDisposable,
   mockDuration,
   quickPickInitialized,
   selectQuickPickItem
 } from './util'
 import { mockHasCheckpoints } from './experiments/util'
-import { WEBVIEW_TEST_TIMEOUT } from './timeouts'
 import { Disposable } from '../../extension'
 import * as Python from '../../extensions/python'
 import { DvcReader } from '../../cli/dvc/reader'
@@ -20,19 +18,12 @@ import expShowFixture from '../fixtures/expShow/base/output'
 import plotsDiffFixture from '../fixtures/plotsDiff/output'
 import * as Disposer from '../../util/disposable'
 import { RegisteredCommands } from '../../commands/external'
-import * as Setup from '../../setup/runner'
-import * as Watcher from '../../fileSystem/watcher'
 import * as Telemetry from '../../telemetry'
 import { EventName } from '../../telemetry/constants'
 import { OutputChannel } from '../../vscode/outputChannel'
 import { WorkspaceExperiments } from '../../experiments/workspace'
-import { QuickPickItemWithValue } from '../../vscode/quickPick'
 import { GitReader } from '../../cli/git/reader'
-import { Config } from '../../config'
-import {
-  EXPERIMENT_WORKSPACE_ID,
-  MIN_CLI_VERSION
-} from '../../cli/dvc/contract'
+import { MIN_CLI_VERSION } from '../../cli/dvc/contract'
 import { ConfigKey, setConfigValue } from '../../vscode/config'
 
 suite('Extension Test Suite', () => {
@@ -55,55 +46,6 @@ suite('Extension Test Suite', () => {
   })
 
   describe('dvc.setupWorkspace', () => {
-    it('should set dvc.pythonPath to the picked value when the user selects to pick a Python interpreter', async () => {
-      stub(DvcReader.prototype, 'version').rejects('do not initialize')
-      stub(Python, 'isPythonExtensionInstalled').returns(false)
-
-      const mockShowQuickPick = stub(window, 'showQuickPick')
-      const mockUri = Uri.file(
-        resolve('file', 'picked', 'path', 'to', 'python')
-      )
-      const mockPath = mockUri.fsPath
-      stub(window, 'showOpenDialog').resolves([mockUri])
-      const pythonChanged = configurationChangeEvent(
-        ConfigKey.PYTHON_PATH,
-        disposable
-      )
-
-      const venvQuickPickActive = quickPickInitialized(mockShowQuickPick, 0)
-
-      const quickPick = window.createQuickPick<QuickPickItemWithValue<string>>()
-      const mockCreateQuickPick = stub(window, 'createQuickPick').returns(
-        quickPick
-      )
-      const pickOneOrInputActive = new Promise(resolve => {
-        disposable.track(quickPick.onDidChangeActive(() => resolve(undefined)))
-      })
-
-      const setupWorkspaceWizard = commands.executeCommand(
-        RegisteredCommands.EXTENSION_SETUP_WORKSPACE
-      )
-
-      await venvQuickPickActive
-
-      const selectVenvAndInterpreter = selectQuickPickItem(1)
-      await selectVenvAndInterpreter
-
-      await pickOneOrInputActive
-      mockCreateQuickPick.restore()
-
-      const selectToFindInterpreter = selectQuickPickItem(1)
-      await selectToFindInterpreter
-
-      await pythonChanged
-
-      await setupWorkspaceWizard
-
-      expect(workspace.getConfiguration().get(ConfigKey.PYTHON_PATH)).to.equal(
-        mockPath
-      )
-    }).timeout(WEBVIEW_TEST_TIMEOUT)
-
     it('should initialize the extension when the cli is usable', async () => {
       stub(Python, 'isPythonExtensionInstalled').returns(true)
       const selectVirtualEnvWithPython = async (path: string) => {
@@ -296,24 +238,6 @@ suite('Extension Test Suite', () => {
 
       expect(mockCreateFileSystemWatcher).not.to.be.calledWithMatch('{}')
     }).timeout(25000)
-
-    it('should send an error telemetry event when setupWorkspace fails', async () => {
-      mockDuration(0)
-
-      const mockErrorMessage = 'NOPE'
-      stub(Setup, 'runWorkspace').rejects(new Error(mockErrorMessage))
-      const mockSendTelemetryEvent = stub(Telemetry, 'sendTelemetryEvent')
-
-      await expect(
-        commands.executeCommand(RegisteredCommands.EXTENSION_SETUP_WORKSPACE)
-      ).to.be.eventually.rejectedWith(Error)
-
-      expect(mockSendTelemetryEvent).to.be.calledWithExactly(
-        `errors.${RegisteredCommands.EXTENSION_SETUP_WORKSPACE}`,
-        { error: mockErrorMessage },
-        { duration: 0 }
-      )
-    }).timeout(WEBVIEW_TEST_TIMEOUT)
   })
 
   describe('dvc.stopRunningExperiment', () => {
@@ -351,75 +275,6 @@ suite('Extension Test Suite', () => {
       const showOutputSpy = spy(OutputChannel.prototype, 'show')
       await commands.executeCommand(RegisteredCommands.EXTENSION_SHOW_OUTPUT)
       expect(showOutputSpy).to.have.been.calledOnce
-    })
-  })
-
-  describe('dvc.checkCLICompatible', () => {
-    it('should call setup', async () => {
-      const mockSetup = stub(Setup, 'run').resolves(undefined)
-      await commands.executeCommand(
-        RegisteredCommands.EXTENSION_CHECK_CLI_COMPATIBLE
-      )
-      expect(mockSetup).to.have.been.calledOnce
-    })
-
-    it('should set the dvc.cli.incompatible context value', async () => {
-      stub(Watcher, 'createFileSystemWatcher').returns(undefined)
-      stub(DvcReader.prototype, 'expShow').resolves({
-        [EXPERIMENT_WORKSPACE_ID]: { baseline: {} }
-      })
-      stub(DvcReader.prototype, 'root').resolves('.')
-      stub(DvcReader.prototype, 'dataStatus').resolves({})
-      stub(DvcReader.prototype, 'plotsDiff').resolves({})
-      stub(GitReader.prototype, 'hasChanges').resolves(false)
-      stub(GitReader.prototype, 'listUntracked').resolves(new Set())
-      stub(Config.prototype, 'getPythonBinPath').resolves(join('python'))
-
-      stub(DvcReader.prototype, 'version')
-        .onFirstCall()
-        .resolves('1.0.0')
-        .onSecondCall()
-        .resolves(MIN_CLI_VERSION)
-        .onThirdCall()
-        .rejects(new Error('NO CLI HERE'))
-
-      const executeCommandSpy = spy(commands, 'executeCommand')
-      await commands.executeCommand(
-        RegisteredCommands.EXTENSION_CHECK_CLI_COMPATIBLE
-      )
-
-      expect(
-        executeCommandSpy,
-        'should set dvc.cli.incompatible to true if the version is incompatible'
-      ).to.be.calledWithExactly('setContext', 'dvc.cli.incompatible', true)
-      executeCommandSpy.resetHistory()
-
-      await commands.executeCommand(
-        RegisteredCommands.EXTENSION_CHECK_CLI_COMPATIBLE
-      )
-
-      expect(
-        executeCommandSpy,
-        'should set dvc.cli.incompatible to false if the version is compatible'
-      ).to.be.calledWithExactly('setContext', 'dvc.cli.incompatible', false)
-
-      const mockShowWarningMessage = stub(
-        window,
-        'showWarningMessage'
-      ).resolves(undefined)
-
-      await commands.executeCommand(
-        RegisteredCommands.EXTENSION_CHECK_CLI_COMPATIBLE
-      )
-
-      expect(
-        executeCommandSpy,
-        'should unset dvc.cli.incompatible if the CLI throws an error'
-      ).to.be.calledWithExactly('setContext', 'dvc.cli.incompatible', undefined)
-      expect(
-        mockShowWarningMessage,
-        'should warn the user if the CLI throws an error'
-      ).to.be.calledOnce
     })
   })
 

--- a/extension/src/test/suite/setup/index.test.ts
+++ b/extension/src/test/suite/setup/index.test.ts
@@ -1,10 +1,16 @@
+import { resolve } from 'path'
 import { afterEach, beforeEach, describe, it, suite } from 'mocha'
 import { ensureFileSync, remove } from 'fs-extra'
 import { expect } from 'chai'
 import { SinonStub, restore, spy, stub } from 'sinon'
-import { QuickPickItem, commands, window } from 'vscode'
+import { QuickPickItem, Uri, commands, window, workspace } from 'vscode'
 import { buildSetup, buildSetupWithWatchers, TEMP_DIR } from './util'
-import { closeAllEditors, getMessageReceivedEmitter } from '../util'
+import {
+  closeAllEditors,
+  getMessageReceivedEmitter,
+  quickPickInitialized,
+  selectQuickPickItem
+} from '../util'
 import { WEBVIEW_TEST_TIMEOUT } from '../timeouts'
 import { MessageFromWebviewType } from '../../../webview/contract'
 import { Disposable } from '../../../extension'
@@ -21,6 +27,10 @@ import {
   QuickPickItemWithValue,
   QuickPickOptionsWithTitle
 } from '../../../vscode/quickPick'
+import * as Telemetry from '../../../telemetry'
+import { StopWatch } from '../../../util/time'
+import { MIN_CLI_VERSION } from '../../../cli/dvc/contract'
+import { run } from '../../../setup/runner'
 
 suite('Setup Test Suite', () => {
   const disposable = Disposable.fn()
@@ -35,7 +45,12 @@ suite('Setup Test Suite', () => {
     if (isDirectory(TEMP_DIR)) {
       remove(TEMP_DIR)
     }
-    return closeAllEditors()
+    return Promise.all([
+      workspace
+        .getConfiguration()
+        .update(Config.ConfigKey.PYTHON_PATH, undefined, false),
+      closeAllEditors()
+    ])
   })
 
   describe('Setup', () => {
@@ -365,6 +380,128 @@ suite('Setup Test Suite', () => {
         Config.ConfigKey.FOCUSED_PROJECTS,
         mockFocusedProjects
       )
+    })
+
+    it('should set dvc.pythonPath to the picked value when the user selects to pick a Python interpreter', async () => {
+      const { config, setup, mockExecuteCommand, mockVersion } =
+        buildSetup(disposable)
+
+      mockExecuteCommand.restore()
+
+      stub(config, 'isPythonExtensionInstalled').returns(false)
+
+      mockVersion.rejects('do not initialize')
+
+      const mockShowQuickPick = stub(window, 'showQuickPick')
+      const mockUri = Uri.file(
+        resolve('file', 'picked', 'path', 'to', 'python')
+      )
+      const mockPath = mockUri.fsPath
+      stub(window, 'showOpenDialog').resolves([mockUri])
+
+      const venvQuickPickActive = quickPickInitialized(mockShowQuickPick, 0)
+
+      const quickPick = window.createQuickPick<QuickPickItemWithValue<string>>()
+      const mockCreateQuickPick = stub(window, 'createQuickPick').returns(
+        quickPick
+      )
+      const pickOneOrInputActive = new Promise(resolve => {
+        disposable.track(quickPick.onDidChangeActive(() => resolve(undefined)))
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const setupWorkspaceWizard = (setup as any).setupWorkspace()
+
+      await venvQuickPickActive
+
+      const selectVenvAndInterpreter = selectQuickPickItem(1)
+
+      await selectVenvAndInterpreter
+
+      await pickOneOrInputActive
+
+      mockCreateQuickPick.restore()
+
+      const selectToFindInterpreter = selectQuickPickItem(1)
+      await selectToFindInterpreter
+
+      await setupWorkspaceWizard
+
+      expect(config.getPythonBinPath()).to.equal(mockPath)
+    }).timeout(WEBVIEW_TEST_TIMEOUT)
+
+    it('should send an error telemetry event when setupWorkspace fails', async () => {
+      stub(StopWatch.prototype, 'getElapsedTime').returns(0)
+
+      const { setup } = buildSetup(disposable)
+
+      const mockErrorMessage = 'NOPE'
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      stub(setup as any, 'runWorkspace').rejects(new Error(mockErrorMessage))
+      const mockSendTelemetryEvent = stub(Telemetry, 'sendTelemetryEvent')
+
+      await expect(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (setup as any).setupWorkspace()
+      ).to.be.eventually.rejectedWith(Error)
+
+      expect(mockSendTelemetryEvent).to.be.calledWithExactly(
+        `errors.${RegisteredCommands.EXTENSION_SETUP_WORKSPACE}`,
+        { error: mockErrorMessage },
+        { duration: 0 }
+      )
+    }).timeout(WEBVIEW_TEST_TIMEOUT)
+
+    it('should set the dvc.cli.incompatible context value', async () => {
+      const { config, mockExecuteCommand, mockRunSetup, mockVersion, setup } =
+        buildSetup(disposable, true, false, false)
+      mockRunSetup.restore()
+      stub(config, 'isPythonExtensionUsed').returns(false)
+      stub(config, 'getPythonBinPath').resolves(join('python'))
+
+      mockExecuteCommand.restore()
+      mockVersion
+        .onFirstCall()
+        .resolves('1.0.0')
+        .onSecondCall()
+        .resolves(MIN_CLI_VERSION)
+        .onThirdCall()
+        .rejects(new Error('NO CLI HERE'))
+
+      const executeCommandSpy = spy(commands, 'executeCommand')
+      await run(setup)
+
+      expect(mockVersion).to.be.calledOnce
+      expect(
+        executeCommandSpy,
+        'should set dvc.cli.incompatible to true if the version is incompatible'
+      ).to.be.calledWithExactly('setContext', 'dvc.cli.incompatible', true)
+      executeCommandSpy.resetHistory()
+
+      await run(setup)
+
+      expect(mockVersion).to.be.calledTwice
+      expect(
+        executeCommandSpy,
+        'should set dvc.cli.incompatible to false if the version is compatible'
+      ).to.be.calledWithExactly('setContext', 'dvc.cli.incompatible', false)
+
+      const mockShowWarningMessage = stub(
+        window,
+        'showWarningMessage'
+      ).resolves(undefined)
+
+      await run(setup)
+
+      expect(mockVersion).to.be.calledThrice
+      expect(
+        executeCommandSpy,
+        'should unset dvc.cli.incompatible if the CLI throws an error'
+      ).to.be.calledWithExactly('setContext', 'dvc.cli.incompatible', undefined)
+      expect(
+        mockShowWarningMessage,
+        'should warn the user if the CLI throws an error'
+      ).to.be.calledOnce
     })
   })
 })

--- a/extension/src/test/suite/setup/index.test.ts
+++ b/extension/src/test/suite/setup/index.test.ts
@@ -460,6 +460,7 @@ suite('Setup Test Suite', () => {
       stub(config, 'getPythonBinPath').resolves(join('python'))
 
       mockExecuteCommand.restore()
+      mockVersion.resetBehavior()
       mockVersion
         .onFirstCall()
         .resolves('1.0.0')

--- a/extension/src/test/suite/setup/util.ts
+++ b/extension/src/test/suite/setup/util.ts
@@ -21,6 +21,7 @@ import { WorkspaceScale } from '../../../telemetry/collect'
 import { dvcDemoPath } from '../../util'
 import { Config } from '../../../config'
 import { Resource } from '../../../resourceLocator'
+import { MIN_CLI_VERSION } from '../../../cli/dvc/contract'
 
 export const TEMP_DIR = join(dvcDemoPath, 'temp-empty-watcher-dir')
 
@@ -33,7 +34,7 @@ const buildSetupDependencies = (
   const mockEvent = mockEmitter.event
 
   const mockRoot = stub().resolves(mockDvcRoot)
-  const mockVersion = stub().resolves(undefined)
+  const mockVersion = stub().resolves(MIN_CLI_VERSION)
   const mockGetGitRepositoryRoot = stub().resolves(mockGitRoot)
 
   const mockInitializeDvc = fake()

--- a/extension/src/test/suite/setup/util.ts
+++ b/extension/src/test/suite/setup/util.ts
@@ -33,6 +33,7 @@ const buildSetupDependencies = (
   const mockEvent = mockEmitter.event
 
   const mockRoot = stub().resolves(mockDvcRoot)
+  const mockVersion = stub().resolves(undefined)
   const mockGetGitRepositoryRoot = stub().resolves(mockGitRoot)
 
   const mockInitializeDvc = fake()
@@ -48,7 +49,8 @@ const buildSetupDependencies = (
     mockDvcReader: {
       onDidCompleteProcess: mockEvent,
       onDidStartProcess: mockEvent,
-      root: mockRoot
+      root: mockRoot,
+      version: mockVersion
     } as unknown as DvcReader,
     mockDvcRunner: {
       onDidCompleteProcess: mockEvent,
@@ -78,7 +80,8 @@ const buildSetupDependencies = (
     mockRunSetupWithGlobalRecheck: stub(
       Runner,
       'runWithGlobalRecheck'
-    ).resolves(undefined)
+    ).resolves(undefined),
+    mockVersion
   }
 }
 
@@ -104,7 +107,9 @@ export const buildSetup = (
     mockGetGitRepositoryRoot,
     mockInitializeDvc,
     mockInitializeGit,
-    mockInternalCommands
+    mockInternalCommands,
+    mockRunSetup,
+    mockVersion
   } = buildSetupDependencies(disposer, mockDvcRoot, mockGitRoot)
   stub(FileSystem, 'findDvcRootPaths').resolves(
     [mockDvcRoot].filter(Boolean) as string[]
@@ -146,6 +151,8 @@ export const buildSetup = (
     mockInitializeDvc,
     mockInitializeGit,
     mockOpenExperiments,
+    mockRunSetup,
+    mockVersion,
     resourceLocator,
     setup
   }


### PR DESCRIPTION
This PR should fix a lot of the flakiness in the integration tests surrounding our `Setup` class. We will no longer be relying on calls to `DvcReader.prototype.version` to test the desired behaviour.