### PR TITLE
Add missing telemetry events to onboarding

### DIFF
--- a/extension/src/setup/webview/messages.ts
+++ b/extension/src/setup/webview/messages.ts
@@ -67,9 +67,9 @@ export class WebviewMessages {
       case MessageFromWebviewType.INITIALIZE_DVC:
         return this.initializeDvc()
       case MessageFromWebviewType.INITIALIZE_GIT:
-        return this.initializeGit()
+        return this.gitInit()
       case MessageFromWebviewType.SHOW_SCM_PANEL:
-        return commands.executeCommand('workbench.view.scm')
+        return this.showScmForCommit()
       case MessageFromWebviewType.SELECT_PYTHON_INTERPRETER:
         return this.selectPythonInterpreter()
       case MessageFromWebviewType.INSTALL_DVC:
@@ -81,6 +81,20 @@ export class WebviewMessages {
       default:
         Logger.error(`Unexpected message: ${JSON.stringify(message)}`)
     }
+  }
+
+  private gitInit() {
+    sendTelemetryEvent(EventName.VIEWS_SETUP_INIT_GIT, undefined, undefined)
+    return this.initializeGit()
+  }
+
+  private showScmForCommit() {
+    sendTelemetryEvent(
+      EventName.VIEWS_SETUP_SHOW_SCM_FOR_COMMIT,
+      undefined,
+      undefined
+    )
+    return commands.executeCommand('workbench.view.scm')
   }
 
   private selectPythonInterpreter() {

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -77,9 +77,11 @@ export const EventName = Object.assign(
     VIEWS_SETUP_CLOSE: 'view.setup.closed',
     VIEWS_SETUP_CREATED: 'view.setup.created',
     VIEWS_SETUP_FOCUS_CHANGED: 'views.setup.focusChanged',
+    VIEWS_SETUP_INIT_GIT: 'views.setup.initializeGit',
     VIEWS_SETUP_INSTALL_DVC: 'views.setup.installDvc',
     VIEWS_SETUP_SELECT_PYTHON_INTERPRETER:
       'views.setup.selectPythonInterpreter',
+    VIEWS_SETUP_SHOW_SCM_FOR_COMMIT: 'views.setup.showScmForCommit',
 
     VIEWS_TERMINAL_CLOSED: 'views.terminal.closed',
     VIEWS_TERMINAL_CREATED: 'views.terminal.created',
@@ -266,6 +268,8 @@ export interface IEventNamePropertyMapping {
   [EventName.VIEWS_SETUP_CREATED]: undefined
   [EventName.VIEWS_SETUP_FOCUS_CHANGED]: undefined
   [EventName.VIEWS_SETUP_SELECT_PYTHON_INTERPRETER]: undefined
+  [EventName.VIEWS_SETUP_SHOW_SCM_FOR_COMMIT]: undefined
+  [EventName.VIEWS_SETUP_INIT_GIT]: undefined
   [EventName.VIEWS_SETUP_INSTALL_DVC]: undefined
 
   [EventName.SETUP_SHOW]: undefined


### PR DESCRIPTION
This came up in a discussion with @shcheklein this morning. I checked to see that we had events for all of the actions that a user can take in the onboarding process. There were a couple that was missing so I added them.