### PR TITLE
Add ability to stop experiments running in the workspace (outside of the extension)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -820,7 +820,7 @@
         },
         {
           "command": "dvc.stopAllRunningExperiments",
-          "when": "dvc.commands.available && dvc.project.available && dvc.experiment.stoppable"
+          "when": "dvc.commands.available && dvc.project.available && dvc.experiment.running"
         },
         {
           "command": "dvc.views.experimentsColumnsTree.selectColumns",
@@ -993,7 +993,7 @@
         {
           "command": "dvc.stopAllRunningExperiments",
           "group": "navigation@0",
-          "when": "dvc.experiment.stoppable && dvc.commands.available"
+          "when": "dvc.experiment.running && dvc.commands.available"
         },
         {
           "command": "dvc.resetAndRunCheckpointExperiment",
@@ -1186,12 +1186,12 @@
         },
         {
           "command": "dvc.stopAllRunningExperiments",
-          "when": "view == dvc.views.experimentsTree && !dvc.experiments.webview.active && dvc.experiment.stoppable",
+          "when": "view == dvc.views.experimentsTree && !dvc.experiments.webview.active && dvc.experiment.running",
           "group": "1_run@1"
         },
         {
           "command": "dvc.stopAllRunningExperiments",
-          "when": "view == dvc.views.experimentsTree && dvc.experiments.webview.active && dvc.experiment.stoppable",
+          "when": "view == dvc.views.experimentsTree && dvc.experiments.webview.active && dvc.experiment.running",
           "group": "navigation@1"
         },
         {

--- a/extension/src/cli/dvc/constants.ts
+++ b/extension/src/cli/dvc/constants.ts
@@ -4,13 +4,14 @@ export const UNEXPECTED_ERROR_CODE = 255
 export const DOT_DVC = '.dvc'
 
 export const TEMP_PLOTS_DIR = join(DOT_DVC, 'tmp', 'plots')
+
+const TEMP_EXP_DIR = join(DOT_DVC, 'tmp', 'exps')
 export const DVCLIVE_ONLY_RUNNING_SIGNAL_FILE = join(
-  DOT_DVC,
-  'tmp',
-  'exps',
+  TEMP_EXP_DIR,
   'run',
   'DVCLIVE_ONLY'
 )
+export const EXP_RWLOCK_FILE = join(TEMP_EXP_DIR, 'rwlock.lock')
 
 export const NUM_OF_COMMITS_TO_SHOW = '3'
 

--- a/extension/src/context.ts
+++ b/extension/src/context.ts
@@ -37,7 +37,7 @@ export class Context extends Disposable {
           repositories.push(this.experiments.getRepository(dvcRoot))
         }
 
-        void this.setIsExperimentRunning(repositories)
+        this.setIsExperimentRunning(repositories)
 
         void setContextValue(
           ContextKey.EXPERIMENTS_FILTERED,
@@ -52,24 +52,11 @@ export class Context extends Disposable {
     )
   }
 
-  private async setIsExperimentRunning(repositories: Experiments[] = []) {
-    if (
-      this.dvcRunner.isExperimentRunning() ||
-      repositories.some(experiments => experiments.hasRunningQueuedExperiment())
-    ) {
-      void setContextValue(ContextKey.EXPERIMENT_RUNNING, true)
-      void setContextValue(ContextKey.EXPERIMENT_STOPPABLE, true)
-      return
-    }
-
+  private setIsExperimentRunning(repositories: Experiments[] = []) {
     void setContextValue(
       ContextKey.EXPERIMENT_RUNNING,
-      repositories.some(experiments => experiments.hasRunningExperiment())
-    )
-
-    void setContextValue(
-      ContextKey.EXPERIMENT_STOPPABLE,
-      await this.experiments.hasDvcLiveOnlyExperimentRunning()
+      this.dvcRunner.isExperimentRunning() ||
+        repositories.some(experiments => experiments.hasRunningExperiment())
     )
   }
 }

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -521,10 +521,6 @@ export class Experiments extends BaseRepository<TableData> {
     return this.experiments.hasRunningExperiment()
   }
 
-  public hasRunningQueuedExperiment() {
-    return this.experiments.getRunningQueueTasks().length > 0
-  }
-
   public getFirstThreeColumnOrder() {
     return this.columns.getFirstThreeColumnOrder()
   }

--- a/extension/src/experiments/processes/collect.test.ts
+++ b/extension/src/experiments/processes/collect.test.ts
@@ -1,0 +1,69 @@
+import { join } from 'path'
+import { collectRunningExperimentPids } from './collect'
+import { getPidFromFile } from '../../fileSystem'
+import {
+  DVCLIVE_ONLY_RUNNING_SIGNAL_FILE,
+  EXP_RWLOCK_FILE
+} from '../../cli/dvc/constants'
+
+jest.mock('../../fileSystem')
+
+const mockedGetPidFromFile = jest.mocked(getPidFromFile)
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('collectRunningExperimentPids', () => {
+  it('should exclude undefined from the final result', async () => {
+    mockedGetPidFromFile
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(1234)
+
+    const mockedDvcRoot = join('mock', 'root')
+
+    expect(await collectRunningExperimentPids([mockedDvcRoot])).toStrictEqual([
+      1234
+    ])
+
+    expect(mockedGetPidFromFile).toHaveBeenCalledTimes(2)
+    expect(mockedGetPidFromFile).toHaveBeenCalledWith(
+      join(mockedDvcRoot, DVCLIVE_ONLY_RUNNING_SIGNAL_FILE)
+    )
+    expect(mockedGetPidFromFile).toHaveBeenCalledWith(
+      join(mockedDvcRoot, EXP_RWLOCK_FILE)
+    )
+  })
+
+  it("should collect the pid of processes which are located in each repository's files", async () => {
+    mockedGetPidFromFile
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(3)
+      .mockResolvedValueOnce(4)
+
+    const mockedFirstDvcRoot = join('mock', 'root', '1')
+    const mockedSecondDvcRoot = join('mock', 'root', '2')
+
+    expect(
+      await collectRunningExperimentPids([
+        mockedFirstDvcRoot,
+        mockedSecondDvcRoot
+      ])
+    ).toStrictEqual([1, 2, 3, 4])
+
+    expect(mockedGetPidFromFile).toHaveBeenCalledTimes(4)
+    expect(mockedGetPidFromFile).toHaveBeenCalledWith(
+      join(mockedFirstDvcRoot, DVCLIVE_ONLY_RUNNING_SIGNAL_FILE)
+    )
+    expect(mockedGetPidFromFile).toHaveBeenCalledWith(
+      join(mockedFirstDvcRoot, EXP_RWLOCK_FILE)
+    )
+    expect(mockedGetPidFromFile).toHaveBeenCalledWith(
+      join(mockedSecondDvcRoot, DVCLIVE_ONLY_RUNNING_SIGNAL_FILE)
+    )
+    expect(mockedGetPidFromFile).toHaveBeenCalledWith(
+      join(mockedSecondDvcRoot, EXP_RWLOCK_FILE)
+    )
+  })
+})

--- a/extension/src/experiments/processes/collect.ts
+++ b/extension/src/experiments/processes/collect.ts
@@ -1,0 +1,32 @@
+import { join } from 'path'
+import {
+  DVCLIVE_ONLY_RUNNING_SIGNAL_FILE,
+  EXP_RWLOCK_FILE
+} from '../../cli/dvc/constants'
+import { getPidFromFile } from '../../fileSystem'
+
+const collectDvcRootPids = async (
+  acc: Set<number>,
+  dvcRoot: string
+): Promise<void> => {
+  for (const file of [
+    join(dvcRoot, DVCLIVE_ONLY_RUNNING_SIGNAL_FILE),
+    join(dvcRoot, EXP_RWLOCK_FILE)
+  ]) {
+    const pid = await getPidFromFile(file)
+    if (!pid) {
+      continue
+    }
+    acc.add(pid)
+  }
+}
+
+export const collectRunningExperimentPids = async (
+  dvcRoots: string[]
+): Promise<number[]> => {
+  const acc = new Set<number>()
+  for (const dvcRoot of dvcRoots) {
+    await collectDvcRootPids(acc, dvcRoot)
+  }
+  return [...acc]
+}

--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -1,9 +1,8 @@
-import { join } from 'path'
 import { EventEmitter, Memento } from 'vscode'
 import isEmpty from 'lodash.isempty'
 import { Experiments, ModifiedExperimentAndRunCommandId } from '.'
 import { TableData } from './webview/contract'
-import { Args, DVCLIVE_ONLY_RUNNING_SIGNAL_FILE } from '../cli/dvc/constants'
+import { Args } from '../cli/dvc/constants'
 import {
   AvailableCommands,
   CommandId,
@@ -15,8 +14,7 @@ import { getInput, getPositiveIntegerInput } from '../vscode/inputBox'
 import { BaseWorkspaceWebviews } from '../webview/workspace'
 import { Title } from '../vscode/title'
 import { ContextKey, setContextValue } from '../vscode/context'
-import { findOrCreateDvcYamlFile, getPidFromSignalFile } from '../fileSystem'
-import { definedAndNonEmpty } from '../util/array'
+import { findOrCreateDvcYamlFile } from '../fileSystem'
 import { quickPickOneOrInput } from '../vscode/quickPick'
 import { pickFile } from '../vscode/resourcePicker'
 
@@ -415,28 +413,9 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
     return allLoading
   }
 
-  public async hasDvcLiveOnlyExperimentRunning() {
-    return definedAndNonEmpty(await this.getDvcLiveOnlyPids())
-  }
-
-  public async getDvcLiveOnlyPids() {
-    const pids: number[] = []
-
-    for (const dvcRoot of this.getDvcRoots()) {
-      const signalFile = join(dvcRoot, DVCLIVE_ONLY_RUNNING_SIGNAL_FILE)
-      const pid = await getPidFromSignalFile(signalFile)
-      if (!pid) {
-        continue
-      }
-      pids.push(pid)
-    }
-
-    return pids
-  }
-
-  public hasQueuedExperimentsRunning() {
+  public hasRunningExperiment() {
     return Object.values(this.repositories).some(experiments =>
-      experiments.hasRunningQueuedExperiment()
+      experiments.hasRunningExperiment()
     )
   }
 

--- a/extension/src/fileSystem/index.ts
+++ b/extension/src/fileSystem/index.ts
@@ -173,7 +173,7 @@ export const writeJson = <T extends Record<string, unknown>>(
   return writeFileSync(path, JSON.stringify(obj))
 }
 
-export const getPidFromSignalFile = async (
+export const getPidFromFile = async (
   path: string
 ): Promise<number | undefined> => {
   if (!exists(path)) {
@@ -191,7 +191,7 @@ export const getPidFromSignalFile = async (
 }
 
 export const checkSignalFile = async (path: string): Promise<boolean> => {
-  return !!(await getPidFromSignalFile(path))
+  return !!(await getPidFromFile(path))
 }
 
 export const pollSignalFileForProcess = async (

--- a/extension/src/test/suite/context.test.ts
+++ b/extension/src/test/suite/context.test.ts
@@ -88,7 +88,7 @@ suite('Context Test Suite', () => {
 
   // eslint-disable-next-line sonarjs/cognitive-complexity
   describe('Context', () => {
-    it('should set the dvc.experiment.running and dvc.experiment.stoppable context to true whenever an experiment is running in the runner', async () => {
+    it('should set the dvc.experiment.running context to true whenever an experiment is running in the runner', async () => {
       const { executeCommandSpy, onDidStartProcess, processStarted } =
         buildContext(true)
 
@@ -102,12 +102,6 @@ suite('Context Test Suite', () => {
       expect(executeCommandSpy).to.be.calledWith(
         'setContext',
         'dvc.experiment.running',
-        true
-      )
-
-      expect(executeCommandSpy).to.be.calledWith(
-        'setContext',
-        'dvc.experiment.stoppable',
         true
       )
     })
@@ -171,100 +165,6 @@ suite('Context Test Suite', () => {
       expect(executeCommandSpy).to.be.calledWith(
         'setContext',
         'dvc.experiment.running',
-        false
-      )
-    })
-
-    it('should set the dvc.experiment.stoppable context to whether or not there is a DVCLive only experiment running if an experiment is not running in the runner or queue', async () => {
-      const {
-        executeCommandSpy,
-        experimentsChanged,
-        mockGetDvcRoots,
-        mockGetRepository,
-        mockHasDvcLiveOnlyExperimentRunning,
-        onDidChangeExperiments
-      } = buildContext(false)
-
-      const dvcLiveOnlyRunningEvent = new Promise(resolve =>
-        disposable.track(onDidChangeExperiments(() => resolve(undefined)))
-      )
-
-      const mockDvcRoot = resolve('first', 'root')
-      mockGetDvcRoots.returns([mockDvcRoot])
-      mockGetRepository.callsFake(() => buildMockExperiments())
-
-      mockHasDvcLiveOnlyExperimentRunning.resolves(true)
-
-      experimentsChanged.fire()
-      await dvcLiveOnlyRunningEvent
-
-      expect(executeCommandSpy).to.be.calledWith(
-        'setContext',
-        'dvc.experiment.stoppable',
-        true
-      )
-      mockHasDvcLiveOnlyExperimentRunning.resetBehavior()
-      executeCommandSpy.resetHistory()
-
-      const dvcLiveOnlyStoppedEvent = new Promise(resolve =>
-        disposable.track(onDidChangeExperiments(() => resolve(undefined)))
-      )
-
-      mockHasDvcLiveOnlyExperimentRunning.resolves(false)
-
-      experimentsChanged.fire()
-      await dvcLiveOnlyStoppedEvent
-
-      expect(executeCommandSpy).to.be.calledWith(
-        'setContext',
-        'dvc.experiment.stoppable',
-        false
-      )
-    })
-
-    it('should set the dvc.experiment.stoppable context to true if an experiment is running in the queue', async () => {
-      const {
-        executeCommandSpy,
-        experimentsChanged,
-        mockGetDvcRoots,
-        mockGetRepository,
-        mockHasDvcLiveOnlyExperimentRunning,
-        onDidChangeExperiments
-      } = buildContext(false)
-
-      const queuedExperimentRunningEvent = new Promise(resolve =>
-        disposable.track(onDidChangeExperiments(() => resolve(undefined)))
-      )
-
-      const mockDvcRoot = resolve('first', 'root')
-      mockGetDvcRoots.returns([mockDvcRoot])
-      let hasRunningQueuedExperiment = true
-      mockGetRepository.callsFake(() =>
-        buildMockExperiments([], [], false, hasRunningQueuedExperiment)
-      )
-
-      mockHasDvcLiveOnlyExperimentRunning.resolves(false)
-
-      experimentsChanged.fire()
-      await queuedExperimentRunningEvent
-
-      expect(executeCommandSpy).to.be.calledWith(
-        'setContext',
-        'dvc.experiment.stoppable',
-        true
-      )
-      executeCommandSpy.resetHistory()
-
-      const queuedExperimentStoppedEvent = new Promise(resolve =>
-        disposable.track(onDidChangeExperiments(() => resolve(undefined)))
-      )
-      hasRunningQueuedExperiment = false
-      experimentsChanged.fire()
-      await queuedExperimentStoppedEvent
-
-      expect(executeCommandSpy).to.be.calledWith(
-        'setContext',
-        'dvc.experiment.stoppable',
         false
       )
     })

--- a/extension/src/util/number.test.ts
+++ b/extension/src/util/number.test.ts
@@ -11,6 +11,11 @@ describe('createInteger', () => {
     expect(integer).toStrictEqual(1234)
   })
 
+  it('should create an integer from a string with a space at the start', () => {
+    const integer = createValidInteger(' 3538')
+    expect(integer).toStrictEqual(3538)
+  })
+
   it('should return undefined if the string does not represent an integer', () => {
     const integer = createValidInteger('1234.0001')
     expect(integer).toBeUndefined()

--- a/extension/src/vscode/context.ts
+++ b/extension/src/vscode/context.ts
@@ -7,7 +7,6 @@ export enum ContextKey {
   EXPERIMENT_FILTERS_SELECTED = 'dvc.experiments.filter.selected',
   EXPERIMENTS_WEBVIEW_ACTIVE = 'dvc.experiments.webview.active',
   EXPERIMENT_RUNNING = 'dvc.experiment.running',
-  EXPERIMENT_STOPPABLE = 'dvc.experiment.stoppable',
   EXPERIMENTS_FILTERED = 'dvc.experiments.filtered',
   EXPERIMENTS_SORTED = 'dvc.experiments.sorted',
   MULTIPLE_PROJECTS = 'dvc.multiple.projects',


### PR DESCRIPTION
This PR uses the value provided in `.dvc/exps/rwlock.lock` to stop experiments which are running in the workspace. This means we can now stop experiments that are started outside of the extension context.

### Demo

https://user-images.githubusercontent.com/37993418/217414543-40b7d27d-a1b6-489e-925c-767e1ccc98dd.mov

I'll follow up to add an option to stop experiments running in the workspace from the table's context menu.

Related to https://github.com/iterative/dvc/issues/8963.