### PR TITLE
Direct user to setup when they cannot run an experiment

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1374,7 +1374,13 @@
     "viewsWelcome": [
       {
         "view": "dvc.views.actions",
-        "contents": "[$(beaker) Show Experiments](command:dvc.showExperiments)\n[$(graph-scatter) Show Plots](command:dvc.showPlots)\n[$(play) Run Experiment](command:dvc.runExperiment)"
+        "contents": "[$(beaker) Show Experiments](command:dvc.showExperiments)\n[$(graph-scatter) Show Plots](command:dvc.showPlots)\n[$(play) Run Experiment](command:dvc.runExperiment)",
+        "when": "!dvc.experiment.checkpoints"
+      },
+      {
+        "view": "dvc.views.actions",
+        "contents": "[$(beaker) Show Experiments](command:dvc.showExperiments)\n[$(graph-scatter) Show Plots](command:dvc.showPlots)\n[$(play) Run Experiment](command:dvc.resetAndRunCheckpointExperiment)",
+        "when": "dvc.experiment.checkpoints"
       },
       {
         "view": "dvc.views.studio",

--- a/extension/src/experiments/commands/register.ts
+++ b/extension/src/experiments/commands/register.ts
@@ -289,7 +289,9 @@ const registerExperimentRunCommands = (
 ): void => {
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.EXPERIMENT_RUN,
-    () => experiments.getCwdThenRun(AvailableCommands.EXPERIMENT_RUN, true)
+    showSetupOrExecuteCommand(setup, () =>
+      experiments.getCwdThenRun(AvailableCommands.EXPERIMENT_RUN, true)
+    )
   )
 
   internalCommands.registerExternalCliCommand(
@@ -299,11 +301,12 @@ const registerExperimentRunCommands = (
 
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.EXPERIMENT_RESET_AND_RUN,
-    () =>
+    showSetupOrExecuteCommand(setup, () =>
       experiments.getCwdThenRun(
         AvailableCommands.EXPERIMENT_RESET_AND_RUN,
         true
       )
+    )
   )
 
   internalCommands.registerExternalCliCommand(

--- a/extension/src/test/suite/experiments/workspace.test.ts
+++ b/extension/src/test/suite/experiments/workspace.test.ts
@@ -401,6 +401,7 @@ suite('Workspace Experiments Test Suite', () => {
         DvcRunner.prototype,
         'runExperiment'
       ).resolves(undefined)
+      stub(Setup.prototype, 'shouldBeShown').returns(false)
 
       stubWorkspaceExperimentsGetters(dvcDemoPath)
 
@@ -434,6 +435,7 @@ suite('Workspace Experiments Test Suite', () => {
         DvcRunner.prototype,
         'runExperimentReset'
       ).resolves(undefined)
+      stub(Setup.prototype, 'shouldBeShown').returns(false)
 
       stubWorkspaceExperimentsGetters(dvcDemoPath)
 


### PR DESCRIPTION
The original idea behind this PR was to switch the `Run Experiments` button over to use `dvc.resetAndRunCheckpointExperiment` whenever there are checkpoints in the workspace but I realised that we also need to redirect to the Setup webview when it is not possible to run an experiment.


### Demo

https://user-images.githubusercontent.com/37993418/220248539-c430006e-25e0-4319-aef2-1fccc9cf52aa.mov


https://user-images.githubusercontent.com/37993418/220248587-07d8f195-7305-4034-bb98-90ab08095d0b.mov


