### PR TITLE
Improve vega bindings color (smooth template)

### DIFF
--- a/webview/src/plots/components/styles.module.scss
+++ b/webview/src/plots/components/styles.module.scss
@@ -48,7 +48,8 @@ $gap: 20px;
   position: absolute;
   bottom: 0;
   width: 100%;
-  background-color: $fg-color;
+  background-color: $plot-block-bg-color;
+  color: $fg-color;
   padding: 10px;
   display: none;
 


### PR DESCRIPTION
Related to #3223. 

Whilst not perfect I think the color change makes the slider look better overall.

## Screenshots

### Before

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/37993418/217510138-ec78926c-1e86-4312-950c-088a0cea0793.png">

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/37993418/217510239-71508f7f-6eca-4562-afd0-dd91c612799f.png">

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/37993418/217510327-43611cd7-1c49-4818-b7c1-b125c0ee0b6f.png">

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/37993418/217510051-cedffc1e-5570-431c-a4ae-314184a7f112.png">


### After 

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/37993418/217509499-ed0c4fa8-4bfa-46a7-bd83-6ab5a8456c82.png">

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/37993418/217509576-e13243f0-97f8-4e7b-a401-7af532d00676.png">

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/37993418/217509676-8368ad09-fb2c-4704-85b4-7091635fa391.png">

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/37993418/217510548-9ca123da-4d6d-4a8e-ad64-c58f74f270b7.png">
