### PR TITLE
Fix package-manager issue

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,9 @@ First, ensure that [Visual Studio Code](https://code.visualstudio.com) and
 - Open this repository as a project in VS Code and run `yarn install` from the
   _Integrated Terminal_.
 
-- Run `Tasks: Run Build Task` (Shift + Ctrl/Cmd + `b`) to start the extension
-  and Webview dev servers (alternatively, run `yarn dev-server` from the
-  _Terminal_). The latest build is saved in `extension/dist`.
+- Run `Tasks: Run Build Task` (Shift + Ctrl/Cmd + `b`) to start the individual
+  dev servers (alternatively, run `yarn dev-server` from the _Terminal_). The
+  latest build is saved in `extension/dist`.
 
   > **Warning**: Having a separate `.vsix` version of this extension installed
   > may cause all kinds of chaos in your dev env.

--- a/package.json
+++ b/package.json
@@ -79,5 +79,6 @@
     "trim": "1.0.1",
     "vega-functions": "5.13.0",
     "vega-scale": "7.2.0"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
This PR updates the contributing.md and adds the package manager field to our root package.json. The idea here is to help contributors who have the wrong version of yarn installed (e.g v2 or v3).