### PR TITLE
Add stop queued experiment running option into table context menu

### DIFF
--- a/extension/src/commands/external.ts
+++ b/extension/src/commands/external.ts
@@ -19,6 +19,7 @@ export enum RegisteredCliCommands {
   EXPERIMENT_VIEW_REMOVE = 'dvc.views.experiments.removeExperiment',
   EXPERIMENT_VIEW_SHARE_AS_BRANCH = 'dvc.views.experiments.shareExperimentAsBranch',
   EXPERIMENT_VIEW_SHARE_AS_COMMIT = 'dvc.views.experiments.shareExperimentAsCommit',
+  EXPERIMENT_VIEW_STOP = 'dvc.views.experiments.stopQueueExperiment',
 
   EXPERIMENT_VIEW_QUEUE = 'dvc.views.experiments.queueExperiment',
   EXPERIMENT_VIEW_RESUME = 'dvc.views.experiments.resumeCheckpointExperiment',

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -569,7 +569,13 @@ export class Experiments extends BaseRepository<TableData> {
       this.checkpoints,
       () => this.getWebview(),
       () => this.notifyChanged(),
-      () => this.selectColumns()
+      () => this.selectColumns(),
+      (dvcRoot: string, ...ids: string[]) =>
+        this.internalCommands.executeCommand(
+          AvailableCommands.QUEUE_KILL,
+          dvcRoot,
+          ...ids
+        )
     )
 
     this.dispose.track(

--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -31,7 +31,7 @@ import { collectFlatExperimentParams } from './modify/collect'
 import {
   Experiment,
   isQueued,
-  isRunning,
+  isRunningInQueue,
   Row,
   RunningExperiment
 } from '../webview/contract'
@@ -401,8 +401,8 @@ export class ExperimentsModel extends ModelWithPersistence {
   }
 
   public getRunningQueueTasks() {
-    return this.getExperimentsAndQueued().filter(
-      ({ status, executor }) => isRunning(status) && executor === 'dvc-task'
+    return this.getExperimentsAndQueued().filter(experiment =>
+      isRunningInQueue(experiment)
     )
   }
 

--- a/extension/src/experiments/webview/contract.ts
+++ b/extension/src/experiments/webview/contract.ts
@@ -55,6 +55,16 @@ export const isRunning = (status: ExperimentStatus | undefined): boolean =>
 export const isQueued = (status: ExperimentStatus | undefined): boolean =>
   status === ExperimentStatus.QUEUED
 
+export const isRunningInQueue = ({
+  status,
+  executor
+}:
+  | Experiment
+  | {
+      status: ExperimentStatus | undefined
+      executor: string | null | undefined
+    }): boolean => isRunning(status) && executor === 'dvc-task'
+
 export interface Row extends Experiment {
   subRows?: Row[]
 }

--- a/extension/src/experiments/webview/contract.ts
+++ b/extension/src/experiments/webview/contract.ts
@@ -58,12 +58,10 @@ export const isQueued = (status: ExperimentStatus | undefined): boolean =>
 export const isRunningInQueue = ({
   status,
   executor
-}:
-  | Experiment
-  | {
-      status: ExperimentStatus | undefined
-      executor: string | null | undefined
-    }): boolean => isRunning(status) && executor === 'dvc-task'
+}: {
+  status?: ExperimentStatus
+  executor?: string | null
+}): boolean => isRunning(status) && executor === 'dvc-task'
 
 export interface Row extends Experiment {
   subRows?: Row[]

--- a/extension/src/experiments/webview/messages.ts
+++ b/extension/src/experiments/webview/messages.ts
@@ -161,7 +161,7 @@ export class WebviewMessages {
       }
 
       case MessageFromWebviewType.STOP_EXPERIMENT: {
-        return this.stopExperiments([message.payload].flat())
+        return this.stopExperiments(message.payload)
       }
 
       default:

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -152,6 +152,7 @@ export interface IEventNamePropertyMapping {
   [EventName.EXPERIMENT_VIEW_REMOVE]: undefined
   [EventName.EXPERIMENT_VIEW_SHARE_AS_BRANCH]: undefined
   [EventName.EXPERIMENT_VIEW_SHARE_AS_COMMIT]: undefined
+  [EventName.EXPERIMENT_VIEW_STOP]: undefined
   [EventName.QUEUE_EXPERIMENT]: undefined
   [EventName.QUEUE_KILL]: undefined
   [EventName.QUEUE_START]: undefined

--- a/extension/src/webview/contract.ts
+++ b/extension/src/webview/contract.ts
@@ -30,6 +30,7 @@ export enum MessageFromWebviewType {
   REFRESH_REVISIONS = 'refresh-revisions',
   RESIZE_COLUMN = 'resize-column',
   RESIZE_PLOTS = 'resize-plots',
+  STOP_EXPERIMENT = 'stop-experiment',
   SORT_COLUMN = 'sort-column',
   TOGGLE_EXPERIMENT = 'toggle-experiment',
   TOGGLE_EXPERIMENT_STAR = 'toggle-experiment-star',
@@ -124,6 +125,10 @@ export type MessageFromWebview =
   | {
       type: MessageFromWebviewType.SORT_COLUMN
       payload: SortDefinition
+    }
+  | {
+      type: MessageFromWebviewType.STOP_EXPERIMENT
+      payload: string[]
     }
   | {
       type: MessageFromWebviewType.REMOVE_COLUMN_SORT

--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -874,6 +874,7 @@ describe('App', () => {
         'Modify and Resume',
         'Modify and Queue',
         'Star',
+        'Stop',
         'Remove'
       ])
 
@@ -888,7 +889,7 @@ describe('App', () => {
       fireEvent.contextMenu(row, { bubbles: true })
 
       advanceTimersByTime(100)
-      expect(screen.getAllByRole('menuitem')).toHaveLength(9)
+      expect(screen.getAllByRole('menuitem')).toHaveLength(10)
 
       fireEvent.click(window, { bubbles: true })
       advanceTimersByTime(100)
@@ -902,7 +903,7 @@ describe('App', () => {
       fireEvent.contextMenu(row, { bubbles: true })
 
       advanceTimersByTime(100)
-      expect(screen.getAllByRole('menuitem')).toHaveLength(9)
+      expect(screen.getAllByRole('menuitem')).toHaveLength(10)
 
       const commit = getRow('main')
       fireEvent.click(commit, { bubbles: true })
@@ -917,13 +918,13 @@ describe('App', () => {
       fireEvent.contextMenu(row, { bubbles: true })
 
       advanceTimersByTime(100)
-      expect(screen.queryAllByRole('menuitem')).toHaveLength(9)
+      expect(screen.queryAllByRole('menuitem')).toHaveLength(10)
 
       fireEvent.contextMenu(within(row).getByText('[exp-e7a67]'), {
         bubbles: true
       })
       advanceTimersByTime(200)
-      expect(screen.queryAllByRole('menuitem')).toHaveLength(9)
+      expect(screen.queryAllByRole('menuitem')).toHaveLength(10)
     })
 
     it('should present the Remove experiment option for the checkpoint tips', () => {

--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -967,6 +967,33 @@ describe('App', () => {
       })
     })
 
+    it('should present the Stop option if rows that are running in the queue are selected', () => {
+      renderTableWithoutRunningExperiments()
+
+      clickRowCheckbox('4fb124a')
+
+      const target = screen.getByText('4fb124a')
+      fireEvent.contextMenu(target, { bubbles: true })
+
+      advanceTimersByTime(100)
+      const menuitems = screen.getAllByRole('menuitem')
+      const itemLabels = menuitems.map(item => item.textContent)
+      expect(itemLabels).toContain('Stop')
+
+      const stopOption = menuitems.find(item =>
+        item.textContent?.includes('Stop')
+      )
+
+      expect(stopOption).toBeDefined()
+
+      stopOption && fireEvent.click(stopOption)
+
+      expect(sendMessage).toHaveBeenCalledWith({
+        payload: ['exp-e7a67'],
+        type: MessageFromWebviewType.STOP_EXPERIMENT
+      })
+    })
+
     it('should always present the Plots options if multiple rows are selected', () => {
       renderTableWithoutRunningExperiments()
 


### PR DESCRIPTION
Related to https://github.com/iterative/vscode-dvc/issues/3091

This PR adds the ability to stop experiments running in the queue from the experiments table's row context menu.


### Demo (both single and multi-select)

https://user-images.githubusercontent.com/37993418/215371899-6a3d23eb-6f35-4479-aa39-e9bf1f25350d.mov

