### PR TITLE
Update Windows yarn network timeout to 5 minutes (downloading packages on slow disk)

### DIFF
--- a/.github/workflows/cross-platform-test.yml
+++ b/.github/workflows/cross-platform-test.yml
@@ -41,6 +41,7 @@ jobs:
           restore-keys: |
             turbo-${{ runner.os }}-cross-platform-${{ github.job }}-${{ github.ref_name }}-
 
+      - run: yarn config set network-timeout 300000
       - run: yarn install
 
       - run: yarn run test:jest


### PR DESCRIPTION
Another attempt to shore up the Windows part of our CI.

From searching for the error shown here: https://github.com/iterative/vscode-dvc/actions/runs/3956590225/jobs/6775974156 & https://github.com/iterative/vscode-dvc/actions/runs/3943616876/jobs/6748649883

Advice provided here: https://github.com/yarnpkg/yarn/issues/8242