### PR TITLE
Optimize rendering of plots

### DIFF
--- a/webview/src/plots/components/templatePlots/TemplatePlotsGridItem.tsx
+++ b/webview/src/plots/components/templatePlots/TemplatePlotsGridItem.tsx
@@ -1,0 +1,50 @@
+import { AnyAction } from '@reduxjs/toolkit'
+import { Section, TemplatePlotEntry } from 'dvc/src/plots/webview/contract'
+import React, { memo, useMemo } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { VisualizationSpec } from 'react-vega'
+import { changeDisabledDragIds } from './templatePlotsSlice'
+import { ZoomablePlot } from '../ZoomablePlot'
+import { SnapPoints } from '../../hooks/useSnapPoints'
+import { PlotsState } from '../../store'
+
+interface TemplatePlotsGridItemProps {
+  plot: TemplatePlotEntry
+  addEventsOnViewReady: () => void
+  snapPoints: SnapPoints
+  changeSize: (size: number) => AnyAction
+}
+
+const TemplatePlotsGridItemComponent: React.FC<TemplatePlotsGridItemProps> = ({
+  plot,
+  addEventsOnViewReady,
+  snapPoints,
+  changeSize
+}) => {
+  const dispatch = useDispatch()
+  const currentSize = useSelector((state: PlotsState) => state.template.size)
+  const { id, content, multiView } = plot
+  const toggleDrag = (enabled: boolean) => {
+    dispatch(changeDisabledDragIds(enabled ? [] : [id]))
+  }
+  const spec = useMemo(
+    () => ({ ...content, height: 'container', width: 'container' }),
+    [content]
+  ) as VisualizationSpec
+
+  return (
+    <ZoomablePlot
+      id={id}
+      spec={spec}
+      onViewReady={addEventsOnViewReady}
+      toggleDrag={toggleDrag}
+      changeSize={changeSize}
+      currentSnapPoint={currentSize}
+      shouldNotResize={multiView}
+      section={Section.TEMPLATE_PLOTS}
+      snapPoints={snapPoints}
+    />
+  )
+}
+
+export const TemplatePlotsGridItem = memo(TemplatePlotsGridItemComponent)

--- a/webview/src/util/wdyr.ts
+++ b/webview/src/util/wdyr.ts
@@ -5,6 +5,6 @@ import React from 'react'
 if (process.env.NODE_ENV === 'development') {
   const whyDidYouRender = require('@welldone-software/why-did-you-render')
   whyDidYouRender(React, {
-    trackAllPureComponents: true
+    trackAllPureComponents: false
   })
 }


### PR DESCRIPTION
I turned on _Why Did You Render?_ and saw multiple re-rendering due to the spec prop of `ZoomablePlot` it was memoized fine for checkpoint plots, but not at all for template plots. This PR addresses the memoization of the spec of template plots. It is even more beneficial while resizing (more fluid now).


https://user-images.githubusercontent.com/3683420/220441217-3bfe3b17-77f5-42c8-9b04-22639bb8a65b.mov

Resizing is still slow, but it does lag a lot less than it used to.