### PR TITLE
Fix Experiments table multi-select context menu

### DIFF
--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -48,6 +48,7 @@ import {
   setTableData
 } from '../../test/experimentsTable'
 import { clearSelection, createWindowTextSelection } from '../../test/selection'
+import { sendMessage } from '../../shared/vscode'
 
 jest.mock('../../shared/api')
 jest.mock('../../util/styles')
@@ -950,6 +951,19 @@ describe('App', () => {
       const menuitems = screen.getAllByRole('menuitem')
       const itemLabels = menuitems.map(item => item.textContent)
       expect(itemLabels).toContain('Remove Selected Rows')
+
+      const removeOption = menuitems.find(item =>
+        item.textContent?.includes('Remove Selected Rows')
+      )
+
+      expect(removeOption).toBeDefined()
+
+      removeOption && fireEvent.click(removeOption)
+
+      expect(sendMessage).toHaveBeenCalledWith({
+        payload: ['exp-e7a67', 'test-branch'],
+        type: MessageFromWebviewType.REMOVE_EXPERIMENT
+      })
     })
 
     it('should always present the Plots options if multiple rows are selected', () => {
@@ -966,6 +980,19 @@ describe('App', () => {
       const itemLabels = menuitems.map(item => item.textContent)
       expect(itemLabels).toContain('Plot and Show')
       expect(itemLabels).toContain('Plot')
+
+      const plotOption = menuitems.find(item =>
+        item.textContent?.includes('Plot and Show')
+      )
+
+      expect(plotOption).toBeDefined()
+
+      plotOption && fireEvent.click(plotOption)
+
+      expect(sendMessage).toHaveBeenCalledWith({
+        payload: ['exp-e7a67', 'test-branch'],
+        type: MessageFromWebviewType.SET_EXPERIMENTS_AND_OPEN_PLOTS
+      })
     })
 
     it('should allow batch selection of rows by shift-clicking a range of them', () => {

--- a/webview/src/experiments/components/table/RowContextMenu.tsx
+++ b/webview/src/experiments/components/table/RowContextMenu.tsx
@@ -50,11 +50,11 @@ const getMultiSelectMenuOptions = (
     }) => starred
   )
 
-  const selectedIds = selectedRowsList.map(value => value.row.id)
+  const selectedIds = selectedRowsList.map(value => value.row.original.id)
 
   const removableRowIds = selectedRowsList
     .filter(value => value.row.depth === 1)
-    .map(value => value.row.id)
+    .map(value => value.row.original.id)
 
   const hideRemoveOption =
     removableRowIds.length !== selectedRowsList.length || hasRunningExperiment


### PR DESCRIPTION
Experiments table multi-select context menu actions were broken by the react table upgrade. The row's new ID was being used instead of the row's original ID. Understandable mistake as the behaviour was not tested.

### Before

https://user-images.githubusercontent.com/37993418/214477748-51c5e58e-8add-4919-ab03-83e5df0bf7fc.mov


### After


https://user-images.githubusercontent.com/37993418/214477820-4a2be603-94ca-496d-bd41-a064e19c9551.mov

