### PR TITLE
Replace branch terminology with commit for Experiments internals

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1135,22 +1135,22 @@
         {
           "command": "dvc.views.experiments.runExperiment",
           "group": "2_modify@1",
-          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(workspace|branch|experiment|queued)$/ && !dvc.experiment.running && !dvc.experiment.checkpoints"
+          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(workspace|commit|experiment|queued)$/ && !dvc.experiment.running && !dvc.experiment.checkpoints"
         },
         {
           "command": "dvc.views.experiments.resetAndRunCheckpointExperiment",
           "group": "2_modify@1",
-          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(workspace|branch|experiment|queued)$/ && !dvc.experiment.running && dvc.experiment.checkpoints"
+          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(workspace|commit|experiment|queued)$/ && !dvc.experiment.running && dvc.experiment.checkpoints"
         },
         {
           "command": "dvc.views.experiments.resumeCheckpointExperiment",
           "group": "2_modify@2",
-          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(workspace|branch|experiment|queued)$/ && !dvc.experiment.running && dvc.experiment.checkpoints"
+          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(workspace|commit|experiment|queued)$/ && !dvc.experiment.running && dvc.experiment.checkpoints"
         },
         {
           "command": "dvc.views.experiments.queueExperiment",
           "group": "2_modify@3",
-          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(workspace|branch|experiment|queued)$/ && !dvc.experiment.running"
+          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(workspace|commit|experiment|queued)$/ && !dvc.experiment.running"
         }
       ],
       "view/title": [

--- a/extension/src/cli/dvc/contract.ts
+++ b/extension/src/cli/dvc/contract.ts
@@ -84,13 +84,13 @@ export interface ExperimentFieldsOrError {
   error?: ErrorContents
 }
 
-export interface ExperimentsBranchOutput {
+export interface ExperimentsCommitOutput {
   [sha: string]: ExperimentFieldsOrError
   baseline: ExperimentFieldsOrError
 }
 
 export interface ExperimentsOutput {
-  [name: string]: ExperimentsBranchOutput
+  [name: string]: ExperimentsCommitOutput
   [EXPERIMENT_WORKSPACE_ID]: {
     baseline: ExperimentFieldsOrError
   }

--- a/extension/src/experiments/columns/collect/index.ts
+++ b/extension/src/experiments/columns/collect/index.ts
@@ -9,7 +9,7 @@ import { Column } from '../../webview/contract'
 import {
   ExperimentFields,
   ExperimentFieldsOrError,
-  ExperimentsBranchOutput,
+  ExperimentsCommitOutput,
   ExperimentsOutput
 } from '../../../cli/dvc/contract'
 import { standardizePath } from '../../../fileSystem/path'
@@ -26,11 +26,11 @@ const collectFromExperiment = (
   }
 }
 
-const collectFromBranch = (
+const collectFromCommit = (
   acc: ColumnAccumulator,
-  branch: ExperimentsBranchOutput
+  commit: ExperimentsCommitOutput
 ) => {
-  const { baseline, ...rest } = branch
+  const { baseline, ...rest } = commit
   collectFromExperiment(acc, baseline)
   for (const experiment of Object.values(rest)) {
     collectFromExperiment(acc, experiment)
@@ -43,9 +43,9 @@ export const collectColumns = (data: ExperimentsOutput): Column[] => {
   acc.timestamp = timestampColumn
 
   const { workspace, ...rest } = data
-  collectFromBranch(acc, workspace)
-  for (const branch of Object.values(rest)) {
-    collectFromBranch(acc, branch)
+  collectFromCommit(acc, workspace)
+  for (const commit of Object.values(rest)) {
+    collectFromCommit(acc, commit)
   }
   return Object.values(acc)
 }

--- a/extension/src/experiments/columns/extract.ts
+++ b/extension/src/experiments/columns/extract.ts
@@ -47,7 +47,7 @@ const extractMetricsOrParams = (
 
 const extractDeps = (
   columns?: Deps,
-  branch?: Experiment
+  commit?: Experiment
 ): DepColumns | undefined => {
   if (!columns) {
     return
@@ -59,7 +59,7 @@ const extractDeps = (
     const value = shortenForLabel<string | null>(hash)
     if (value) {
       acc[path] = {
-        changes: !!branch && branch?.deps?.[path]?.value !== value,
+        changes: !!commit && commit?.deps?.[path]?.value !== value,
         value
       }
     }
@@ -78,7 +78,7 @@ type Columns = {
 
 export const extractColumns = (
   experiment: ExperimentFields,
-  branch?: Experiment
+  commit?: Experiment
 ): Columns => {
   const metricsData = extractMetricsOrParams(experiment.metrics)
   const paramsData = extractMetricsOrParams(experiment.params)
@@ -90,7 +90,7 @@ export const extractColumns = (
 
   const columns: Columns = {
     Created: experiment?.timestamp,
-    deps: extractDeps(experiment.deps, branch),
+    deps: extractDeps(experiment.deps, commit),
     metrics: metricsData?.columns,
     params: paramsData?.columns
   }

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -385,9 +385,9 @@ export class Experiments extends BaseRepository<TableData> {
     }
   }
 
-  public pickCurrentExperiment() {
+  public pickExperiment() {
     return pickExperiment(
-      this.experiments.getExperimentsWithoutQueued(),
+      this.experiments.getExperiments(),
       this.getFirstThreeColumnOrder()
     )
   }
@@ -402,7 +402,7 @@ export class Experiments extends BaseRepository<TableData> {
 
   public pickExperimentsToRemove() {
     return pickExperiments(
-      this.experiments.getExperimentsWithQueued(),
+      this.experiments.getExperimentsAndQueued(),
       this.getFirstThreeColumnOrder(),
       Title.SELECT_EXPERIMENTS_REMOVE
     )
@@ -423,20 +423,20 @@ export class Experiments extends BaseRepository<TableData> {
     return pickAndModifyParams(params)
   }
 
-  public getExperiments() {
+  public getWorkspaceAndCommits() {
     if (!this.columns.hasNonDefaultColumns()) {
       return []
     }
 
-    return this.experiments.getExperiments()
+    return this.experiments.getWorkspaceAndCommits()
   }
 
   public getCheckpoints(id: string) {
     return this.experiments.getCheckpointsWithType(id)
   }
 
-  public getBranchExperiments(branch: Experiment) {
-    return this.experiments.getExperimentsByBranchForTree(branch)
+  public getCommitExperiments(commit: Experiment) {
+    return this.experiments.getExperimentsByCommitForTree(commit)
   }
 
   public sendInitialWebviewData() {
@@ -455,8 +455,8 @@ export class Experiments extends BaseRepository<TableData> {
     this.experiments.setRevisionCollected(revisions)
   }
 
-  public getBranchRevisions() {
-    return this.experiments.getBranchRevisions()
+  public getCommitRevisions() {
+    return this.experiments.getCommitRevisions()
   }
 
   public getFinishedExperiments() {
@@ -615,7 +615,7 @@ export class Experiments extends BaseRepository<TableData> {
     }
 
     const experiment = await pickExperiment(
-      this.experiments.getAllExperiments(),
+      this.experiments.getRecordsWithoutCheckpoints(),
       this.getFirstThreeColumnOrder(),
       Title.SELECT_BASE_EXPERIMENT
     )

--- a/extension/src/experiments/model/accumulator.ts
+++ b/extension/src/experiments/model/accumulator.ts
@@ -3,9 +3,9 @@ import { Experiment, isRunning, RunningExperiment } from '../webview/contract'
 
 export class ExperimentsAccumulator {
   public workspace = {} as Experiment
-  public branches: Experiment[] = []
+  public commits: Experiment[] = []
   public checkpointsByTip: Map<string, Experiment[]> = new Map()
-  public experimentsByBranch: Map<string, Experiment[]> = new Map()
+  public experimentsByCommit: Map<string, Experiment[]> = new Map()
   public runningExperiments: RunningExperiment[]
 
   constructor(workspace: Experiment | undefined) {

--- a/extension/src/experiments/model/collect.test.ts
+++ b/extension/src/experiments/model/collect.test.ts
@@ -8,8 +8,8 @@ import {
 import { COMMITS_SEPARATOR } from '../../cli/git/constants'
 
 describe('collectExperiments', () => {
-  it('should return an empty array if no branches are present', () => {
-    const { branches } = collectExperiments(
+  it('should return an empty array if no commits are present', () => {
+    const { commits } = collectExperiments(
       {
         [EXPERIMENT_WORKSPACE_ID]: {
           baseline: {}
@@ -18,14 +18,14 @@ describe('collectExperiments', () => {
       false,
       ''
     )
-    expect(branches).toStrictEqual([])
+    expect(commits).toStrictEqual([])
   })
 
-  const repoWithTwoBranches = {
+  const repoWithTwoCommits = {
     [EXPERIMENT_WORKSPACE_ID]: {
       baseline: {}
     },
-    branchA: {
+    commitA: {
       baseline: { data: { name: 'branchA' } },
       otherExp1: { data: {} },
       otherExp2: {
@@ -35,51 +35,51 @@ describe('collectExperiments', () => {
         data: { checkpoint_tip: 'otherExp2' }
       }
     },
-    branchB: {
+    commitB: {
       baseline: { data: { name: 'branchB' } }
     }
   }
 
   it('should define a workspace', () => {
-    const { workspace } = collectExperiments(repoWithTwoBranches, false, '')
+    const { workspace } = collectExperiments(repoWithTwoCommits, false, '')
 
     expect(workspace).toBeDefined()
   })
 
   it('should find two branches from a repo with two branches', () => {
-    const { branches } = collectExperiments(repoWithTwoBranches, false, '')
+    const { commits } = collectExperiments(repoWithTwoCommits, false, '')
 
-    expect(branches.length).toStrictEqual(2)
+    expect(commits.length).toStrictEqual(2)
   })
 
-  it('should list branches in the same order as they are collected', () => {
-    const { branches } = collectExperiments(repoWithTwoBranches, false, '')
-    const [branchA, branchB] = branches
+  it('should list commits in the same order as they are collected', () => {
+    const { commits } = collectExperiments(repoWithTwoCommits, false, '')
+    const [commitA, commitB] = commits
 
-    expect(branchA.id).toStrictEqual('branchA')
-    expect(branchB.id).toStrictEqual('branchB')
+    expect(commitA.id).toStrictEqual('branchA')
+    expect(commitB.id).toStrictEqual('branchB')
   })
 
-  it('should find two experiments on branchA', () => {
-    const { experimentsByBranch } = collectExperiments(
-      repoWithTwoBranches,
+  it('should find two experiments on commitA', () => {
+    const { experimentsByCommit } = collectExperiments(
+      repoWithTwoCommits,
       false,
       ''
     )
-    expect(experimentsByBranch.get('branchA')?.length).toStrictEqual(2)
+    expect(experimentsByCommit.get('branchA')?.length).toStrictEqual(2)
   })
 
   it('should find no experiments on branchB', () => {
-    const { experimentsByBranch } = collectExperiments(
-      repoWithTwoBranches,
+    const { experimentsByCommit } = collectExperiments(
+      repoWithTwoCommits,
       false,
       ''
     )
-    expect(experimentsByBranch.get('branchB')).toBeUndefined()
+    expect(experimentsByCommit.get('branchB')).toBeUndefined()
   })
 
-  it('should add git commit data to branches if git log output is provided', () => {
-    const { branches } = collectExperiments(
+  it('should add data from git to commits if git log output is provided', () => {
+    const { commits } = collectExperiments(
       {
         [EXPERIMENT_WORKSPACE_ID]: {
           baseline: {}
@@ -94,7 +94,7 @@ describe('collectExperiments', () => {
       false,
       `a123\nJohn Smith\n3 days ago\nrefNames:tag: v.1.1\nmessage:add new feature${COMMITS_SEPARATOR}b123\nrenovate[bot]\n5 weeks ago\nrefNames:\nmessage:update various dependencies\n* update dvc\n* update dvclive`
     )
-    const [branch1, branch2] = branches
+    const [branch1, branch2] = commits
     expect(branch1.displayNameOrParent).toStrictEqual('add new feature')
     expect(branch2.displayNameOrParent).toStrictEqual(
       'update various dependencies ...'
@@ -133,12 +133,12 @@ describe('collectExperiments', () => {
   }
 
   it('should only list the tip as a top-level experiment', () => {
-    const { experimentsByBranch } = collectExperiments(
+    const { experimentsByCommit } = collectExperiments(
       repoWithNestedCheckpoints,
       false,
       ''
     )
-    expect(experimentsByBranch.size).toStrictEqual(1)
+    expect(experimentsByCommit.size).toStrictEqual(1)
   })
 
   it('should find three checkpoints on the tip', () => {
@@ -224,8 +224,8 @@ describe('collectExperiments', () => {
     }
     const acc = collectExperiments(repoWithNestedCheckpoints, false, '')
 
-    const { experimentsByBranch, checkpointsByTip } = acc
-    const [experiment] = experimentsByBranch.get('branchA') || []
+    const { experimentsByCommit, checkpointsByTip } = acc
+    const [experiment] = experimentsByCommit.get('branchA') || []
 
     expect(experiment.id).toStrictEqual(checkpointTipWithoutAName)
     expect(

--- a/extension/src/experiments/model/index.test.ts
+++ b/extension/src/experiments/model/index.test.ts
@@ -37,7 +37,7 @@ describe('ExperimentsModel', () => {
 
   const [
     workspaceColor,
-    branchColor,
+    commitColor,
     expColor,
     fourthColor,
     fifthColor,
@@ -212,7 +212,7 @@ describe('ExperimentsModel', () => {
       ''
     )
 
-    const experiments = model.getAllExperiments()
+    const experiments = model.getRecordsWithoutCheckpoints()
 
     const changed: string[] = []
     for (const { deps, sha } of experiments) {
@@ -230,7 +230,7 @@ describe('ExperimentsModel', () => {
   it('should handle deps have all null properties (never been committed)', () => {
     const model = new ExperimentsModel('', buildMockMemento())
     model.transformAndSet(uncommittedDepsFixture, false, '')
-    const [workspace] = model.getExperiments()
+    const [workspace] = model.getWorkspaceAndCommits()
     expect(workspace.deps).toStrictEqual({})
   })
 
@@ -363,7 +363,7 @@ describe('ExperimentsModel', () => {
         label: EXPERIMENT_WORKSPACE_ID
       }),
       expect.objectContaining({
-        displayColor: branchColor,
+        displayColor: commitColor,
         id: 'testBranch',
         label: 'testBranch'
       }),
@@ -429,12 +429,12 @@ describe('ExperimentsModel', () => {
     expect((experimentsModel as any).useFiltersForSelection).toBe(false)
   })
 
-  it('should fetch branch params', () => {
+  it('should fetch commit params', () => {
     const model = new ExperimentsModel('', buildMockMemento())
     model.transformAndSet(outputFixture, false, '')
 
-    const branchParams = model.getExperimentParams('main')
-    expect(definedAndNonEmpty(branchParams)).toBe(true)
+    const commitParams = model.getExperimentParams('main')
+    expect(definedAndNonEmpty(commitParams)).toBe(true)
   })
 
   it('should fetch workspace params', () => {

--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -63,7 +63,7 @@ export type ExperimentWithCheckpoints = Experiment & {
 
 export enum ExperimentType {
   WORKSPACE = 'workspace',
-  BRANCH = 'branch',
+  COMMIT = 'commit',
   EXPERIMENT = 'experiment',
   CHECKPOINT = 'checkpoint',
   QUEUED = 'queued'
@@ -71,8 +71,8 @@ export enum ExperimentType {
 
 export class ExperimentsModel extends ModelWithPersistence {
   private workspace = {} as Experiment
-  private branches: Experiment[] = []
-  private experimentsByBranch: Map<string, Experiment[]> = new Map()
+  private commits: Experiment[] = []
+  private experimentsByCommit: Map<string, Experiment[]> = new Map()
   private checkpointsByTip: Map<string, Experiment[]> = new Map()
   private availableColors: Color[]
   private coloredStatus: ColoredStatus
@@ -124,15 +124,15 @@ export class ExperimentsModel extends ModelWithPersistence {
   ) {
     const {
       workspace,
-      branches,
-      experimentsByBranch,
+      commits,
+      experimentsByCommit,
       checkpointsByTip,
       runningExperiments
     } = collectExperiments(data, dvcLiveOnly, commitsOutput)
 
     this.workspace = workspace
-    this.branches = branches
-    this.experimentsByBranch = experimentsByBranch
+    this.commits = commits
+    this.experimentsByCommit = experimentsByCommit
     this.checkpointsByTip = checkpointsByTip
 
     this.setColoredStatus(runningExperiments)
@@ -148,7 +148,7 @@ export class ExperimentsModel extends ModelWithPersistence {
   public toggleStatus(id: string) {
     if (
       isQueued(
-        this.getExperimentsWithQueued().find(
+        this.getExperimentsAndQueued().find(
           ({ id: queuedId }) => queuedId === id
         )?.status
       )
@@ -185,7 +185,7 @@ export class ExperimentsModel extends ModelWithPersistence {
   }
 
   public setRevisionCollected(revisions: string[]) {
-    for (const { id } of this.getExperimentsWithQueued().filter(({ label }) =>
+    for (const { id } of this.getExperimentsAndQueued().filter(({ label }) =>
       revisions.includes(label)
     )) {
       if (this.finishedRunning[id]) {
@@ -264,8 +264,8 @@ export class ExperimentsModel extends ModelWithPersistence {
     return result
   }
 
-  public getBranchRevisions() {
-    return this.branches.map(({ id, sha }) => ({ id, sha }))
+  public getCommitRevisions() {
+    return this.commits.map(({ id, sha }) => ({ id, sha }))
   }
 
   public getRevisions() {
@@ -273,7 +273,10 @@ export class ExperimentsModel extends ModelWithPersistence {
   }
 
   public getMutableRevisions(hasCheckpoints: boolean) {
-    return collectMutableRevisions(this.getAllExperiments(), hasCheckpoints)
+    return collectMutableRevisions(
+      this.getRecordsWithoutCheckpoints(),
+      hasCheckpoints
+    )
   }
 
   public getSelectedRevisions() {
@@ -281,7 +284,7 @@ export class ExperimentsModel extends ModelWithPersistence {
   }
 
   public getSelectedExperiments() {
-    return this.getSelectedFromList(() => this.getExperimentsWithQueued())
+    return this.getSelectedFromList(() => this.getExperimentsAndQueued())
   }
 
   public setSelected(selectedExperiments: Experiment[]) {
@@ -309,7 +312,7 @@ export class ExperimentsModel extends ModelWithPersistence {
 
   public getUnfilteredExperiments(filters = this.getFilters()) {
     const unfilteredExperiments = this.getSubRows(
-      this.getAllExperiments(),
+      this.getRecordsWithoutCheckpoints(),
       filters
     )
 
@@ -330,25 +333,25 @@ export class ExperimentsModel extends ModelWithPersistence {
     )
   }
 
-  public getExperiments(): ExperimentAugmented[] {
+  public getWorkspaceAndCommits(): ExperimentAugmented[] {
     return [
       {
         ...this.addDetails(this.workspace),
         hasChildren: false,
         type: ExperimentType.WORKSPACE
       },
-      ...this.branches.map(branch => {
+      ...this.commits.map(commit => {
         return {
-          ...this.addDetails(branch),
-          hasChildren: !!this.experimentsByBranch.get(branch.label),
-          type: ExperimentType.BRANCH
+          ...this.addDetails(commit),
+          hasChildren: !!this.experimentsByCommit.get(commit.label),
+          type: ExperimentType.COMMIT
         }
       })
     ]
   }
 
-  public getAllExperiments() {
-    return [...this.getExperiments(), ...this.getExperimentsWithQueued()]
+  public getRecordsWithoutCheckpoints() {
+    return [...this.getWorkspaceAndCommits(), ...this.getExperimentsAndQueued()]
   }
 
   public getErrors() {
@@ -361,7 +364,7 @@ export class ExperimentsModel extends ModelWithPersistence {
 
   public getExperimentsWithCheckpoints(): ExperimentWithCheckpoints[] {
     const experimentsWithCheckpoints: ExperimentWithCheckpoints[] = []
-    for (const experiment of this.getAllExperiments()) {
+    for (const experiment of this.getRecordsWithoutCheckpoints()) {
       const { id, status } = experiment
       if (isQueued(status)) {
         continue
@@ -378,27 +381,27 @@ export class ExperimentsModel extends ModelWithPersistence {
   }
 
   public getExperimentParams(id: string) {
-    const params = this.getAllExperiments().find(
+    const params = this.getRecordsWithoutCheckpoints().find(
       experiment => experiment.id === id
     )?.params
 
     return collectFlatExperimentParams(params)
   }
 
-  public getExperimentsWithoutQueued() {
-    return this.getExperimentsWithQueued().filter(({ status }) => {
+  public getExperiments() {
+    return this.getExperimentsAndQueued().filter(({ status }) => {
       return !isQueued(status)
     })
   }
 
-  public getExperimentsWithQueued() {
-    return flattenMapValues(this.experimentsByBranch).map(experiment =>
+  public getExperimentsAndQueued() {
+    return flattenMapValues(this.experimentsByCommit).map(experiment =>
       this.addDetails(experiment)
     )
   }
 
   public getRunningQueueTasks() {
-    return this.getExperimentsWithQueued().filter(
+    return this.getExperimentsAndQueued().filter(
       ({ status, executor }) => isRunning(status) && executor === 'dvc-task'
     )
   }
@@ -415,16 +418,16 @@ export class ExperimentsModel extends ModelWithPersistence {
   public getRowData() {
     return [
       this.addDetails(this.workspace),
-      ...this.branches.map(branch => {
-        const experiments = this.getExperimentsByBranch(branch)
-        const branchWithSelectedAndStarred = this.addDetails(branch)
+      ...this.commits.map(commit => {
+        const experiments = this.getExperimentsByCommit(commit)
+        const commitWithSelectedAndStarred = this.addDetails(commit)
 
         if (!definedAndNonEmpty(experiments)) {
-          return branchWithSelectedAndStarred
+          return commitWithSelectedAndStarred
         }
 
         return {
-          ...branchWithSelectedAndStarred,
+          ...commitWithSelectedAndStarred,
           subRows: this.getSubRows(experiments)
         }
       })
@@ -442,8 +445,8 @@ export class ExperimentsModel extends ModelWithPersistence {
   public getExperimentCount() {
     return sum([
       this.getFlattenedCheckpoints().length,
-      this.getExperimentsWithQueued().length,
-      this.branches.length,
+      this.getExperimentsAndQueued().length,
+      this.commits.length,
       1
     ])
   }
@@ -456,14 +459,14 @@ export class ExperimentsModel extends ModelWithPersistence {
   public getCombinedList() {
     return [
       this.workspace,
-      ...this.branches,
-      ...this.getExperimentsWithQueued(),
+      ...this.commits,
+      ...this.getExperimentsAndQueued(),
       ...this.getFlattenedCheckpoints()
     ]
   }
 
-  public getExperimentsByBranchForTree(branch: Experiment) {
-    return this.getExperimentsByBranch(branch)?.map(experiment => ({
+  public getExperimentsByCommitForTree(commit: Experiment) {
+    return this.getExperimentsByCommit(commit)?.map(experiment => ({
       ...experiment,
       hasChildren: definedAndNonEmpty(this.checkpointsByTip.get(experiment.id)),
       type: isQueued(experiment.status)
@@ -509,7 +512,7 @@ export class ExperimentsModel extends ModelWithPersistence {
   private getFilteredExperiments() {
     const acc: ExperimentWithType[] = []
 
-    for (const experiment of this.getExperimentsWithoutQueued()) {
+    for (const experiment of this.getExperiments()) {
       const checkpoints = this.getCheckpointsWithType(experiment.id) || []
       collectFiltered(acc, this.getFilters(), experiment, checkpoints)
     }
@@ -535,9 +538,9 @@ export class ExperimentsModel extends ModelWithPersistence {
       ?.map(checkpoint => this.addDetails(checkpoint))
   }
 
-  private getExperimentsByBranch(branch: Experiment) {
-    const experiments = this.experimentsByBranch
-      .get(branch.label)
+  private getExperimentsByCommit(commit: Experiment) {
+    const experiments = this.experimentsByCommit
+      .get(commit.label)
       ?.map(experiment => this.addDetails(experiment))
     if (!experiments) {
       return
@@ -559,9 +562,9 @@ export class ExperimentsModel extends ModelWithPersistence {
       return
     }
     const { coloredStatus, availableColors } = collectColoredStatus(
-      this.getExperiments(),
+      this.getWorkspaceAndCommits(),
       this.checkpointsByTip,
-      this.experimentsByBranch,
+      this.experimentsByCommit,
       this.coloredStatus,
       this.availableColors,
       this.startedRunning,
@@ -582,7 +585,7 @@ export class ExperimentsModel extends ModelWithPersistence {
 
     this.finishedRunning = collectFinishedRunningExperiments(
       { ...this.finishedRunning },
-      this.getExperimentsWithQueued(),
+      this.getExperimentsAndQueued(),
       this.running,
       stillRunning,
       this.coloredStatus

--- a/extension/src/experiments/model/quickPick.test.ts
+++ b/extension/src/experiments/model/quickPick.test.ts
@@ -198,7 +198,7 @@ describe('pickExperimentsToPlot', () => {
     }
 
     const mockedWorkspace = { label: EXPERIMENT_WORKSPACE_ID, selected: false }
-    const mockedBranch = {
+    const mockedCommit = {
       commit: {
         author: 'John Smith',
         date: '3 days ago',
@@ -230,7 +230,7 @@ describe('pickExperimentsToPlot', () => {
     const picked = await pickExperimentsToPlot(
       [
         mockedWorkspace,
-        mockedBranch,
+        mockedCommit,
         {
           ...mockedExp1,
           checkpoints: [mockedExp1Checkpoint1, mockedExp1Checkpoint2]
@@ -258,8 +258,8 @@ describe('pickExperimentsToPlot', () => {
       [
         getExpectedItem(mockedWorkspace),
         {
-          ...getExpectedItem(mockedBranch),
-          description: `$(git-commit)${mockedBranch.displayNameOrParent}`
+          ...getExpectedItem(mockedCommit),
+          description: `$(git-commit)${mockedCommit.displayNameOrParent}`
         },
         {
           kind: QuickPickItemKind.Separator,

--- a/extension/src/experiments/model/status/collect.ts
+++ b/extension/src/experiments/model/status/collect.ts
@@ -28,13 +28,13 @@ const collectStatus = (acc: ColoredStatus, experiment: Experiment): void => {
 const collectExistingStatuses = (
   experiments: Experiment[],
   checkpointsByTip: Map<string, Experiment[]>,
-  experimentsByBranch: Map<string, Experiment[]>,
+  experimentsByCommit: Map<string, Experiment[]>,
   previousStatus: ColoredStatus
 ): ColoredStatus => {
   const existingStatuses: ColoredStatus = {}
   for (const experiment of [
     ...experiments,
-    ...flattenMapValues(experimentsByBranch),
+    ...flattenMapValues(experimentsByCommit),
     ...flattenMapValues(checkpointsByTip)
   ]) {
     const { id } = experiment
@@ -115,16 +115,16 @@ export const unassignColors = (
 export const collectColoredStatus = (
   experiments: Experiment[],
   checkpointsByTip: Map<string, Experiment[]>,
-  experimentsByBranch: Map<string, Experiment[]>,
+  experimentsByCommit: Map<string, Experiment[]>,
   previousStatus: ColoredStatus,
   unassignedColors: Color[],
   startedRunning: Set<string>,
   finishedRunning: { [id: string]: string }
 ): { coloredStatus: ColoredStatus; availableColors: Color[] } => {
-  const flattenExperimentsByBranch = flattenMapValues(experimentsByBranch)
+  const flattenExperimentsByCommit = flattenMapValues(experimentsByCommit)
   const flattenCheckpoints = flattenMapValues(checkpointsByTip)
   const availableColors = unassignColors(
-    [...experiments, ...flattenExperimentsByBranch, ...flattenCheckpoints],
+    [...experiments, ...flattenExperimentsByCommit, ...flattenCheckpoints],
     previousStatus,
     unassignedColors
   )
@@ -132,7 +132,7 @@ export const collectColoredStatus = (
   const coloredStatus = collectExistingStatuses(
     experiments,
     checkpointsByTip,
-    experimentsByBranch,
+    experimentsByCommit,
     previousStatus
   )
 
@@ -145,7 +145,7 @@ export const collectColoredStatus = (
 
   for (const experiment of [
     ...experiments,
-    ...flattenExperimentsByBranch,
+    ...flattenExperimentsByCommit,
     ...flattenCheckpoints
   ]) {
     collectStatus(coloredStatus, experiment)

--- a/extension/src/experiments/model/tree.test.ts
+++ b/extension/src/experiments/model/tree.test.ts
@@ -34,11 +34,11 @@ const mockedGetMarkdownString = jest.mocked(getMarkdownString)
 
 const {
   mockedExperiments,
-  mockedGetDvcRoots,
-  mockedGetExperiments,
-  mockedGetBranchExperiments,
   mockedGetCheckpoints,
-  mockedGetFirstThreeColumnOrder
+  mockedGetCommitExperiments,
+  mockedGetDvcRoots,
+  mockedGetFirstThreeColumnOrder,
+  mockedGetWorkspaceAndCommits
 } = buildMockedExperiments()
 
 const mockedClockResource = {
@@ -76,8 +76,8 @@ describe('ExperimentsTree', () => {
         mockedResourceLocator
       )
       mockedGetDvcRoots.mockReturnValueOnce(['demo', 'second/repo'])
-      mockedGetExperiments.mockReturnValueOnce([])
-      mockedGetExperiments.mockReturnValueOnce([])
+      mockedGetWorkspaceAndCommits.mockReturnValueOnce([])
+      mockedGetWorkspaceAndCommits.mockReturnValueOnce([])
 
       const rootElements = await experimentsTree.getChildren()
 
@@ -90,7 +90,7 @@ describe('ExperimentsTree', () => {
         mockedResourceLocator
       )
       mockedGetDvcRoots.mockReturnValueOnce(['demo'])
-      mockedGetExperiments.mockReturnValueOnce([])
+      mockedGetWorkspaceAndCommits.mockReturnValueOnce([])
 
       const rootElements = await experimentsTree.getChildren()
 
@@ -104,9 +104,9 @@ describe('ExperimentsTree', () => {
         mockedResourceLocator
       )
       mockedGetDvcRoots.mockReturnValueOnce(dvcRoots)
-      mockedGetExperiments.mockReturnValueOnce([])
-      mockedGetExperiments.mockReturnValueOnce([])
-      mockedGetExperiments.mockReturnValueOnce([
+      mockedGetWorkspaceAndCommits.mockReturnValueOnce([])
+      mockedGetWorkspaceAndCommits.mockReturnValueOnce([])
+      mockedGetWorkspaceAndCommits.mockReturnValueOnce([
         { label: EXPERIMENT_WORKSPACE_ID },
         { label: 'main' },
         { label: '90aea7f' }
@@ -178,7 +178,7 @@ describe('ExperimentsTree', () => {
         mockedExperiments,
         mockedResourceLocator
       )
-      mockedGetExperiments
+      mockedGetWorkspaceAndCommits
         .mockReturnValueOnce(experiments)
         .mockReturnValueOnce(experiments)
 
@@ -339,7 +339,7 @@ describe('ExperimentsTree', () => {
       ])
     })
 
-    it('should return the branch experiments when the element is a branch', async () => {
+    it("should return the commit's experiments when the element is a commit", async () => {
       const experimentsTree = new ExperimentsTree(
         mockedExperiments,
         mockedResourceLocator
@@ -347,7 +347,7 @@ describe('ExperimentsTree', () => {
       const getMockedUri = (name: string, color: string) =>
         Uri.file(join('path', 'to', 'resources', `${name}-${color}.svg`))
       const dvcRoot = '/dvc-root'
-      const branch = {
+      const commit = {
         collapsibleState: 0,
         description: 'f81f1b5',
         dvcRoot,
@@ -356,10 +356,10 @@ describe('ExperimentsTree', () => {
         id: 'f81f1b5',
         label: 'f81f1b5',
         tooltip: undefined,
-        type: ExperimentType.BRANCH
+        type: ExperimentType.COMMIT
       }
 
-      const experimentsByBranch = [
+      const experimentsByCommit = [
         {
           displayColor: undefined,
           hasChildren: false,
@@ -369,10 +369,10 @@ describe('ExperimentsTree', () => {
           type: ExperimentType.EXPERIMENT
         }
       ]
-      mockedGetBranchExperiments.mockReturnValueOnce(experimentsByBranch)
+      mockedGetCommitExperiments.mockReturnValueOnce(experimentsByCommit)
       mockedGetFirstThreeColumnOrder.mockReturnValue([])
 
-      const children = await experimentsTree.getChildren(branch)
+      const children = await experimentsTree.getChildren(commit)
 
       expect(children).toStrictEqual([
         {
@@ -460,7 +460,7 @@ describe('ExperimentsTree', () => {
         mockedExperiments,
         mockedResourceLocator
       )
-      mockedGetExperiments
+      mockedGetWorkspaceAndCommits
         .mockReturnValueOnce(experiments)
         .mockReturnValueOnce(experiments)
       mockedGetDvcRoots.mockReturnValueOnce(['repo'])
@@ -542,8 +542,8 @@ describe('ExperimentsTree', () => {
         mockedResourceLocator
       )
       mockedGetDvcRoots.mockReturnValueOnce(['demo', 'other'])
-      mockedGetExperiments.mockReturnValueOnce([])
-      mockedGetExperiments.mockReturnValueOnce([])
+      mockedGetWorkspaceAndCommits.mockReturnValueOnce([])
+      mockedGetWorkspaceAndCommits.mockReturnValueOnce([])
 
       await experimentsTree.getChildren()
 

--- a/extension/src/experiments/model/tree.ts
+++ b/extension/src/experiments/model/tree.ts
@@ -122,12 +122,12 @@ export class ExperimentsTree
     }
 
     if (this.isRoot(element)) {
-      return Promise.resolve(this.getExperiments(element))
+      return Promise.resolve(this.getWorkspaceAndCommits(element))
     }
 
-    if (element.type === ExperimentType.BRANCH) {
+    if (element.type === ExperimentType.COMMIT) {
       return Promise.resolve(
-        this.getExperimentsByBranch(element.dvcRoot, element)
+        this.getExperimentsByCommit(element.dvcRoot, element)
       )
     }
 
@@ -169,7 +169,7 @@ export class ExperimentsTree
     }
 
     const experiments = dvcRoots.flatMap(dvcRoot =>
-      this.experiments.getRepository(dvcRoot).getExperiments()
+      this.experiments.getRepository(dvcRoot).getWorkspaceAndCommits()
     )
     if (definedAndNonEmpty(experiments)) {
       if (dvcRoots.length === 1) {
@@ -209,21 +209,21 @@ export class ExperimentsTree
     }
   }
 
-  private getExperiments(dvcRoot: string): ExperimentItem[] {
+  private getWorkspaceAndCommits(dvcRoot: string): ExperimentItem[] {
     return this.experiments
       .getRepository(dvcRoot)
-      .getExperiments()
+      .getWorkspaceAndCommits()
       .map(experiment => this.formatExperiment(experiment, dvcRoot))
   }
 
-  private getExperimentsByBranch(
+  private getExperimentsByCommit(
     dvcRoot: string,
-    branch: Experiment
+    commit: Experiment
   ): ExperimentItem[] {
     return (
       this.experiments
         .getRepository(dvcRoot)
-        .getBranchExperiments(branch)
+        .getCommitExperiments(commit)
         ?.map(experiment =>
           this.formatExperiment(experiment as ExperimentAugmented, dvcRoot)
         ) || []
@@ -246,7 +246,7 @@ export class ExperimentsTree
   ) {
     if (
       (description && this.expandedExperiments[description]) ||
-      type === ExperimentType.BRANCH
+      type === ExperimentType.COMMIT
     ) {
       return TreeItemCollapsibleState.Expanded
     }

--- a/extension/src/experiments/workspace.test.ts
+++ b/extension/src/experiments/workspace.test.ts
@@ -19,7 +19,7 @@ const mockedDisposable = jest.mocked(Disposable)
 const mockedDvcRoot = '/my/dvc/root'
 const mockedOtherDvcRoot = '/my/fun/dvc/root'
 const mockedQuickPickOne = jest.mocked(quickPickOne)
-const mockedPickCurrentExperiment = jest.fn()
+const mockedPickExperiment = jest.fn()
 const mockedGetInput = jest.mocked(getInput)
 const mockedRun = jest.fn()
 const mockedExpFunc = jest.fn()
@@ -63,12 +63,12 @@ describe('Experiments', () => {
     {
       '/my/dvc/root': {
         getDvcRoot: () => mockedDvcRoot,
-        pickCurrentExperiment: mockedPickCurrentExperiment,
+        pickExperiment: mockedPickExperiment,
         showWebview: mockedShowWebview
       } as unknown as Experiments,
       '/my/fun/dvc/root': {
         getDvcRoot: () => mockedOtherDvcRoot,
-        pickCurrentExperiment: jest.fn(),
+        pickExperiment: jest.fn(),
         showWebview: jest.fn()
       } as unknown as Experiments
     },
@@ -112,7 +112,7 @@ describe('Experiments', () => {
   describe('getExpNameThenRun', () => {
     it('should call the correct function with the correct parameters if a project and experiment are picked', async () => {
       mockedQuickPickOne.mockResolvedValueOnce(mockedDvcRoot)
-      mockedPickCurrentExperiment.mockResolvedValueOnce({
+      mockedPickExperiment.mockResolvedValueOnce({
         id: 'a123456',
         name: 'exp-123'
       })
@@ -120,7 +120,7 @@ describe('Experiments', () => {
       await workspaceExperiments.getCwdAndExpNameThenRun(mockedCommandId)
 
       expect(mockedQuickPickOne).toHaveBeenCalledTimes(1)
-      expect(mockedPickCurrentExperiment).toHaveBeenCalledTimes(1)
+      expect(mockedPickExperiment).toHaveBeenCalledTimes(1)
       expect(mockedExpFunc).toHaveBeenCalledTimes(1)
       expect(mockedExpFunc).toHaveBeenCalledWith(mockedDvcRoot, 'exp-123')
     })
@@ -189,7 +189,7 @@ describe('Experiments', () => {
   describe('getCwdExpNameAndInputThenRun', () => {
     it('should call the correct function with the correct parameters if a project and experiment are picked and an input provided', async () => {
       mockedQuickPickOne.mockResolvedValueOnce(mockedDvcRoot)
-      mockedPickCurrentExperiment.mockResolvedValueOnce({
+      mockedPickExperiment.mockResolvedValueOnce({
         id: 'a123456',
         name: 'exp-123'
       })
@@ -202,7 +202,7 @@ describe('Experiments', () => {
       )
 
       expect(mockedQuickPickOne).toHaveBeenCalledTimes(1)
-      expect(mockedPickCurrentExperiment).toHaveBeenCalledTimes(1)
+      expect(mockedPickExperiment).toHaveBeenCalledTimes(1)
       expect(mockedExpFunc).toHaveBeenCalledTimes(1)
       expect(mockedExpFunc).toHaveBeenCalledWith(
         mockedDvcRoot,
@@ -227,7 +227,7 @@ describe('Experiments', () => {
 
     it('should not call the function if user input is not provided', async () => {
       mockedQuickPickOne.mockResolvedValueOnce(mockedDvcRoot)
-      mockedPickCurrentExperiment.mockResolvedValueOnce({
+      mockedPickExperiment.mockResolvedValueOnce({
         id: 'b456789',
         name: 'exp-456'
       })

--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -239,9 +239,7 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
   }
 
   public getCwdAndExpNameThenRun(commandId: CommandId) {
-    return this.pickExpThenRun(commandId, cwd =>
-      this.pickCurrentExperiment(cwd)
-    )
+    return this.pickExpThenRun(commandId, cwd => this.pickExperiment(cwd))
   }
 
   public async getCwdAndQuickPickThenRun(
@@ -268,7 +266,7 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
       return
     }
 
-    const experiment = await this.pickCurrentExperiment(cwd)
+    const experiment = await this.pickExperiment(cwd)
 
     if (!experiment) {
       return
@@ -462,7 +460,7 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
     return runCommand(...args, input)
   }
 
-  private pickCurrentExperiment(cwd: string) {
-    return this.getRepository(cwd).pickCurrentExperiment()
+  private pickExperiment(cwd: string) {
+    return this.getRepository(cwd).pickExperiment()
   }
 }

--- a/extension/src/plots/model/collect.test.ts
+++ b/extension/src/plots/model/collect.test.ts
@@ -19,7 +19,7 @@ import {
 } from '../../cli/dvc/contract'
 import { definedAndNonEmpty, sameContents } from '../../util/array'
 import { TemplatePlot } from '../webview/contract'
-import { getCLIBranchId } from '../../test/fixtures/plotsDiff/util'
+import { getCLICommitId } from '../../test/fixtures/plotsDiff/util'
 import { SelectedExperimentWithColor } from '../../experiments/model'
 import { Experiment } from '../../experiments/webview/contract'
 
@@ -227,7 +227,7 @@ describe('collectData', () => {
     expect(isEmpty(values)).toBeFalsy()
 
     for (const revision of revisions) {
-      const expectedValues = values[getCLIBranchId(revision)].map(value => ({
+      const expectedValues = values[getCLICommitId(revision)].map(value => ({
         ...value,
         rev: revision
       }))

--- a/extension/src/plots/model/collect.ts
+++ b/extension/src/plots/model/collect.ts
@@ -223,9 +223,9 @@ export const collectCheckpointPlotsData = (
   for (const { baseline, ...experimentsObject } of Object.values(
     omit(data, EXPERIMENT_WORKSPACE_ID)
   )) {
-    const branch = transformExperimentData(baseline)
+    const commit = transformExperimentData(baseline)
 
-    if (branch) {
+    if (commit) {
       collectFromExperimentsObject(acc, experimentsObject)
     }
   }
@@ -635,19 +635,19 @@ export const collectSelectedTemplatePlots = (
   return acc.length > 0 ? acc : undefined
 }
 
-export const collectBranchRevisionDetails = (
-  branchShas: {
+export const collectCommitRevisionDetails = (
+  shas: {
     id: string
     sha: string | undefined
   }[]
 ) => {
-  const branchRevisions: Record<string, string> = {}
-  for (const { id, sha } of branchShas) {
+  const commitRevisions: Record<string, string> = {}
+  for (const { id, sha } of shas) {
     if (sha) {
-      branchRevisions[id] = shortenForLabel(sha)
+      commitRevisions[id] = shortenForLabel(sha)
     }
   }
-  return branchRevisions
+  return commitRevisions
 }
 
 const getRevision = (

--- a/extension/src/plots/model/index.ts
+++ b/extension/src/plots/model/index.ts
@@ -10,7 +10,7 @@ import {
   ComparisonData,
   RevisionData,
   TemplateAccumulator,
-  collectBranchRevisionDetails,
+  collectCommitRevisionDetails,
   collectOverrideRevisionDetails
 } from './collect'
 import { getRevisionFirstThreeColumns } from './util'
@@ -51,7 +51,7 @@ export class PlotsModel extends ModelWithPersistence {
 
   private plotSizes: Record<Section, number>
   private sectionCollapsed: SectionCollapsed
-  private branchRevisions: Record<string, string> = {}
+  private commitRevisions: Record<string, string> = {}
 
   private fetchedRevs = new Set<string>()
 
@@ -383,10 +383,7 @@ export class PlotsModel extends ModelWithPersistence {
   }
 
   private removeStaleData() {
-    return Promise.all([
-      this.removeStaleBranches(),
-      this.removeStaleRevisions()
-    ])
+    return Promise.all([this.removeStaleCommits(), this.removeStaleRevisions()])
   }
 
   private removeStaleRevisions() {
@@ -409,19 +406,19 @@ export class PlotsModel extends ModelWithPersistence {
     }
   }
 
-  private removeStaleBranches() {
-    const currentBranchRevisions = collectBranchRevisionDetails(
-      this.experiments.getBranchRevisions()
+  private removeStaleCommits() {
+    const currentCommitRevisions = collectCommitRevisionDetails(
+      this.experiments.getCommitRevisions()
     )
-    for (const id of Object.keys(this.branchRevisions)) {
-      if (this.branchRevisions[id] !== currentBranchRevisions[id]) {
+    for (const id of Object.keys(this.commitRevisions)) {
+      if (this.commitRevisions[id] !== currentCommitRevisions[id]) {
         this.deleteRevisionData(id)
       }
     }
-    if (!isEqual(this.branchRevisions, currentBranchRevisions)) {
+    if (!isEqual(this.commitRevisions, currentCommitRevisions)) {
       this.deleteRevisionData(EXPERIMENT_WORKSPACE_ID)
     }
-    this.branchRevisions = currentBranchRevisions
+    this.commitRevisions = currentCommitRevisions
   }
 
   private deleteRevisionData(id: string) {
@@ -431,7 +428,7 @@ export class PlotsModel extends ModelWithPersistence {
   }
 
   private getCLIId(label: string) {
-    return this.branchRevisions[label] || label
+    return this.commitRevisions[label] || label
   }
 
   private getPlots(

--- a/extension/src/test/fixtures/expShow/base/noErrors.ts
+++ b/extension/src/test/fixtures/expShow/base/noErrors.ts
@@ -5,11 +5,11 @@ import {
 import expShowFixture, { errorShas } from './output'
 
 const excludeErrors = (): ExperimentsOutput => {
-  const { workspace, ...branchesObject } = expShowFixture
+  const { workspace, ...commitsObject } = expShowFixture
   const expShowFixtureWithoutErrors: ExperimentsOutput = { workspace }
 
   for (const [sha, { baseline, ...experimentsObject }] of Object.entries(
-    branchesObject
+    commitsObject
   )) {
     const experiments: { [sha: string]: ExperimentFieldsOrError } = {}
     for (const [sha, experiment] of Object.entries(experimentsObject)) {

--- a/extension/src/test/fixtures/plotsDiff/index.ts
+++ b/extension/src/test/fixtures/plotsDiff/index.ts
@@ -17,7 +17,7 @@ import {
 } from '../../../plots/webview/contract'
 import { join } from '../../util/path'
 import { copyOriginalColors } from '../../../experiments/model/status/colors'
-import { getCLIBranchId, replaceBranchCLIId } from './util'
+import { getCLICommitId, replaceCommitCLIId } from './util'
 import { formatDate } from '../../../util/date'
 import { ColumnType, Row } from '../../../experiments/webview/contract'
 
@@ -490,7 +490,7 @@ const extendedSpecs = (plotsOutput: TemplatePlots): TemplatePlotSection[] => {
             data: {
               values:
                 expectedRevisions.flatMap(revision =>
-                  originalPlot.datapoints?.[getCLIBranchId(revision)].map(
+                  originalPlot.datapoints?.[getCLICommitId(revision)].map(
                     values => ({
                       ...values,
                       rev: revision
@@ -687,7 +687,7 @@ export const getComparisonWebviewMessage = (
   for (const [path, plots] of Object.entries(getImageData(baseUrl, joinFunc))) {
     const revisionsAcc: ComparisonRevisionData = {}
     for (const { url, revisions } of plots) {
-      const revision = replaceBranchCLIId(revisions?.[0])
+      const revision = replaceCommitCLIId(revisions?.[0])
       if (!revision) {
         continue
       }

--- a/extension/src/test/fixtures/plotsDiff/util.ts
+++ b/extension/src/test/fixtures/plotsDiff/util.ts
@@ -1,11 +1,11 @@
-export const replaceBranchCLIId = (revision: string): string => {
+export const replaceCommitCLIId = (revision: string): string => {
   if (revision === '53c3851') {
     return 'main'
   }
   return revision
 }
 
-export const getCLIBranchId = (revision: string): string => {
+export const getCLICommitId = (revision: string): string => {
   if (revision === 'main') {
     return '53c3851'
   }

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -87,12 +87,12 @@ suite('Experiments Test Suite', () => {
   })
 
   describe('getExperiments', () => {
-    it('should return the workspace and branch (HEAD revision)', async () => {
+    it('should return the workspace and commit (HEAD revision)', async () => {
       const { experiments } = buildExperiments(disposable)
 
       await experiments.isReady()
 
-      const runs = experiments.getExperiments()
+      const runs = experiments.getWorkspaceAndCommits()
 
       expect(runs.map(experiment => experiment.label)).to.deep.equal([
         EXPERIMENT_WORKSPACE_ID,
@@ -742,8 +742,9 @@ suite('Experiments Test Suite', () => {
       const queuedExperiment = '90aea7f2482117a55dfcadcdb901aaa6610fbbc9'
 
       const isExperimentSelected = (expId: string): boolean =>
-        !!experimentsModel.getAllExperiments().find(({ id }) => id === expId)
-          ?.selected
+        !!experimentsModel
+          .getRecordsWithoutCheckpoints()
+          .find(({ id }) => id === expId)?.selected
 
       expect(isExperimentSelected(experimentToToggle), 'experiment is selected')
         .to.be.true
@@ -939,7 +940,9 @@ suite('Experiments Test Suite', () => {
       const areExperimentsStarred = (expIds: string[]): boolean =>
         expIds
           .map(expId =>
-            experimentsModel.getAllExperiments().find(({ id }) => id === expId)
+            experimentsModel
+              .getRecordsWithoutCheckpoints()
+              .find(({ id }) => id === expId)
           )
           .every(exp => exp?.starred)
 
@@ -1622,7 +1625,7 @@ suite('Experiments Test Suite', () => {
       await experiments.isReady()
 
       expect(
-        experiments.getExperiments(),
+        experiments.getWorkspaceAndCommits(),
         'should send no experiments to the tree'
       ).to.deep.equal([])
       expect(

--- a/extension/src/test/suite/experiments/model/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/tree.test.ts
@@ -172,7 +172,7 @@ suite('Experiments Tree Test Suite', () => {
       })
       const isWorkspaceSelected = (): boolean =>
         !!experiments
-          .getExperiments()
+          .getWorkspaceAndCommits()
           .find(({ id }) => id === EXPERIMENT_WORKSPACE_ID)?.selected
 
       await experiments.isReady()

--- a/extension/src/test/suite/plots/index.test.ts
+++ b/extension/src/test/suite/plots/index.test.ts
@@ -134,7 +134,7 @@ suite('Plots Test Suite', () => {
       )
     })
 
-    it('should call plots diff with the branch name whenever the current branch commit changes', async () => {
+    it('should call plots diff with the branch name (if available) whenever the current commit changes', async () => {
       const mockNow = getMockNow()
       const { data, experiments, mockPlotsDiff } = await buildPlots(
         disposable,

--- a/extension/src/test/util/jest/index.ts
+++ b/extension/src/test/util/jest/index.ts
@@ -32,13 +32,13 @@ export const buildMockedExperiments = () => {
   const mockedExperimentsChanged = buildMockedEventEmitter()
   const mockedGetChildColumns = jest.fn()
   const mockedGetDvcRoots = jest.fn()
-  const mockedGetExperiments = jest.fn()
+  const mockedGetWorkspaceAndCommits = jest.fn()
   const mockedGetCheckpoints = jest.fn()
   const mockedGetFilters = jest.fn()
   const mockedGetFilter = jest.fn()
   const mockedGetSorts = jest.fn()
   const mockedGetSelectedRevisions = jest.fn()
-  const mockedGetBranchExperiments = jest.fn()
+  const mockedGetCommitExperiments = jest.fn()
   const mockedGetFirstThreeColumnOrder = jest.fn()
   const mockedExperiments = {
     columnsChanged: mockedColumnsChanged,
@@ -46,15 +46,15 @@ export const buildMockedExperiments = () => {
     getDvcRoots: mockedGetDvcRoots,
     getRepository: () =>
       ({
-        getBranchExperiments: mockedGetBranchExperiments,
         getCheckpoints: mockedGetCheckpoints,
         getChildColumns: mockedGetChildColumns,
-        getExperiments: mockedGetExperiments,
+        getCommitExperiments: mockedGetCommitExperiments,
         getFilter: mockedGetFilter,
         getFilters: mockedGetFilters,
         getFirstThreeColumnOrder: mockedGetFirstThreeColumnOrder,
         getSelectedRevisions: mockedGetSelectedRevisions,
-        getSorts: mockedGetSorts
+        getSorts: mockedGetSorts,
+        getWorkspaceAndCommits: mockedGetWorkspaceAndCommits
       } as unknown as Experiments),
     isReady: () => true
   } as unknown as WorkspaceExperiments
@@ -64,16 +64,16 @@ export const buildMockedExperiments = () => {
     mockedColumnsOrderOrStatusChanged,
     mockedExperiments,
     mockedExperimentsChanged,
-    mockedGetBranchExperiments,
     mockedGetCheckpoints,
     mockedGetChildColumns,
+    mockedGetCommitExperiments,
     mockedGetDvcRoots,
-    mockedGetExperiments,
     mockedGetFilter,
     mockedGetFilters,
     mockedGetFirstThreeColumnOrder,
     mockedGetSelectedRevisions,
-    mockedGetSorts
+    mockedGetSorts,
+    mockedGetWorkspaceAndCommits
   }
 }
 

--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -196,7 +196,7 @@ describe('App', () => {
       expect(screen.queryByText(checkpointLabel)).not.toBeInTheDocument()
     })
 
-    it('should maintain expansion status when the branch changes', () => {
+    it('should maintain expansion status when the commit changes', () => {
       renderTable()
 
       expect(screen.getByText(experimentLabel)).toBeInTheDocument()
@@ -209,14 +209,14 @@ describe('App', () => {
       expect(screen.getByText(experimentLabel)).toBeInTheDocument()
       expect(screen.queryByText(checkpointLabel)).not.toBeInTheDocument()
 
-      const changedBranchName = 'changed-branch'
+      const changedCommitName = 'changed-branch'
 
       const changedRows = [...tableDataFixture.rows]
       changedRows[1] = {
         ...changedRows[1],
-        id: changedBranchName,
-        label: changedBranchName,
-        name: changedBranchName,
+        id: changedCommitName,
+        label: changedCommitName,
+        name: changedCommitName,
         sha: '99999dfb4aa5fb41915610c3a256b418fc095610'
       }
 
@@ -225,7 +225,7 @@ describe('App', () => {
         rows: changedRows
       })
 
-      expect(screen.getByText(changedBranchName)).toBeInTheDocument()
+      expect(screen.getByText(changedCommitName)).toBeInTheDocument()
       expect(screen.getByText(experimentLabel)).toBeInTheDocument()
       expect(screen.queryByText(checkpointLabel)).not.toBeInTheDocument()
     })
@@ -904,8 +904,8 @@ describe('App', () => {
       advanceTimersByTime(100)
       expect(screen.getAllByRole('menuitem')).toHaveLength(9)
 
-      const branch = getRow('main')
-      fireEvent.click(branch, { bubbles: true })
+      const commit = getRow('main')
+      fireEvent.click(commit, { bubbles: true })
       advanceTimersByTime(100)
       expect(screen.queryAllByRole('menuitem')).toHaveLength(0)
     })


### PR DESCRIPTION
# 2/2 `main` <- #3166 <- this

This PR drops the branch terminology that we were incorrectly using all over the place to describe commit records within our experiments data. I have also attempted to improve the function naming in `ExperimentsModel` so that the names better represent what the functions are doing.