### PR TITLE
Add resolution for json5 library (security)

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@types/react": "18.0.26",
     "**/recursive-readdir/minimatch": "5.1.2",
     "fastify": "3.29.4",
+    "json5": "2.2.3",
     "loader-utils": "2.0.4",
     "terser": "5.16.1",
     "trim-newlines": "3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12602,22 +12602,10 @@ json-stringify-pretty-compact@^3.0.0, json-stringify-pretty-compact@~3.0.0:
   resolved "https://registry.yarnpkg.com/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz#f71ef9d82ef16483a407869556588e91b681d9ab"
   integrity sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==
 
-json5@2.2.3:
+json5@2.2.3, json5@^1.0.1, json5@^2.1.2, json5@^2.1.3, json5@^2.2.1:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
-
-json5@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
-  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
-  dependencies:
-    minimist "^1.2.0"
-
-json5@^2.1.2, json5@^2.1.3, json5@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
-  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
 jsonc-parser@3.2.0, jsonc-parser@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
Will clear 2 dependabot alerts.

`eslint-plugin-import` is the only package that is really keeping us below the required version:

```
yarn why v1.22.19
[1/4] 🤔  Why do we have the module "json5"...?
[2/4] 🚚  Initialising dependency graph...
warning Resolution field "fastify@3.29.4" is incompatible with requested version "fastify@^4.10.2"
warning Resolution field "@types/react@18.0.26" is incompatible with requested version "@types/react@^17"
warning Resolution field "@types/react@18.0.26" is incompatible with requested version "@types/react@^16.9.19"
warning Resolution field "minimatch@5.1.2" is incompatible with requested version "minimatch@3.0.4"
warning Resolution field "loader-utils@2.0.4" is incompatible with requested version "loader-utils@^1.4.0"
warning Resolution field "loader-utils@2.0.4" is incompatible with requested version "loader-utils@^1.2.3"
warning Resolution field "terser@5.16.1" is incompatible with requested version "terser@^4.1.2"
warning Resolution field "trim@1.0.1" is incompatible with requested version "trim@0.0.1"
warning Resolution field "loader-utils@2.0.4" is incompatible with requested version "loader-utils@^1.2.3"
warning Resolution field "loader-utils@2.0.4" is incompatible with requested version "loader-utils@^1.2.3"
warning Resolution field "terser@5.16.1" is incompatible with requested version "terser@^4.6.3"
warning Resolution field "trim-newlines@3.0.1" is incompatible with requested version "trim-newlines@^1.0.0"
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "json5@2.2.1"
info Has been hoisted to "json5"
info Reasons this module exists
   - "workspace-aggregator-49bbb657-1219-43c9-b36a-bb12a6bc9c51" depends on it
   - Hoisted from "_project_#@babel#core#json5"
   - Hoisted from "_project_#css-loader#loader-utils#json5"
   - Hoisted from "_project_#@jest#transform#@babel#core#json5"
   - Hoisted from "_project_#dvc-vscode-webview#@storybook#addon-essentials#@storybook#core-common#json5"
   - Hoisted from "_project_#jest#@jest#core#jest-config#@babel#core#json5"
   - Hoisted from "_project_#jest#@jest#core#jest-snapshot#@babel#core#json5"
   - Hoisted from "_project_#dvc-vscode-webview#@svgr#cli#@svgr#core#@babel#core#json5"
   - Hoisted from "_project_#dvc-vscode-webview#@svgr#cli#@svgr#plugin-jsx#@babel#core#json5"
   - Hoisted from "_project_#dvc-vscode-webview#@storybook#addon-essentials#@storybook#addon-docs#@storybook#mdx1-csf#@mdx-js#mdx#@babel#core#json5"
   - Hoisted from "_project_#dvc-vscode-webview#@storybook#addon-essentials#@storybook#addon-docs#@storybook#mdx1-csf#@mdx-js#mdx#remark-mdx#@babel#core#json5"
info Disk size without dependencies: "288KB"
info Disk size with unique dependencies: "288KB"
info Disk size with transitive dependencies: "288KB"
info Number of shared dependencies: 0
=> Found "dvc#json5@2.2.3"
info This module exists because "_project_#dvc" depends on it.
info Disk size without dependencies: "292KB"
info Disk size with unique dependencies: "292KB"
info Disk size with transitive dependencies: "292KB"
info Number of shared dependencies: 0
=> Found "tsconfig-paths#json5@1.0.1"
info This module exists because "_project_#eslint-plugin-import#tsconfig-paths" depends on it.
info Disk size without dependencies: "264KB"
info Disk size with unique dependencies: "368KB"
info Disk size with transitive dependencies: "368KB"
info Number of shared dependencies: 1
✨  Done in 0.47s.
```