### PR TITLE
Add reminder to commit after `dvc init`

### DIFF
--- a/extension/src/setup/index.ts
+++ b/extension/src/setup/index.ts
@@ -43,6 +43,7 @@ import { EventName } from '../telemetry/constants'
 import { WorkspaceScale } from '../telemetry/collect'
 import { gitPath } from '../cli/git/constants'
 import { DOT_DVC } from '../cli/dvc/constants'
+import { Toast } from '../vscode/toast'
 
 export type SetupWebviewWebview = BaseWebview<TSetupData>
 
@@ -310,6 +311,9 @@ export class Setup
     const root = getFirstWorkspaceFolder()
     if (root) {
       await this.dvcExecutor.init(root)
+      void Toast.infoWithOptions(
+        'Initialized DVC repository. You can now [commit the changes to git](command:workbench.view.scm).'
+      )
     }
   }
 


### PR DESCRIPTION
* adds a `Toast` message after the "Initialize a DVC Project" command is run

## Demo

https://user-images.githubusercontent.com/43496356/217296643-8a8f22bd-c328-4c2c-a7e2-6b942e5a209c.mov

Part of #3057 