### PR TITLE
Add stop experiments queue processing immediately command

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -347,6 +347,11 @@
         "category": "DVC"
       },
       {
+        "title": "%command.stopExperimentsQueueAndRunning%",
+        "command": "dvc.stopExperimentsQueueAndRunning",
+        "category": "DVC"
+      },
+      {
         "title": "%command.stopQueuedExperiments%",
         "command": "dvc.stopQueuedExperiments",
         "category": "DVC"
@@ -789,6 +794,10 @@
         },
         {
           "command": "dvc.stopExperimentsQueue",
+          "when": "dvc.commands.available && dvc.project.available"
+        },
+        {
+          "command": "dvc.stopExperimentsQueueAndRunning",
           "when": "dvc.commands.available && dvc.project.available"
         },
         {
@@ -1282,6 +1291,11 @@
           "command": "dvc.stopExperimentsQueue",
           "when": "view == dvc.views.experimentsTree",
           "group": "3_queue@3"
+        },
+        {
+          "command": "dvc.stopExperimentsQueueAndRunning",
+          "when": "view == dvc.views.experimentsTree",
+          "group": "3_queue@4"
         },
         {
           "command": "dvc.stopQueuedExperiments",

--- a/extension/src/cli/dvc/constants.ts
+++ b/extension/src/cli/dvc/constants.ts
@@ -44,6 +44,7 @@ export enum Flag {
   GRANULAR = '--granular',
   JOBS = '-j',
   JSON = '--json',
+  KILL = '--kill',
   NUM_COMMIT = '-n',
   OUTPUT_PATH = '-o',
   SUBDIRECTORY = '--subdir',

--- a/extension/src/cli/dvc/executor.ts
+++ b/extension/src/cli/dvc/executor.ts
@@ -149,8 +149,13 @@ export class DvcExecutor extends DvcCli {
     )
   }
 
-  public queueStop(cwd: string) {
-    return this.executeDvcProcess(cwd, Command.QUEUE, QueueSubCommand.STOP)
+  public queueStop(cwd: string, ...args: Args) {
+    return this.executeDvcProcess(
+      cwd,
+      Command.QUEUE,
+      QueueSubCommand.STOP,
+      ...args
+    )
   }
 
   public remove(cwd: string, ...args: Args) {

--- a/extension/src/commands/external.ts
+++ b/extension/src/commands/external.ts
@@ -14,6 +14,7 @@ export enum RegisteredCliCommands {
   QUEUE_KILL = 'dvc.stopQueuedExperiments',
   QUEUE_START = 'dvc.startExperimentsQueue',
   QUEUE_STOP = 'dvc.stopExperimentsQueue',
+  QUEUE_STOP_KILL = 'dvc.stopExperimentsQueueAndRunning',
 
   EXPERIMENT_VIEW_APPLY = 'dvc.views.experiments.applyExperiment',
   EXPERIMENT_VIEW_BRANCH = 'dvc.views.experiments.branchExperiment',

--- a/extension/src/experiments/commands/register.ts
+++ b/extension/src/experiments/commands/register.ts
@@ -12,6 +12,7 @@ import {
 } from '../../commands/external'
 import { Title } from '../../vscode/title'
 import { Context, getDvcRootFromContext } from '../../vscode/context'
+import { Flag } from '../../cli/dvc/constants'
 
 type ExperimentDetails = { dvcRoot: string; id: string }
 
@@ -30,6 +31,11 @@ const registerExperimentCwdCommands = (
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.QUEUE_STOP,
     () => experiments.getCwdThenReport(AvailableCommands.QUEUE_STOP)
+  )
+
+  internalCommands.registerExternalCliCommand(
+    RegisteredCliCommands.QUEUE_STOP_KILL,
+    () => experiments.getCwdThenReport(AvailableCommands.QUEUE_STOP, Flag.KILL)
   )
 
   internalCommands.registerExternalCliCommand(

--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -228,13 +228,13 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
     this.updatesPaused.fire(false)
   }
 
-  public async getCwdThenReport(commandId: CommandId) {
+  public async getCwdThenReport(commandId: CommandId, ...args: Args) {
     const cwd = await this.getFocusedOrOnlyOrPickProject()
     if (!cwd) {
       return
     }
 
-    const stdout = this.internalCommands.executeCommand(commandId, cwd)
+    const stdout = this.internalCommands.executeCommand(commandId, cwd, ...args)
     return Toast.showOutput(stdout)
   }
 

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -157,6 +157,7 @@ export interface IEventNamePropertyMapping {
   [EventName.QUEUE_KILL]: undefined
   [EventName.QUEUE_START]: undefined
   [EventName.QUEUE_STOP]: undefined
+  [EventName.QUEUE_STOP_KILL]: undefined
 
   [EventName.EXPERIMENT_VIEW_QUEUE]: undefined
   [EventName.EXPERIMENT_VIEW_RESUME]: undefined

--- a/extension/src/test/suite/experiments/workspace.test.ts
+++ b/extension/src/test/suite/experiments/workspace.test.ts
@@ -513,7 +513,7 @@ suite('Workspace Experiments Test Suite', () => {
     })
   })
 
-  describe('dvc.stopExperimentsQueue', () => {
+  describe('stop processing queued experiments', () => {
     it('should be able to stop the experiments queue', async () => {
       const mockQueueStop = stub(DvcExecutor.prototype, 'queueStop').resolves(
         undefined
@@ -525,6 +525,16 @@ suite('Workspace Experiments Test Suite', () => {
 
       expect(mockQueueStop).to.be.calledOnce
       expect(mockQueueStop).to.be.calledWithExactly(dvcDemoPath)
+
+      mockQueueStop.resetHistory()
+
+      await commands.executeCommand(RegisteredCliCommands.QUEUE_STOP_KILL)
+
+      expect(mockQueueStop).to.be.calledOnce
+      expect(
+        mockQueueStop,
+        'should be able to stop the experiments queue and kill currently running tasks'
+      ).to.be.calledWithExactly(dvcDemoPath, '--kill')
     })
   })
 


### PR DESCRIPTION
# 2/? `main` <- #3154 <- this

This PR implements the command alluded to [here](https://github.com/iterative/vscode-dvc/pull/3154#discussion_r1086148224). This command not only stops all experiments queue workers but kills currently executing queued experiments. I've added this command so that it can be wired into the stop button.

Docs for the stop command are [here](https://dvc.org/doc/command-reference/queue/stop).

### Demo


https://user-images.githubusercontent.com/37993418/214470456-5f966ea2-dfc6-400e-8729-237c5ef442a9.mov

