### PR TITLE
Fix plots tooltip being hidden in zoom in mode

### DIFF
--- a/webview/src/shared/components/modal/styles.module.scss
+++ b/webview/src/shared/components/modal/styles.module.scss
@@ -12,7 +12,6 @@
   justify-content: center;
   z-index: 500;
   border: none;
-  z-index: 1001;
 }
 
 .modal {


### PR DESCRIPTION
Making tooltip visible again when it's zoomed:


https://user-images.githubusercontent.com/3659196/213881503-9d1bcb82-34df-41a8-b650-df475483d9d3.mov

