### PR TITLE
fix: DnD landing breaks on ellipsis

### DIFF
--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -391,11 +391,9 @@ $bullet-size: calc(var(--design-unit) * 4px);
       @extend %truncateLeftParent;
       direction: rtl;
       opacity: 0.6;
-
-      span {
-        // to prevent extra dragLeave and dragEnter fired
-        pointer-events: none;
-      }
+      // to prevent extra dragLeave and dragEnter fired
+      // should be on parent div, not span to work on text-overflow: ellipsis
+      pointer-events: none;
     }
     .cellContents {
       @extend %truncateLeftChild;


### PR DESCRIPTION
Thanks @sroy3 for the hint to check the parent `div` in this case 🙏  Since `text-overflow` belongs to it and `ellipsis` is generated by it. Moving `pointer-events` up to the parent `div` solves the issue:


https://user-images.githubusercontent.com/3659196/219970807-0d0ac1f0-8503-4930-aa7d-a0026b6380ef.mov

