### PR TITLE
Extend timeout of cross-platform-test to 25 minutes

### DIFF
--- a/.github/workflows/cross-platform-test.yml
+++ b/.github/workflows/cross-platform-test.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   suite:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 25
     strategy:
       matrix:
         os: [windows-latest]


### PR DESCRIPTION
Trying to avoid the Windows test suite timing out.