### PR TITLE
Optimize the plots sections to reduce the number of useless re-renderings

### DIFF
--- a/webview/src/plots/components/templatePlots/TemplatePlots.tsx
+++ b/webview/src/plots/components/templatePlots/TemplatePlots.tsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { MessageFromWebviewType } from 'dvc/src/webview/contract'
 import { AddedSection } from './AddedSection'
 import { TemplatePlotsGrid } from './TemplatePlotsGrid'
-import { PlotGroup, updateUserSections } from './templatePlotsSlice'
+import { PlotGroup, updateSections } from './templatePlotsSlice'
 import { removeFromPreviousAndAddToNewSection } from './util'
 import { sendMessage } from '../../../shared/vscode'
 import { createIDWithIndex, getIDIndex } from '../../../util/ids'
@@ -24,9 +24,7 @@ export enum NewSectionBlock {
 }
 
 export const TemplatePlots: React.FC = () => {
-  const { size, userSections } = useSelector(
-    (state: PlotsState) => state.template
-  )
+  const { size, sections } = useSelector((state: PlotsState) => state.template)
   const draggedOverGroup = useSelector(
     (state: PlotsState) => state.dragAndDrop.draggedOverGroup
   )
@@ -56,7 +54,7 @@ export const TemplatePlots: React.FC = () => {
       /* Although the following dispatch duplicates the work the reducer will do when the state returns 
          from the extension, this is necessary to not see any flickering in the order as the returned state 
          sometimes takes a while to come back */
-      dispatch(updateUserSections(sections))
+      dispatch(updateSections(sections))
       sendReorderMessage(sections)
     },
     [dispatch, sendReorderMessage]
@@ -75,7 +73,7 @@ export const TemplatePlots: React.FC = () => {
       const oldGroupId = getIDIndex(draggedGroup)
       const newGroupId = getIDIndex(groupId)
       const updatedSections = removeFromPreviousAndAddToNewSection(
-        userSections,
+        sections,
         oldGroupId,
         draggedId,
         newGroupId,
@@ -84,30 +82,30 @@ export const TemplatePlots: React.FC = () => {
 
       setSections(updatedSections)
     },
-    [setSections, userSections]
+    [setSections, sections]
   )
 
   const setSectionEntries = useCallback(
     (index: number, entries: string[]) => {
-      const updatedSections = [...userSections]
+      const updatedSections = [...sections]
       updatedSections[index] = {
         ...updatedSections[index],
         entries
       }
       setSections(updatedSections)
     },
-    [setSections, userSections]
+    [setSections, sections]
   )
 
   if (sectionIsLoading(selectedRevisions)) {
     return <LoadingSection />
   }
-  if (!userSections || userSections.length === 0) {
+  if (!sections || sections.length === 0) {
     return <EmptyState isFullScreen={false}>No Plots to Display</EmptyState>
   }
 
-  const firstSection = userSections[0]
-  const lastSection = userSections.slice(-1)[0]
+  const firstSection = sections[0]
+  const lastSection = sections.slice(-1)[0]
 
   if (!firstSection || !lastSection) {
     return null
@@ -121,12 +119,12 @@ export const TemplatePlots: React.FC = () => {
     const draggedId = draggedRef.itemId
 
     const updatedSections = removeFromPreviousAndAddToNewSection(
-      userSections,
+      sections,
       draggedSectionId,
       draggedId
     )
 
-    const { group } = userSections[draggedSectionId]
+    const { group } = sections[draggedSectionId]
 
     setHoveredSection('')
     const newSection = {
@@ -163,7 +161,7 @@ export const TemplatePlots: React.FC = () => {
         id={NewSectionBlock.TOP}
         closestSection={firstSection}
       />
-      {userSections.map((section, i) => {
+      {sections.map((section, i) => {
         const groupId = createIDWithIndex(section.group, i)
         const useVirtualizedGrid = shouldUseVirtualizedGrid(
           Object.keys(section.entries).length,
@@ -186,11 +184,11 @@ export const TemplatePlots: React.FC = () => {
 
           if (draggedRef.group === groupId) {
             const order = section.entries
-            const updatedSections = [...userSections]
+            const updatedSections = [...sections]
 
             const newOrder = changeOrderWithDraggedInfo(order, draggedRef)
             updatedSections[i] = {
-              ...userSections[i],
+              ...sections[i],
               entries: newOrder
             }
             setSections(updatedSections)

--- a/webview/src/plots/components/templatePlots/TemplatePlotsGrid.tsx
+++ b/webview/src/plots/components/templatePlots/TemplatePlotsGrid.tsx
@@ -1,6 +1,6 @@
 import cx from 'classnames'
 import { Section } from 'dvc/src/plots/webview/contract'
-import React, { useEffect, useState, useCallback, useMemo } from 'react'
+import React, { useEffect, useCallback, useMemo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { changeDisabledDragIds, changeSize } from './templatePlotsSlice'
 import { VirtualizedGrid } from '../../../shared/components/virtualizedGrid/VirtualizedGrid'
@@ -24,7 +24,6 @@ interface TemplatePlotsGridProps {
   setSectionEntries: (groupIndex: number, entries: string[]) => void
   useVirtualizedGrid?: boolean
   nbItemsPerRow: number
-  entries: string[]
   parentDraggedOver?: boolean
 }
 
@@ -36,12 +35,13 @@ export const TemplatePlotsGrid: React.FC<TemplatePlotsGridProps> = ({
   setSectionEntries,
   useVirtualizedGrid,
   nbItemsPerRow,
-  entries,
   parentDraggedOver
 }) => {
   const dispatch = useDispatch()
-  const [order, setOrder] = useState<string[]>([])
   const currentSize = useSelector((state: PlotsState) => state.template.size)
+  const entries = useSelector(
+    (state: PlotsState) => state.template.userSections[groupIndex].entries
+  )
 
   const disabledDragPlotIds = useSelector(
     (state: PlotsState) => state.template.disabledDragPlotIds
@@ -65,10 +65,6 @@ export const TemplatePlotsGrid: React.FC<TemplatePlotsGridProps> = ({
   }, [])
 
   useEffect(() => {
-    setOrder(entries)
-  }, [entries])
-
-  useEffect(() => {
     const panels = document.querySelectorAll('.vega-bindings')
     return () => {
       for (const panel of Object.values(panels)) {
@@ -88,11 +84,8 @@ export const TemplatePlotsGrid: React.FC<TemplatePlotsGridProps> = ({
     }
   }, [addDisabled, removeDisabled, disableClick])
 
-  const setEntriesOrder = (order: string[]) => {
-    setOrder(order)
-
+  const setEntriesOrder = (order: string[]) =>
     setSectionEntries(groupIndex, order)
-  }
 
   const plotClassName = cx(styles.plot, {
     [styles.multiViewPlot]: multiView
@@ -107,7 +100,7 @@ export const TemplatePlotsGrid: React.FC<TemplatePlotsGridProps> = ({
 
   const items = useMemo(
     () =>
-      order.map((plot: string) => {
+      entries.map((plot: string) => {
         const colSpan =
           (multiView &&
             plotDataStore[Section.TEMPLATE_PLOTS][plot].revisions?.length) ||
@@ -134,7 +127,7 @@ export const TemplatePlotsGrid: React.FC<TemplatePlotsGridProps> = ({
         )
       }),
     [
-      order,
+      entries,
       plotClassName,
       addEventsOnViewReady,
       currentSize,
@@ -145,7 +138,7 @@ export const TemplatePlotsGrid: React.FC<TemplatePlotsGridProps> = ({
 
   return (
     <DragDropContainer
-      order={order}
+      order={entries}
       setOrder={setEntriesOrder}
       items={items}
       group={groupId}

--- a/webview/src/plots/components/templatePlots/TemplatePlotsGrid.tsx
+++ b/webview/src/plots/components/templatePlots/TemplatePlotsGrid.tsx
@@ -40,7 +40,7 @@ export const TemplatePlotsGrid: React.FC<TemplatePlotsGridProps> = ({
   const dispatch = useDispatch()
   const currentSize = useSelector((state: PlotsState) => state.template.size)
   const entries = useSelector(
-    (state: PlotsState) => state.template.userSections[groupIndex].entries
+    (state: PlotsState) => state.template.sections[groupIndex].entries
   )
 
   const disabledDragPlotIds = useSelector(

--- a/webview/src/plots/components/templatePlots/templatePlotsSlice.ts
+++ b/webview/src/plots/components/templatePlots/templatePlotsSlice.ts
@@ -13,7 +13,7 @@ export interface TemplatePlotsState extends Omit<TemplatePlotsData, 'plots'> {
   isCollapsed: boolean
   hasData: boolean
   plotsSnapshots: { [key: string]: string }
-  userSections: PlotGroup[]
+  sections: PlotGroup[]
   disabledDragPlotIds: string[]
 }
 
@@ -22,8 +22,8 @@ export const templatePlotsInitialState: TemplatePlotsState = {
   hasData: false,
   isCollapsed: DEFAULT_SECTION_COLLAPSED[Section.TEMPLATE_PLOTS],
   plotsSnapshots: {},
-  size: DEFAULT_SECTION_SIZES[Section.TEMPLATE_PLOTS],
-  userSections: []
+  sections: [],
+  size: DEFAULT_SECTION_SIZES[Section.TEMPLATE_PLOTS]
 }
 
 export const templatePlotsSlice = createSlice({
@@ -58,17 +58,17 @@ export const templatePlotsSlice = createSlice({
         ...state,
         hasData: !!action.payload,
         plotsSnapshots: snapShots,
-        size: Math.abs(action.payload.size),
-        userSections:
-          JSON.stringify(plotSections) === JSON.stringify(state.userSections)
-            ? state.userSections
-            : plotSections
+        sections:
+          JSON.stringify(plotSections) === JSON.stringify(state.sections)
+            ? state.sections
+            : plotSections,
+        size: Math.abs(action.payload.size)
       }
     },
-    updateUserSections: (state, action: PayloadAction<PlotGroup[]>) => {
+    updateSections: (state, action: PayloadAction<PlotGroup[]>) => {
       return {
         ...state,
-        userSections: action.payload
+        sections: action.payload
       }
     }
   }
@@ -79,7 +79,7 @@ export const {
   setCollapsed,
   changeSize,
   changeDisabledDragIds,
-  updateUserSections
+  updateSections
 } = templatePlotsSlice.actions
 
 export default templatePlotsSlice.reducer

--- a/webview/src/plots/components/templatePlots/templatePlotsSlice.ts
+++ b/webview/src/plots/components/templatePlots/templatePlotsSlice.ts
@@ -12,8 +12,8 @@ export type PlotGroup = { group: TemplatePlotGroup; entries: string[] }
 export interface TemplatePlotsState extends Omit<TemplatePlotsData, 'plots'> {
   isCollapsed: boolean
   hasData: boolean
-  plotSections: PlotGroup[]
   plotsSnapshots: { [key: string]: string }
+  userSections: PlotGroup[]
   disabledDragPlotIds: string[]
 }
 
@@ -21,9 +21,9 @@ export const templatePlotsInitialState: TemplatePlotsState = {
   disabledDragPlotIds: [],
   hasData: false,
   isCollapsed: DEFAULT_SECTION_COLLAPSED[Section.TEMPLATE_PLOTS],
-  plotSections: [],
   plotsSnapshots: {},
-  size: DEFAULT_SECTION_SIZES[Section.TEMPLATE_PLOTS]
+  size: DEFAULT_SECTION_SIZES[Section.TEMPLATE_PLOTS],
+  userSections: []
 }
 
 export const templatePlotsSlice = createSlice({
@@ -48,6 +48,7 @@ export const templatePlotsSlice = createSlice({
         entries: section.entries.map(entry => entry.id),
         group: section.group
       }))
+
       const plots = action.payload.plots?.flatMap(section => section.entries)
       const plotsIds = plots?.map(plot => plot.id) || []
       const snapShots = addPlotsWithSnapshots(plots, Section.TEMPLATE_PLOTS)
@@ -56,15 +57,29 @@ export const templatePlotsSlice = createSlice({
       return {
         ...state,
         hasData: !!action.payload,
-        plotSections,
         plotsSnapshots: snapShots,
-        size: Math.abs(action.payload.size)
+        size: Math.abs(action.payload.size),
+        userSections:
+          JSON.stringify(plotSections) === JSON.stringify(state.userSections)
+            ? state.userSections
+            : plotSections
+      }
+    },
+    updateUserSections: (state, action: PayloadAction<PlotGroup[]>) => {
+      return {
+        ...state,
+        userSections: action.payload
       }
     }
   }
 })
 
-export const { update, setCollapsed, changeSize, changeDisabledDragIds } =
-  templatePlotsSlice.actions
+export const {
+  update,
+  setCollapsed,
+  changeSize,
+  changeDisabledDragIds,
+  updateUserSections
+} = templatePlotsSlice.actions
 
 export default templatePlotsSlice.reducer


### PR DESCRIPTION
Part of #3334 

### Demo before


https://user-images.githubusercontent.com/3683420/221030411-bd441d74-d36f-4d4d-ae47-5aad60815935.mov

### Demo now


https://user-images.githubusercontent.com/3683420/221030697-e30fe089-db23-4776-a15f-d382147f3efc.mov



Not a big improvement, but this should add up with the number of plots and it should make the code a little easier to read.
