### PR TITLE
Add project level jest config (for WallabyJS)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  projects: [
+    '<rootDir>/webview/jest.config.js',
+    '<rootDir>/extension/jest.config.js',
+    '<rootDir>/languageServer/jest.config.js'
+  ]
+}


### PR DESCRIPTION
This PR adds a project-level jest config. I've added this so that the WallabyJS extension will work with our project. The extension requires a license but you can 

1. get a free 2 week trial
2. qualify for an OSS license (which is free)

A demo of the product is [here](https://wallabyjs.com/). 

Mentioned in Slack [here](https://iterativeai.slack.com/archives/C036GHR1WTV/p1675379336525079).

### Demo


https://user-images.githubusercontent.com/37993418/216473103-7b36b882-07c3-403d-932e-db0f590f7705.mov

