### PR TITLE
Increase timeout of tests which use window.withProgress

### DIFF
--- a/extension/src/test/suite/experiments/workspace.test.ts
+++ b/extension/src/test/suite/experiments/workspace.test.ts
@@ -27,7 +27,7 @@ import {
   QuickPickItemWithValue,
   QuickPickOptionsWithTitle
 } from '../../../vscode/quickPick'
-import { WEBVIEW_TEST_TIMEOUT } from '../timeouts'
+import { PROGRESS_TEST_TIMEOUT, WEBVIEW_TEST_TIMEOUT } from '../timeouts'
 import { Title } from '../../../vscode/title'
 import { join } from '../../util/path'
 import { AvailableCommands } from '../../../commands/internal'
@@ -716,7 +716,7 @@ suite('Workspace Experiments Test Suite', () => {
       expect(mockPush).to.be.calledWithExactly(dvcDemoPath)
       expect(mockGitPush).to.be.calledWithExactly(dvcDemoPath, mockBranch)
     })
-  })
+  }).timeout(PROGRESS_TEST_TIMEOUT)
 
   describe('dvc.shareExperimentAsCommit', () => {
     it('should be able to share an experiment as a commit', async () => {
@@ -770,7 +770,7 @@ suite('Workspace Experiments Test Suite', () => {
       )
       expect(mockPush).to.be.calledWithExactly(dvcDemoPath)
       expect(mockGitPush).to.be.calledWithExactly(dvcDemoPath)
-    })
+    }).timeout(PROGRESS_TEST_TIMEOUT)
   })
 
   describe('dvc.removeExperiments', () => {

--- a/extension/src/test/suite/setup/autoInstall.test.ts
+++ b/extension/src/test/suite/setup/autoInstall.test.ts
@@ -7,6 +7,7 @@ import * as PythonExtension from '../../../extensions/python'
 import * as Python from '../../../python'
 import { autoInstallDvc } from '../../../setup/autoInstall'
 import * as WorkspaceFolders from '../../../vscode/workspaceFolders'
+import { PROGRESS_TEST_TIMEOUT } from '../timeouts'
 
 const { getDefaultPython } = Python
 
@@ -86,6 +87,6 @@ suite('Auto Install Test Suite', () => {
         defaultPython,
         'dvclive'
       )
-    })
+    }).timeout(PROGRESS_TEST_TIMEOUT)
   })
 })

--- a/extension/src/test/suite/timeouts.ts
+++ b/extension/src/test/suite/timeouts.ts
@@ -1,1 +1,2 @@
 export const WEBVIEW_TEST_TIMEOUT = 16000
+export const PROGRESS_TEST_TIMEOUT = 8000


### PR DESCRIPTION
I have seen `should install DVC and DVCLive if a Python interpreter is found` fail in the pipeline. I believe this is because `Toast.showProgress` takes a minimum of 5000ms to execute (the final message is kept around for that amount of time before being auto-dismissed). Seems prudent to increase the timeout of these tests.