### PR TITLE
Ensure that file exists before trying to read mtime

### DIFF
--- a/extension/src/fileSystem/index.test.ts
+++ b/extension/src/fileSystem/index.test.ts
@@ -172,6 +172,12 @@ describe('getModifiedTime', () => {
     expect(typeof epoch).toBe('number')
     expect(epoch).toBeGreaterThan(1640995200000)
   })
+
+  it('should return -1 for a file that does not exist on the system', () => {
+    const epoch = getModifiedTime('not a path')
+
+    expect(epoch).toStrictEqual(-1)
+  })
 })
 
 describe('findOrCreateDvcYamlFile', () => {

--- a/extension/src/fileSystem/index.ts
+++ b/extension/src/fileSystem/index.ts
@@ -36,8 +36,12 @@ export const isDirectory = (path: string): boolean =>
 
 export const isFile = (path: string): boolean => checkStats(path, 'isFile')
 
-export const getModifiedTime = (path: string): number =>
-  lstatSync(path).mtime.getTime()
+export const getModifiedTime = (path: string): number => {
+  if (exists(path)) {
+    return lstatSync(path).mtime.getTime()
+  }
+  return -1
+}
 
 export const findSubRootPaths = async (
   cwd: string,


### PR DESCRIPTION
Possible cause of #3264

Definitely the cause of this error:

<img width="487" alt="image" src="https://user-images.githubusercontent.com/37993418/218344004-5cd0d427-1a82-483b-b862-1551cb59b2d1.png">

What I think is happening here is that when there are a certain number of files written to disk by `plots diff` that the extension can try to access them before `plots diff` is finished/they can be accessed.