### PR TITLE
Update get Studio access token link

### DIFF
--- a/extension/src/connect/index.ts
+++ b/extension/src/connect/index.ts
@@ -90,7 +90,7 @@ export class Connect extends BaseRepository<undefined> {
     if (!username) {
       return
     }
-    return openUrl(`${STUDIO_URL}/user/${username}/profile`)
+    return openUrl(`${STUDIO_URL}/user/${username}/profile#accessToken`)
   }
 
   private async setContext() {

--- a/extension/src/test/suite/connect/index.test.ts
+++ b/extension/src/test/suite/connect/index.test.ts
@@ -89,7 +89,9 @@ suite('Connect Test Suite', () => {
 
       await urlOpenedEvent
       expect(mockOpenExternal).to.be.calledWith(
-        Uri.parse(`https://studio.iterative.ai/user/${mockUsername}/profile`)
+        Uri.parse(
+          `https://studio.iterative.ai/user/${mockUsername}/profile#accessToken`
+        )
       )
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 


### PR DESCRIPTION
This PR updates the link used to direct a user to get an access token from Studio.

### Demo

https://user-images.githubusercontent.com/37993418/219618708-f1ba6d87-7107-42d6-baeb-cccc331844ac.mov

Note: Right now the page will not always be scrolled to the correct section but it will be some of the time. This is better than what we have so I think we should go with it.

For context see [this thread](https://iterativeai.slack.com/archives/C01APS0FHDM/p1676595777004649)

Thanks @mvshmakov 

Related to #3077