### PR TITLE
Watch metric files to update plots

### DIFF
--- a/extension/src/plots/data/collect.test.ts
+++ b/extension/src/plots/data/collect.test.ts
@@ -1,0 +1,42 @@
+import { collectMetricsFiles } from './collect'
+import expShowFixture from '../../test/fixtures/expShow/base/output'
+import { ExperimentsOutput } from '../../cli/dvc/contract'
+
+describe('collectMetricsFiles', () => {
+  it('should return the expected metrics files from the test fixture', () => {
+    expect(collectMetricsFiles(expShowFixture, [])).toStrictEqual([
+      'summary.json'
+    ])
+  })
+
+  it('should persist existing files', () => {
+    const existingFiles = ['file.json', 'file.py', 'file.tsv', 'file.txt']
+
+    expect(
+      collectMetricsFiles({ workspace: { baseline: {} } }, existingFiles)
+    ).toStrictEqual(existingFiles)
+  })
+
+  it('should not fail when given an error', () => {
+    const existingFile = ['metrics.json']
+
+    expect(
+      collectMetricsFiles(
+        {
+          workspace: {
+            baseline: { error: { msg: 'I broke', type: 'not important' } }
+          }
+        },
+        existingFile
+      )
+    ).toStrictEqual(existingFile)
+  })
+
+  it('should not fail when given empty output', () => {
+    const existingFiles: string[] = []
+
+    expect(
+      collectMetricsFiles({} as ExperimentsOutput, existingFiles)
+    ).toStrictEqual(existingFiles)
+  })
+})

--- a/extension/src/plots/data/collect.ts
+++ b/extension/src/plots/data/collect.ts
@@ -63,7 +63,7 @@ export const collectMetricsFiles = (
 ): string[] =>
   uniqueValues([
     ...Object.keys({
-      ...data?.workspace.baseline?.data?.metrics
+      ...data?.workspace?.baseline?.data?.metrics
     }).filter(Boolean),
     ...existingFiles
   ]).sort()

--- a/extension/src/plots/data/collect.ts
+++ b/extension/src/plots/data/collect.ts
@@ -1,4 +1,4 @@
-import { PlotsOutputOrError } from '../../cli/dvc/contract'
+import { ExperimentsOutput, PlotsOutputOrError } from '../../cli/dvc/contract'
 import { isDvcError } from '../../cli/dvc/reader'
 import { uniqueValues } from '../../util/array'
 import { isImagePlot, Plot, TemplatePlot } from '../webview/contract'
@@ -56,3 +56,14 @@ export const collectFiles = (
 
   return uniqueValues(acc)
 }
+
+export const collectMetricsFiles = (
+  data: ExperimentsOutput,
+  existingFiles: string[]
+): string[] =>
+  uniqueValues([
+    ...Object.keys({
+      ...data?.workspace.baseline?.data?.metrics
+    }).filter(Boolean),
+    ...existingFiles
+  ]).sort()

--- a/extension/src/plots/data/index.ts
+++ b/extension/src/plots/data/index.ts
@@ -34,7 +34,7 @@ export class PlotsData extends BaseData<{
           process: () => this.update()
         }
       ],
-      ['dvc.yaml', 'dvc.lock', 'metrics.json']
+      ['dvc.yaml', 'dvc.lock']
     )
     this.model = model
   }

--- a/extension/src/plots/data/index.ts
+++ b/extension/src/plots/data/index.ts
@@ -68,6 +68,7 @@ export class PlotsData extends BaseData<{
   public setMetricFiles(data: ExperimentsOutput) {
     const metricsFiles = collectMetricsFiles(data, this.metricFiles)
     if (!sameContents(metricsFiles, this.metricFiles)) {
+      this.metricFiles = metricsFiles
       this.collectedFiles = uniqueValues([
         ...this.collectedFiles,
         ...metricsFiles

--- a/extension/src/plots/data/index.ts
+++ b/extension/src/plots/data/index.ts
@@ -1,12 +1,13 @@
 import { EventEmitter } from 'vscode'
-import { collectFiles } from './collect'
+import { collectMetricsFiles, collectFiles } from './collect'
 import {
   EXPERIMENT_WORKSPACE_ID,
+  ExperimentsOutput,
   PlotsOutputOrError
 } from '../../cli/dvc/contract'
 import { AvailableCommands, InternalCommands } from '../../commands/internal'
 import { BaseData } from '../../data'
-import { flattenUnique, sameContents } from '../../util/array'
+import { flattenUnique, sameContents, uniqueValues } from '../../util/array'
 import { PlotsModel } from '../model'
 
 export class PlotsData extends BaseData<{
@@ -14,6 +15,8 @@ export class PlotsData extends BaseData<{
   revs: string[]
 }> {
   private readonly model: PlotsModel
+
+  private metricFiles: string[] = []
 
   constructor(
     dvcRoot: string,
@@ -60,6 +63,16 @@ export class PlotsData extends BaseData<{
 
   public managedUpdate() {
     return this.processManager.run('update')
+  }
+
+  public setMetricFiles(data: ExperimentsOutput) {
+    const metricsFiles = collectMetricsFiles(data, this.metricFiles)
+    if (!sameContents(metricsFiles, this.metricFiles)) {
+      this.collectedFiles = uniqueValues([
+        ...this.collectedFiles,
+        ...metricsFiles
+      ])
+    }
   }
 
   protected collectFiles({ data }: { data: PlotsOutputOrError }) {


### PR DESCRIPTION
Slightly more involved patch for #3264.

Will cover slightly more cases than #3319 but still has some limitations. For example, if the metrics files are still too deep or if the events are still dropped for these files then we still won't see live updates for plots. We could also get plot updates when we don't need them. I.e when a metrics file is not plotted.

### Demo (built VSIX on Codespaces)

https://user-images.githubusercontent.com/37993418/220228264-73317ed1-8d42-44ad-9f0e-042343e8d785.mov


