### PR TITLE
Redirect user to add new Studio access token on 401 response

### DIFF
--- a/extension/src/vscode/modal.ts
+++ b/extension/src/vscode/modal.ts
@@ -2,6 +2,7 @@ import { window } from 'vscode'
 import { Response } from './response'
 
 enum Level {
+  ERROR = 'Error',
   INFORMATION = 'Information',
   WARNING = 'Warning'
 }
@@ -13,6 +14,10 @@ export class Modal {
 
   public static warnOfConsequences(text: string, ...items: Response[]) {
     return Modal.show(Level.WARNING, text, ...items)
+  }
+
+  public static errorWithOptions(text: string, ...items: Response[]) {
+    return Modal.show(Level.ERROR, text, ...items)
   }
 
   private static show(


### PR DESCRIPTION
This PR adds a simple unauthorized message when a 401 is received from Studio. The user can then redirect themselves to the Connect to Studio screen in order to add a new token.

### Demo

https://user-images.githubusercontent.com/37993418/219980654-3a6bc9dd-032b-4e51-b338-d273d2d6b0c8.mov

