### PR TITLE
Rename views tree to actions

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1315,8 +1315,8 @@
           "when": "!dvc.commands.available || dvc.cli.incompatible || !dvc.project.available"
         },
         {
-          "id": "dvc.views.webviews",
-          "name": "Views",
+          "id": "dvc.views.actions",
+          "name": "Actions",
           "when": "true"
         },
         {
@@ -1352,7 +1352,7 @@
     },
     "viewsWelcome": [
       {
-        "view": "dvc.views.webviews",
+        "view": "dvc.views.actions",
         "contents": "[$(beaker) Show Experiments](command:dvc.showExperiments)\n[$(graph-scatter) Show Plots](command:dvc.showPlots)\n[$(play) Run Experiment](command:dvc.runExperiment)"
       },
       {


### PR DESCRIPTION
Follow up to #3272. The `Views` title of the tree view in our sidebar panel no longer makes sense. After discussing with @sroy3 seems like the first alternative is `Actions`.

### Screenshot

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/37993418/218581186-c6f6e0c0-d846-4653-a374-7b76b1148445.png">

Note: I should've picked up on this in review.