### PR TITLE
Add show logs to context menu of experiments running in the queue

### DIFF
--- a/extension/src/cli/dvc/constants.ts
+++ b/extension/src/cli/dvc/constants.ts
@@ -67,6 +67,7 @@ export enum ExperimentSubCommand {
 
 export enum QueueSubCommand {
   KILL = 'kill',
+  LOGS = 'logs',
   START = 'start',
   STOP = 'stop'
 }

--- a/extension/src/cli/dvc/runner.ts
+++ b/extension/src/cli/dvc/runner.ts
@@ -9,13 +9,13 @@ import { getOptions } from './options'
 import { CliResult, CliStarted, ICli, typeCheckCommands } from '..'
 import { getCommandString } from '../command'
 import { Config } from '../../config'
-import { PseudoTerminal } from '../../vscode/pseudoTerminal'
 import { createProcess, Process } from '../../processExecution'
 import { StopWatch } from '../../util/time'
 import { sendErrorTelemetryEvent, sendTelemetryEvent } from '../../telemetry'
 import { EventName } from '../../telemetry/constants'
 import { Toast } from '../../vscode/toast'
 import { Disposable } from '../../class/dispose'
+import { MultiUsePseudoTerminal } from '../../vscode/pseudoTerminal/multiUse'
 
 export const autoRegisteredCommands = {
   EXPERIMENT_RESET_AND_RUN: 'runExperimentReset',
@@ -41,7 +41,7 @@ export class DvcRunner extends Disposable implements ICli {
 
   private readonly executable: string | undefined
 
-  private readonly pseudoTerminal: PseudoTerminal
+  private readonly pseudoTerminal: MultiUsePseudoTerminal
   private currentProcess: Process | undefined
   private readonly config: Config
 
@@ -94,7 +94,7 @@ export class DvcRunner extends Disposable implements ICli {
     )
 
     this.pseudoTerminal = this.dispose.track(
-      new PseudoTerminal(this.processOutput, this.processTerminated)
+      new MultiUsePseudoTerminal(this.processOutput, this.processTerminated)
     )
   }
 

--- a/extension/src/cli/dvc/viewer.ts
+++ b/extension/src/cli/dvc/viewer.ts
@@ -2,15 +2,9 @@ import { EventEmitter, Event } from 'vscode'
 import { Args, Command, QueueSubCommand } from './constants'
 import { getOptions } from './options'
 import { CliResult, CliStarted, ICli, typeCheckCommands } from '..'
-import { getCommandString } from '../command'
 import { Config } from '../../config'
-import { PseudoTerminal } from '../../vscode/pseudoTerminal'
-import { createProcess, Process } from '../../processExecution'
-import { StopWatch } from '../../util/time'
-import { sendErrorTelemetryEvent, sendTelemetryEvent } from '../../telemetry'
-import { EventName } from '../../telemetry/constants'
-import { Toast } from '../../vscode/toast'
 import { Disposable } from '../../class/dispose'
+import { SingleUsePseudoTerminal } from '../../vscode/pseudoTerminal/singleUse'
 
 export const autoRegisteredCommands = {
   QUEUE_LOGS: 'queueLogs'
@@ -28,232 +22,62 @@ export class DvcViewer extends Disposable implements ICli {
   public readonly processStarted: EventEmitter<CliStarted>
   public readonly onDidStartProcess: Event<CliStarted>
 
-  private readonly processOutput: EventEmitter<string>
+  private processes: {
+    [key: string]: SingleUsePseudoTerminal
+  }
 
-  private readonly processTerminated: EventEmitter<string>
-  private readonly onDidTerminateProcess: Event<string>
-
-  private readonly executable: string | undefined
-
-  private readonly pseudoTerminal: PseudoTerminal
-  private currentProcess: Process | undefined
   private readonly config: Config
 
-  constructor(
-    config: Config,
-    executable?: string,
-    emitters?: {
-      processCompleted: EventEmitter<CliResult>
-      processOutput: EventEmitter<string>
-      processStarted: EventEmitter<CliStarted>
-      processTerminated?: EventEmitter<string>
-    }
-  ) {
+  constructor(config: Config) {
     super()
 
     this.config = config
 
-    this.executable = executable
+    this.processes = {}
 
-    this.processCompleted =
-      emitters?.processCompleted ||
-      this.dispose.track(new EventEmitter<CliResult>())
+    this.processCompleted = this.dispose.track(new EventEmitter<CliResult>())
     this.onDidCompleteProcess = this.processCompleted.event
-    this.dispose.track(
-      this.onDidCompleteProcess(() => {
-        this.pseudoTerminal.setBlocked(false)
-        this.processOutput.fire('\r\nPress any key to close\r\n\n')
-        this.currentProcess = undefined
-      })
-    )
 
-    this.processOutput =
-      emitters?.processOutput || this.dispose.track(new EventEmitter<string>())
-
-    this.processStarted =
-      emitters?.processStarted ||
-      this.dispose.track(new EventEmitter<CliStarted>())
+    this.processStarted = this.dispose.track(new EventEmitter<CliStarted>())
     this.onDidStartProcess = this.processStarted.event
-
-    this.processTerminated =
-      emitters?.processTerminated ||
-      this.dispose.track(new EventEmitter<string>())
-    this.onDidTerminateProcess = this.processTerminated.event
-    this.dispose.track(
-      this.onDidTerminateProcess(() => {
-        void this.stop()
-      })
-    )
-
-    this.pseudoTerminal = this.dispose.track(
-      new PseudoTerminal(this.processOutput, this.processTerminated)
-    )
   }
 
-  public async run(cwd: string, ...args: Args) {
-    if (this.isProcessRunning()) {
-      await this.stop()
+  public run(cwd: string, ...args: Args) {
+    const viewableProcess = this.getRunningProcess(cwd, ...args)
+    if (viewableProcess) {
+      return viewableProcess.show()
     }
 
-    await this.pseudoTerminal.openCurrentInstance()
-    if (!this.pseudoTerminal.isBlocked()) {
-      return this.startProcess(cwd, args)
-    }
-    void Toast.showError(
-      `Cannot start dvc ${args.join(
-        ' '
-      )} as the output terminal is already occupied.`
-    )
+    return this.viewProcess(cwd, args)
   }
 
   public queueLogs(cwd: string, expName: string) {
     return this.run(cwd, Command.QUEUE, QueueSubCommand.LOGS, expName, '-f')
   }
 
-  public stop() {
-    const stopped = new Promise<boolean>(resolve => {
-      if (!this.currentProcess) {
-        return resolve(false)
-      }
-      const listener = this.dispose.track(
-        this.currentProcess.onDidDispose(disposed => {
-          this.dispose.untrack(listener)
-          listener?.dispose()
-          this.pseudoTerminal.close()
-          resolve(disposed)
-        })
+  public getRunningProcess(cwd: string, ...args: Args) {
+    return this.processes[[cwd, ...args].join('')]
+  }
+
+  private viewProcess(cwd: string, args: Args) {
+    const pseudoTerminal = this.dispose.track(
+      new SingleUsePseudoTerminal(
+        `DVC: ${args.join(' ')}`,
+        this.getOptions(cwd, args),
+        this.processStarted,
+        this.processCompleted
       )
-    })
-
-    try {
-      this.currentProcess?.dispose()
-    } catch {}
-
-    return stopped
-  }
-
-  public isProcessRunning() {
-    return !!this.currentProcess
-  }
-
-  private getOverrideOrCliPath() {
-    if (this.executable) {
-      return this.executable
-    }
-    return this.config.getCliPath()
-  }
-
-  private createProcess({ cwd, args }: { cwd: string; args: Args }): Process {
-    const options = this.getOptions(cwd, args)
-    const command = getCommandString(options)
-    const stopWatch = new StopWatch()
-    const process = this.dispose.track(createProcess(options))
-    const baseEvent = { command, cwd, pid: process.pid }
-
-    this.processStarted.fire(baseEvent)
-
-    this.notifyOutput(process)
-
-    let stderr = ''
-    process.stderr?.on(
-      'data',
-      chunk => (stderr += (chunk as Buffer).toString())
     )
 
-    void process.on('close', exitCode => {
-      void this.dispose.untrack(process)
-      this.notifyCompleted({
-        ...baseEvent,
-        duration: stopWatch.getElapsedTime(),
-        exitCode,
-        killed: process.killed,
-        stderr
-      })
-    })
-
-    return process
+    this.processes[[cwd, ...args].join('')] = pseudoTerminal
   }
 
   private getOptions(cwd: string, args: Args) {
     return getOptions(
       this.config.getPythonBinPath(),
-      this.getOverrideOrCliPath(),
+      this.config.getCliPath(),
       cwd,
       ...args
-    )
-  }
-
-  private startProcess(cwd: string, args: Args) {
-    this.pseudoTerminal.setBlocked(true)
-    this.processOutput.fire(`Running: dvc ${args.join(' ')}\r\n\n`)
-    this.currentProcess = this.createProcess({
-      args,
-      cwd
-    })
-  }
-
-  private notifyOutput(process: Process) {
-    process.all?.on('data', chunk =>
-      this.processOutput.fire(
-        (chunk as Buffer)
-          .toString()
-          .split(/(\r?\n)/g)
-          .join('\r')
-      )
-    )
-  }
-
-  private notifyCompleted({
-    command,
-    pid,
-    cwd,
-    duration,
-    exitCode,
-    killed,
-    stderr
-  }: CliResult & {
-    killed: boolean
-  }) {
-    this.processCompleted.fire({
-      command,
-      cwd,
-      duration,
-      exitCode,
-      pid,
-      stderr: stderr?.replace(/\n+/g, '\n')
-    })
-
-    this.sendTelemetryEvent({ command, duration, exitCode, killed, stderr })
-  }
-
-  private sendTelemetryEvent({
-    command,
-    exitCode,
-    stderr,
-    duration,
-    killed
-  }: {
-    command: string
-    exitCode: number | null
-    stderr?: string
-    duration: number
-    killed: boolean
-  }) {
-    const properties = { command, exitCode }
-
-    if (!killed && exitCode && stderr) {
-      return sendErrorTelemetryEvent(
-        EventName.EXPERIMENTS_RUNNER_COMPLETED,
-        new Error(stderr),
-        duration,
-        properties
-      )
-    }
-
-    return sendTelemetryEvent(
-      EventName.EXPERIMENTS_RUNNER_COMPLETED,
-      { ...properties, wasStopped: killed },
-      { duration }
     )
   }
 }

--- a/extension/src/commands/external.ts
+++ b/extension/src/commands/external.ts
@@ -19,6 +19,7 @@ export enum RegisteredCliCommands {
   EXPERIMENT_VIEW_REMOVE = 'dvc.views.experiments.removeExperiment',
   EXPERIMENT_VIEW_SHARE_AS_BRANCH = 'dvc.views.experiments.shareExperimentAsBranch',
   EXPERIMENT_VIEW_SHARE_AS_COMMIT = 'dvc.views.experiments.shareExperimentAsCommit',
+  EXPERIMENT_VIEW_SHOW_LOGS = 'dvc.views.experiments.showLog',
   EXPERIMENT_VIEW_STOP = 'dvc.views.experiments.stopQueueExperiment',
 
   EXPERIMENT_VIEW_QUEUE = 'dvc.views.experiments.queueExperiment',

--- a/extension/src/commands/internal.ts
+++ b/extension/src/commands/internal.ts
@@ -2,9 +2,10 @@ import { commands } from 'vscode'
 import { RegisteredCliCommands, RegisteredCommands } from './external'
 import { ICli } from '../cli'
 import { Args } from '../cli/constants'
-import { autoRegisteredCommands as CliExecutorCommands } from '../cli/dvc/executor'
-import { autoRegisteredCommands as CliReaderCommands } from '../cli/dvc/reader'
-import { autoRegisteredCommands as dvcRunnerCommands } from '../cli/dvc/runner'
+import { autoRegisteredCommands as DvcExecutorCommands } from '../cli/dvc/executor'
+import { autoRegisteredCommands as DvcReaderCommands } from '../cli/dvc/reader'
+import { autoRegisteredCommands as DvcRunnerCommands } from '../cli/dvc/runner'
+import { autoRegisteredCommands as DvcLoggerCommands } from '../cli/dvc/viewer'
 import { autoRegisteredCommands as GitExecutorCommands } from '../cli/git/executor'
 import { autoRegisteredCommands as GitReaderCommands } from '../cli/git/reader'
 import { sendTelemetryEvent, sendTelemetryEventAndThrow } from '../telemetry'
@@ -18,14 +19,16 @@ type Command = (...args: Args) => unknown | Promise<unknown>
 
 export const AvailableCommands = Object.assign(
   { EXP_PUSH: 'expPush' } as const,
-  CliExecutorCommands,
-  CliReaderCommands,
-  dvcRunnerCommands,
+  DvcExecutorCommands,
+  DvcReaderCommands,
+  DvcRunnerCommands,
+  DvcLoggerCommands,
   GitExecutorCommands,
   GitReaderCommands
-) as typeof CliExecutorCommands &
-  typeof CliReaderCommands &
-  typeof dvcRunnerCommands &
+) as typeof DvcExecutorCommands &
+  typeof DvcReaderCommands &
+  typeof DvcRunnerCommands &
+  typeof DvcLoggerCommands &
   typeof GitExecutorCommands &
   typeof GitReaderCommands & { EXP_PUSH: 'expPush' }
 export type CommandId =

--- a/extension/src/experiments/commands/register.ts
+++ b/extension/src/experiments/commands/register.ts
@@ -350,4 +350,10 @@ export const registerExperimentCommands = (
     RegisteredCommands.EXPERIMENT_VIEW_SHARE_TO_STUDIO,
     getShareExperimentToStudioCommand(internalCommands, connect)
   )
+
+  internalCommands.registerExternalCliCommand(
+    RegisteredCliCommands.EXPERIMENT_VIEW_SHOW_LOGS,
+    ({ dvcRoot, id }: ExperimentDetails) =>
+      internalCommands.executeCommand(AvailableCommands.QUEUE_LOGS, dvcRoot, id)
+  )
 }

--- a/extension/src/experiments/webview/messages.ts
+++ b/extension/src/experiments/webview/messages.ts
@@ -190,6 +190,15 @@ export class WebviewMessages {
           { dvcRoot: this.dvcRoot, id: message.payload }
         )
 
+      case MessageFromWebviewType.SHOW_EXPERIMENT_LOGS:
+        return commands.executeCommand(
+          RegisteredCliCommands.EXPERIMENT_VIEW_SHOW_LOGS,
+          {
+            dvcRoot: this.dvcRoot,
+            id: message.payload
+          }
+        )
+
       default:
         Logger.error(`Unexpected message: ${JSON.stringify(message)}`)
     }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -55,6 +55,7 @@ import { Flag } from './cli/dvc/constants'
 import { LanguageClient } from './languageClient'
 import { collectRunningExperimentPids } from './experiments/processExecution/collect'
 import { registerPatchCommand } from './patch'
+import { DvcViewer } from './cli/dvc/viewer'
 export class Extension extends Disposable {
   protected readonly internalCommands: InternalCommands
 
@@ -68,6 +69,7 @@ export class Extension extends Disposable {
   private readonly dvcExecutor: DvcExecutor
   private readonly dvcReader: DvcReader
   private readonly dvcRunner: DvcRunner
+  private readonly dvcLogger: DvcViewer
   private readonly gitExecutor: GitExecutor
   private readonly gitReader: GitReader
 
@@ -95,6 +97,7 @@ export class Extension extends Disposable {
     this.dvcExecutor = this.dispose.track(new DvcExecutor(config))
     this.dvcReader = this.dispose.track(new DvcReader(config))
     this.dvcRunner = this.dispose.track(new DvcRunner(config))
+    this.dvcLogger = this.dispose.track(new DvcViewer(config))
 
     this.gitExecutor = this.dispose.track(new GitExecutor())
     this.gitReader = this.dispose.track(new GitReader())
@@ -103,6 +106,7 @@ export class Extension extends Disposable {
       this.dvcExecutor,
       this.dvcReader,
       this.dvcRunner,
+      this.dvcLogger,
       this.gitExecutor,
       this.gitReader
     ]

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -27,6 +27,8 @@ export const EventName = Object.assign(
     EXTENSION_EXECUTION_DETAILS_CHANGED: 'extension.executionDetails.changed',
     EXTENSION_LOAD: 'extension.load',
 
+    PROCESS_VIEWER_COMPLETED: 'process.viewer.completed',
+
     VIEWS_CONNECT_CLOSED: 'views.connect.closed',
     VIEWS_CONNECT_CREATED: 'views.connect.created',
     VIEWS_CONNECT_FOCUS_CHANGED: 'views.connect.focusChanged',
@@ -119,6 +121,11 @@ export interface IEventNamePropertyMapping {
   [EventName.EXTENSION_LOAD]: ExtensionProperties
 
   [EventName.EXPERIMENTS_RUNNER_COMPLETED]: {
+    command: string
+    exitCode: number | null
+    wasStopped?: boolean
+  }
+  [EventName.PROCESS_VIEWER_COMPLETED]: {
     command: string
     exitCode: number | null
     wasStopped?: boolean

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -156,6 +156,7 @@ export interface IEventNamePropertyMapping {
   [EventName.EXPERIMENT_VIEW_SHARE_AS_BRANCH]: undefined
   [EventName.EXPERIMENT_VIEW_SHARE_AS_COMMIT]: undefined
   [EventName.EXPERIMENT_VIEW_SHARE_TO_STUDIO]: undefined
+  [EventName.EXPERIMENT_VIEW_SHOW_LOGS]: undefined
   [EventName.EXPERIMENT_VIEW_STOP]: undefined
   [EventName.QUEUE_EXPERIMENT]: undefined
   [EventName.QUEUE_KILL]: undefined

--- a/extension/src/test/suite/vscode/pseudoTerminal.test.ts
+++ b/extension/src/test/suite/vscode/pseudoTerminal.test.ts
@@ -34,7 +34,7 @@ suite('Pseudo Terminal Test Suite', () => {
       const pseudoTerminal = disposable.track(
         new PseudoTerminal(
           disposable.track(new EventEmitter<string>()),
-          disposable.track(new EventEmitter<void>()),
+          disposable.track(new EventEmitter<string>()),
           terminalName
         )
       )

--- a/extension/src/vscode/pseudoTerminal.ts
+++ b/extension/src/vscode/pseudoTerminal.ts
@@ -10,13 +10,13 @@ export class PseudoTerminal extends Disposable {
   private blocked: boolean
 
   private readonly processOutput: EventEmitter<string>
-  private readonly processTerminated: EventEmitter<void>
+  private readonly processTerminated: EventEmitter<string>
 
   private isActive = false
 
   constructor(
     processOutput: EventEmitter<string>,
-    processTerminated: EventEmitter<void>,
+    processTerminated: EventEmitter<string>,
     termName = 'DVC'
   ) {
     super()
@@ -75,7 +75,7 @@ export class PseudoTerminal extends Disposable {
     new Promise<void>(resolve => {
       const pty: Pseudoterminal = {
         close: () => {
-          this.processTerminated.fire()
+          this.processTerminated.fire(this.termName)
           this.setBlocked(false)
         },
         handleInput: data => {

--- a/extension/src/vscode/pseudoTerminal/base.ts
+++ b/extension/src/vscode/pseudoTerminal/base.ts
@@ -1,0 +1,126 @@
+import { EventEmitter, Pseudoterminal, Terminal, window } from 'vscode'
+import { sendTelemetryEvent } from '../../telemetry'
+import { EventName } from '../../telemetry/constants'
+import { Disposable } from '../../class/dispose'
+
+export class BasePseudoTerminal extends Disposable {
+  protected instance: Terminal | undefined
+  protected readonly processOutput: EventEmitter<string>
+
+  private readonly termName: string
+
+  private blocked: boolean
+
+  private readonly processTerminated: EventEmitter<string>
+
+  private isActive = false
+
+  constructor(
+    processOutput: EventEmitter<string>,
+    processTerminated: EventEmitter<string>,
+    termName = 'DVC'
+  ) {
+    super()
+
+    this.termName = termName
+    this.processOutput = processOutput
+    this.processTerminated = processTerminated
+    this.blocked = false
+
+    this.deleteReferenceOnClose()
+
+    this.notifyActiveStatus()
+  }
+
+  public isBlocked() {
+    return this.blocked
+  }
+
+  public setBlocked(blocked: boolean) {
+    this.blocked = blocked
+  }
+
+  public close() {
+    const currentTerminal = this.instance
+    if (currentTerminal) {
+      currentTerminal.dispose()
+    }
+  }
+
+  protected createInstance() {
+    return new Promise<void>(resolve => {
+      const pty: Pseudoterminal = {
+        close: () => {
+          this.processTerminated.fire(this.termName)
+          this.setBlocked(false)
+        },
+        handleInput: data => {
+          if (!this.isBlocked() && data) {
+            this.close()
+          }
+        },
+        onDidWrite: this.processOutput.event,
+        open: () => {
+          this.processOutput.fire('>>>> DVC Terminal >>>>\r\n\n')
+
+          sendTelemetryEvent(
+            EventName.VIEWS_TERMINAL_CREATED,
+            undefined,
+            undefined
+          )
+
+          resolve()
+        }
+      }
+
+      this.instance = this.dispose.track(
+        window.createTerminal({
+          name: this.termName,
+          pty
+        })
+      )
+    })
+  }
+
+  private deleteReferenceOnClose() {
+    this.dispose.track(
+      window.onDidCloseTerminal(event => {
+        if (this.instance && event.name === this.termName) {
+          this.dispose.untrack(this.instance)
+          this.instance = undefined
+
+          sendTelemetryEvent(
+            EventName.VIEWS_TERMINAL_CLOSED,
+            undefined,
+            undefined
+          )
+        }
+      })
+    )
+  }
+
+  private notifyActiveStatus() {
+    this.dispose.track(
+      window.onDidChangeActiveTerminal(term => {
+        if (this.isActive && term?.name !== this.termName) {
+          this.isActive = false
+          return this.sendFocusChangedTelemetryEvent()
+        }
+        if (term && !this.isActive && term.name === this.termName) {
+          this.isActive = true
+          return this.sendFocusChangedTelemetryEvent()
+        }
+      })
+    )
+  }
+
+  private sendFocusChangedTelemetryEvent() {
+    return sendTelemetryEvent(
+      EventName.VIEWS_TERMINAL_FOCUS_CHANGED,
+      {
+        active: this.isActive
+      },
+      undefined
+    )
+  }
+}

--- a/extension/src/vscode/pseudoTerminal/multiUse.ts
+++ b/extension/src/vscode/pseudoTerminal/multiUse.ts
@@ -1,0 +1,11 @@
+import { BasePseudoTerminal } from './base'
+
+export class MultiUsePseudoTerminal extends BasePseudoTerminal {
+  public async openCurrentInstance() {
+    if (!this.instance) {
+      await this.createInstance()
+    }
+    this.instance?.show(true)
+    return this.instance
+  }
+}

--- a/extension/src/vscode/pseudoTerminal/singleUse.ts
+++ b/extension/src/vscode/pseudoTerminal/singleUse.ts
@@ -1,0 +1,75 @@
+import { EventEmitter } from 'vscode'
+import { BasePseudoTerminal } from './base'
+import { ProcessOptions, createProcess } from '../../processExecution'
+import { CliResult, CliStarted } from '../../cli'
+import { getCommandString } from '../../cli/command'
+import { StopWatch } from '../../util/time'
+
+export class SingleUsePseudoTerminal extends BasePseudoTerminal {
+  constructor(
+    termName: string,
+    options: ProcessOptions,
+    processStarted: EventEmitter<CliStarted>,
+    processCompleted: EventEmitter<CliResult>
+  ) {
+    const processOutput = new EventEmitter<string>()
+    const processTerminated = new EventEmitter<string>()
+
+    super(processOutput, processTerminated, termName)
+
+    this.setBlocked(true)
+    void this.createInstance()
+
+    this.dispose.track(processOutput)
+    this.dispose.track(processTerminated)
+
+    const process = this.dispose.track(createProcess(options))
+
+    const command = getCommandString(options)
+    const baseEvent = { command, cwd: options.cwd, pid: process.pid }
+
+    processStarted.fire(baseEvent)
+    processOutput.fire(`Running: dvc ${options.args.join(' ')}\r\n\n`)
+
+    process.all?.on('data', chunk =>
+      processOutput.fire(
+        (chunk as Buffer)
+          .toString()
+          .split(/(\r?\n)/g)
+          .join('\r')
+      )
+    )
+
+    let stderr = ''
+    process.stderr?.on(
+      'data',
+      chunk => (stderr += (chunk as Buffer).toString())
+    )
+
+    const stopWatch = new StopWatch()
+
+    const onDidTerminateProcess = processTerminated.event
+
+    this.dispose.track(
+      onDidTerminateProcess(() => {
+        process.dispose()
+      })
+    )
+
+    void process.on('close', exitCode => {
+      void this.dispose.untrack(process)
+
+      processCompleted.fire({
+        ...baseEvent,
+        duration: stopWatch.getElapsedTime(),
+        exitCode,
+        stderr
+      })
+      processOutput.fire('\r\nPress any key to close\r\n\n')
+    })
+  }
+
+  public show() {
+    return this.instance?.show()
+  }
+}

--- a/extension/src/webview/contract.ts
+++ b/extension/src/webview/contract.ts
@@ -35,6 +35,7 @@ export enum MessageFromWebviewType {
   RESIZE_PLOTS = 'resize-plots',
   SAVE_STUDIO_TOKEN = 'save-studio-token',
   SHARE_EXPERIMENT_TO_STUDIO = 'share-experiment-to-studio',
+  SHOW_EXPERIMENT_LOGS = 'show-experiment-logs',
   STOP_EXPERIMENT = 'stop-experiment',
   SORT_COLUMN = 'sort-column',
   TOGGLE_EXPERIMENT = 'toggle-experiment',
@@ -136,6 +137,7 @@ export type MessageFromWebview =
       type: MessageFromWebviewType.STOP_EXPERIMENT
       payload: { id: string; executor?: string | null }[]
     }
+  | { type: MessageFromWebviewType.SHOW_EXPERIMENT_LOGS; payload: string }
   | {
       type: MessageFromWebviewType.SHARE_EXPERIMENT_TO_STUDIO
       payload: string

--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -864,6 +864,7 @@ describe('App', () => {
       const menuitems = screen.getAllByRole('menuitem')
       const itemLabels = menuitems.map(item => item.textContent)
       expect(itemLabels).toStrictEqual([
+        'Show Logs',
         'Apply to Workspace',
         'Create new Branch',
         'Share to Studio',
@@ -888,7 +889,7 @@ describe('App', () => {
       fireEvent.contextMenu(row, { bubbles: true })
 
       advanceTimersByTime(100)
-      expect(screen.getAllByRole('menuitem')).toHaveLength(11)
+      expect(screen.getAllByRole('menuitem')).toHaveLength(12)
 
       fireEvent.click(window, { bubbles: true })
       advanceTimersByTime(100)
@@ -902,7 +903,7 @@ describe('App', () => {
       fireEvent.contextMenu(row, { bubbles: true })
 
       advanceTimersByTime(100)
-      expect(screen.getAllByRole('menuitem')).toHaveLength(11)
+      expect(screen.getAllByRole('menuitem')).toHaveLength(12)
 
       const commit = getRow('main')
       fireEvent.click(commit, { bubbles: true })
@@ -917,13 +918,13 @@ describe('App', () => {
       fireEvent.contextMenu(row, { bubbles: true })
 
       advanceTimersByTime(100)
-      expect(screen.queryAllByRole('menuitem')).toHaveLength(11)
+      expect(screen.queryAllByRole('menuitem')).toHaveLength(12)
 
       fireEvent.contextMenu(within(row).getByText('[exp-e7a67]'), {
         bubbles: true
       })
       advanceTimersByTime(200)
-      expect(screen.queryAllByRole('menuitem')).toHaveLength(11)
+      expect(screen.queryAllByRole('menuitem')).toHaveLength(12)
     })
 
     it('should present the Remove experiment option for the checkpoint tips', () => {

--- a/webview/src/experiments/components/table/RowContextMenu.tsx
+++ b/webview/src/experiments/components/table/RowContextMenu.tsx
@@ -3,7 +3,8 @@ import { MessageFromWebviewType } from 'dvc/src/webview/contract'
 import {
   ExperimentStatus,
   isQueued,
-  isRunning
+  isRunning,
+  isRunningInQueue
 } from 'dvc/src/experiments/webview/contract'
 import { EXPERIMENT_WORKSPACE_ID } from 'dvc/src/cli/dvc/contract'
 import { RowProp } from './interfaces'
@@ -190,6 +191,12 @@ const getSingleSelectMenuOptions = (
     )
 
   return [
+    experimentMenuOption(
+      id,
+      'Show Logs',
+      MessageFromWebviewType.SHOW_EXPERIMENT_LOGS,
+      !isRunningInQueue({ executor, status })
+    ),
     notRunningWithId(
       'Apply to Workspace',
       MessageFromWebviewType.APPLY_EXPERIMENT_TO_WORKSPACE,
@@ -227,7 +234,7 @@ const getSingleSelectMenuOptions = (
       starred ? 'Unstar' : 'Star',
       MessageFromWebviewType.TOGGLE_EXPERIMENT_STAR,
       isWorkspace,
-      !hasRunningExperiment
+      true
     ),
     experimentMenuOption(
       [{ executor, id }],

--- a/webview/src/test/experimentsTable.tsx
+++ b/webview/src/test/experimentsTable.tsx
@@ -58,6 +58,7 @@ export const renderTableWithSortingData = () => {
   return renderTable(sortingTableDataFixture)
 }
 
+// this no longer works, need to rewrite it + tests
 export const renderTableWithoutRunningExperiments = () => {
   renderTable({
     ...tableDataFixture,


### PR DESCRIPTION
Part of https://github.com/iterative/vscode-dvc/issues/3178

WIP.

Lots of duplication in the PR that ~can~ will be removed. Need to think more about how to set this out so that it can be used under certain circumstances for things like `dvc pull`. Thinking maybe

1. show progress notification which contains "show logs" link
2. show logs link opens a terminal and starts piping the output in (like demo below)

### Demo

https://user-images.githubusercontent.com/37993418/221096848-df1e98c6-66c1-40e0-bb15-ae679d248c1f.mov


