### PR TITLE
Update link to get Studio access token (drop need for username)

### DIFF
--- a/extension/src/connect/index.ts
+++ b/extension/src/connect/index.ts
@@ -7,7 +7,7 @@ import { ViewKey } from '../webview/constants'
 import { MessageFromWebview, MessageFromWebviewType } from '../webview/contract'
 import { BaseRepository } from '../webview/repository'
 import { Logger } from '../common/logger'
-import { getInput, getValidInput } from '../vscode/inputBox'
+import { getValidInput } from '../vscode/inputBox'
 import { Title } from '../vscode/title'
 import { openUrl } from '../vscode/external'
 import { ContextKey, setContextValue } from '../vscode/context'
@@ -85,12 +85,8 @@ export class Connect extends BaseRepository<undefined> {
     return openUrl(STUDIO_URL)
   }
 
-  private async openStudioProfile() {
-    const username = await getInput(Title.ENTER_STUDIO_USERNAME)
-    if (!username) {
-      return
-    }
-    return openUrl(`${STUDIO_URL}/user/${username}/profile#accessToken`)
+  private openStudioProfile() {
+    return openUrl(`${STUDIO_URL}/user/_/profile?section=accessToken`)
   }
 
   private async setContext() {

--- a/extension/src/test/suite/connect/index.test.ts
+++ b/extension/src/test/suite/connect/index.test.ts
@@ -77,11 +77,8 @@ suite('Connect Test Suite', () => {
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it("should handle a message from the webview to open the user's Studio profile", async () => {
-      const mockUsername = 'username-something-something'
       const { mockMessageReceived, mockOpenExternal, urlOpenedEvent } =
         await buildConnect()
-
-      stub(window, 'showInputBox').resolves(mockUsername)
 
       mockMessageReceived.fire({
         type: MessageFromWebviewType.OPEN_STUDIO_PROFILE
@@ -90,7 +87,7 @@ suite('Connect Test Suite', () => {
       await urlOpenedEvent
       expect(mockOpenExternal).to.be.calledWith(
         Uri.parse(
-          `https://studio.iterative.ai/user/${mockUsername}/profile#accessToken`
+          'https://studio.iterative.ai/user/_/profile?section=accessToken'
         )
       )
     }).timeout(WEBVIEW_TEST_TIMEOUT)


### PR DESCRIPTION
Some déjà vu (#3303). See [this thread](https://iterativeai.slack.com/archives/C01APS0FHDM/p1676595777004649) (again) for more context. 

Improvements from the last version:
1. We no longer need a username from the user
2. The provided link now seems to work 100% of the time.


### Demo


https://user-images.githubusercontent.com/37993418/219848830-e117e9dc-26a4-4878-9a30-3c78dd9720a4.mov

