### PR TITLE
fix(3226): remove legend object from Vega spec

### DIFF
--- a/extension/src/plots/model/collect.ts
+++ b/extension/src/plots/model/collect.ts
@@ -37,7 +37,7 @@ import {
 } from '../../experiments/webview/contract'
 import { addToMapArray } from '../../util/map'
 import { TemplateOrder } from '../paths/collect'
-import { extendVegaSpec, isMultiViewPlot } from '../vega/util'
+import { transformVegaSpec, isMultiViewPlot } from '../vega/util'
 import {
   definedAndNonEmpty,
   reorderObjectList,
@@ -558,7 +558,7 @@ const collectTemplatePlot = (
     return
   }
 
-  const content = extendVegaSpec(fillTemplate(template, datapoints), size, {
+  const content = transformVegaSpec(fillTemplate(template, datapoints), size, {
     ...multiSourceEncodingUpdate,
     color: revisionColors
   }) as VisualizationSpec

--- a/extension/src/plots/vega/util.test.ts
+++ b/extension/src/plots/vega/util.test.ts
@@ -5,7 +5,7 @@ import cloneDeep from 'lodash.clonedeep'
 import {
   isMultiViewPlot,
   isMultiViewByCommitPlot,
-  extendVegaSpec,
+  transformVegaSpec,
   getColorScale,
   Encoding,
   reverseOfLegendSuppressionUpdate
@@ -84,7 +84,10 @@ describe('getColorScale', () => {
 
 describe('extendVegaSpec', () => {
   it('should not add encoding if no color scale is provided', () => {
-    const extendedSpec = extendVegaSpec(linearTemplate, PlotSizeNumber.REGULAR)
+    const extendedSpec = transformVegaSpec(
+      linearTemplate,
+      PlotSizeNumber.REGULAR
+    )
     expect(extendedSpec.encoding).toBeUndefined()
   })
 
@@ -93,7 +96,7 @@ describe('extendVegaSpec', () => {
       domain: [EXPERIMENT_WORKSPACE_ID, 'main'],
       range: copyOriginalColors().slice(0, 2)
     }
-    const extendedSpec = extendVegaSpec(
+    const extendedSpec = transformVegaSpec(
       linearTemplate,
       PlotSizeNumber.REGULAR,
       {
@@ -140,7 +143,7 @@ describe('extendVegaSpec', () => {
 
   it('should truncate all titles from the left to 50 characters for large plots', () => {
     const spec = withLongTemplatePlotTitle()
-    const updatedSpec = extendVegaSpec(spec, PlotSizeNumber.LARGE)
+    const updatedSpec = transformVegaSpec(spec, PlotSizeNumber.LARGE)
 
     const truncatedTitle = '…-many-many-characters-at-least-seventy-characters'
     const truncatedHorizontalTitle =
@@ -166,7 +169,7 @@ describe('extendVegaSpec', () => {
 
   it('should truncate all titles from the left to 50 characters for regular plots', () => {
     const spec = withLongTemplatePlotTitle()
-    const updatedSpec = extendVegaSpec(spec, PlotSizeNumber.REGULAR)
+    const updatedSpec = transformVegaSpec(spec, PlotSizeNumber.REGULAR)
 
     const truncatedTitle = '…-many-many-characters-at-least-seventy-characters'
     const truncatedHorizontalTitle =
@@ -192,7 +195,7 @@ describe('extendVegaSpec', () => {
 
   it('should truncate all titles from the left to 30 characters for small plots', () => {
     const spec = withLongTemplatePlotTitle()
-    const updatedSpec = extendVegaSpec(spec, PlotSizeNumber.SMALL)
+    const updatedSpec = transformVegaSpec(spec, PlotSizeNumber.SMALL)
 
     const truncatedTitle = '…s-at-least-seventy-characters'
     const truncatedHorizontalTitle = '…at-least-seventy-characters-x'
@@ -222,7 +225,7 @@ describe('extendVegaSpec', () => {
       text: repeatedTitle
     })
 
-    const updatedSpec = extendVegaSpec(spec, PlotSizeNumber.SMALL)
+    const updatedSpec = transformVegaSpec(spec, PlotSizeNumber.SMALL)
 
     const truncatedTitle = '…ghijklmnopqrstuvwyz1234567890'
 
@@ -239,7 +242,7 @@ describe('extendVegaSpec', () => {
     const repeatedTitle = 'abcdefghijklmnopqrstuvwyz1234567890'
     const spec = withLongTemplatePlotTitle([repeatedTitle, repeatedTitle])
 
-    const updatedSpec = extendVegaSpec(spec, PlotSizeNumber.SMALL)
+    const updatedSpec = transformVegaSpec(spec, PlotSizeNumber.SMALL)
 
     const truncatedTitle = '…ghijklmnopqrstuvwyz1234567890'
 
@@ -259,7 +262,7 @@ describe('extendVegaSpec', () => {
       text: [repeatedTitle, repeatedTitle]
     })
 
-    const updatedSpec = extendVegaSpec(spec, PlotSizeNumber.SMALL)
+    const updatedSpec = transformVegaSpec(spec, PlotSizeNumber.SMALL)
 
     const truncatedTitle = '…ghijklmnopqrstuvwyz1234567890'
 
@@ -273,7 +276,7 @@ describe('extendVegaSpec', () => {
   })
 
   it('should update the multi-source template to remove erroneous shape encoding from the vertical line displayed on hover', () => {
-    const updatedSpec = extendVegaSpec(
+    const updatedSpec = transformVegaSpec(
       multiSourceTemplate,
       PlotSizeNumber.LARGE,
       {

--- a/extension/src/test/fixtures/plotsDiff/index.ts
+++ b/extension/src/test/fixtures/plotsDiff/index.ts
@@ -1,7 +1,7 @@
 import { TopLevelSpec } from 'vega-lite'
 import { VisualizationSpec } from 'react-vega'
 import rowsFixture from '../expShow/base/rows'
-import { extendVegaSpec, isMultiViewPlot } from '../../../plots/vega/util'
+import { transformVegaSpec, isMultiViewPlot } from '../../../plots/vega/util'
 import { EXPERIMENT_WORKSPACE_ID, PlotsOutput } from '../../../cli/dvc/contract'
 import {
   ComparisonPlots,
@@ -484,7 +484,7 @@ const extendedSpecs = (plotsOutput: TemplatePlots): TemplatePlotSection[] => {
   for (const [path, plots] of Object.entries(plotsOutput)) {
     for (const originalPlot of plots) {
       const plot = {
-        content: extendVegaSpec(
+        content: transformVegaSpec(
           {
             ...originalPlot.content,
             data: {


### PR DESCRIPTION
Fixes #3226

https://user-images.githubusercontent.com/3659196/216887839-723ec8b8-39ad-4f9a-8d25-32b3f7cd723b.mov

TODO (can do as a followup if we are comfortable to do a release:

- [ ] Add tests
- [ ] Reduce complexity (generalize spec traversal)

