### PR TITLE
Add `workflow_dispatch` event to `publish` workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,16 @@
 name: Publish Extension
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [closed]
 
 jobs:
   deploy:
     if: |
-      github.event.pull_request.merged == true &&
-      github.event.pull_request.title == 'Update version and CHANGELOG for release'
+      github.event_name == 'workflow_dispatch' || 
+      (github.event.pull_request.merged == true && 
+      github.event.pull_request.title == 'Update version and CHANGELOG for release')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
Allows us to manually start the `publish` workflow in case of an [issue with the workflow automatically running](https://iterativeai.slack.com/archives/C01RB7BTG4C/p1673880179770639). 