### PR TITLE
Clean up from optimizing rendering of plots

### DIFF
--- a/webview/src/plots/components/ZoomablePlot.tsx
+++ b/webview/src/plots/components/ZoomablePlot.tsx
@@ -20,7 +20,7 @@ interface ZoomablePlotProps {
   spec?: VisualizationSpec
   id: string
   onViewReady?: () => void
-  toggleDrag: (enabled: boolean, id: string) => void
+  changeDisabledDragIds: (ids: string[]) => AnyAction
   changeSize: (size: number) => AnyAction
   currentSnapPoint: number
   section: Section
@@ -31,7 +31,7 @@ export const ZoomablePlot: React.FC<ZoomablePlotProps> = ({
   spec: createdSpec,
   id,
   onViewReady,
-  toggleDrag,
+  changeDisabledDragIds,
   changeSize,
   currentSnapPoint,
   section,
@@ -87,10 +87,10 @@ export const ZoomablePlot: React.FC<ZoomablePlotProps> = ({
   const commonResizerProps = {
     onGrab: () => {
       clickDisabled.current = true
-      toggleDrag(false, id)
+      dispatch(changeDisabledDragIds([id]))
     },
     onRelease: () => {
-      toggleDrag(true, id)
+      dispatch(changeDisabledDragIds([]))
       enableClickTimeout.current = window.setTimeout(
         () => (clickDisabled.current = false),
         0

--- a/webview/src/plots/components/ZoomablePlot.tsx
+++ b/webview/src/plots/components/ZoomablePlot.tsx
@@ -42,12 +42,10 @@ export const ZoomablePlot: React.FC<ZoomablePlotProps> = ({
   )
   const { data, content: spec } = useGetPlot(section, id, createdSpec)
   const dispatch = useDispatch()
-  const previousSpecsAndData = useRef(JSON.stringify({ data, spec }))
   const currentPlotProps = useRef<VegaLiteProps>()
   const clickDisabled = useRef(false)
   const enableClickTimeout = useRef(0)
   const [isExpanding, setIsExpanding] = useState(false)
-  const newSpecsAndData = JSON.stringify({ data, spec })
   const size = snapPoints[currentSnapPoint - 1]
 
   const plotProps: VegaLiteProps = {
@@ -61,13 +59,10 @@ export const ZoomablePlot: React.FC<ZoomablePlotProps> = ({
   currentPlotProps.current = plotProps
 
   useEffect(() => {
-    if (previousSpecsAndData.current !== newSpecsAndData) {
-      dispatch(
-        setZoomedInPlot({ id, plot: currentPlotProps.current, refresh: true })
-      )
-      previousSpecsAndData.current = newSpecsAndData
-    }
-  }, [newSpecsAndData, id, dispatch])
+    dispatch(
+      setZoomedInPlot({ id, plot: currentPlotProps.current, refresh: true })
+    )
+  }, [data, spec, dispatch, id])
 
   useEffect(() => {
     return () => {

--- a/webview/src/plots/components/checkpointPlots/CheckpointPlot.tsx
+++ b/webview/src/plots/components/checkpointPlots/CheckpointPlot.tsx
@@ -1,5 +1,5 @@
 import { ColorScale, Section } from 'dvc/src/plots/webview/contract'
-import React, { useMemo, useEffect, useState } from 'react'
+import React, { useMemo, useEffect, useState, useCallback } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { createSpec } from './util'
 import { changeDisabledDragIds, changeSize } from './checkpointPlotsSlice'
@@ -37,15 +37,18 @@ export const CheckpointPlot: React.FC<CheckpointPlotProps> = ({
     setPlot(plotDataStore[Section.CHECKPOINT_PLOTS][id])
   }, [plotSnapshot, id])
 
+  const toggleDrag = useCallback(
+    (enabled: boolean, plotId: string) => {
+      dispatch(changeDisabledDragIds(enabled ? [] : [plotId]))
+    },
+    [dispatch]
+  )
+
   if (!plot) {
     return null
   }
 
   const key = `plot-${id}`
-
-  const toggleDrag = (enabled: boolean) => {
-    dispatch(changeDisabledDragIds(enabled ? [] : [id]))
-  }
 
   return (
     <div className={styles.plot} data-testid={key} id={id} style={withScale(1)}>

--- a/webview/src/plots/components/checkpointPlots/CheckpointPlot.tsx
+++ b/webview/src/plots/components/checkpointPlots/CheckpointPlot.tsx
@@ -1,6 +1,6 @@
 import { ColorScale, Section } from 'dvc/src/plots/webview/contract'
-import React, { useMemo, useEffect, useState, useCallback } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import React, { useMemo, useEffect, useState } from 'react'
+import { useSelector } from 'react-redux'
 import { createSpec } from './util'
 import { changeDisabledDragIds, changeSize } from './checkpointPlotsSlice'
 import { ZoomablePlot } from '../ZoomablePlot'
@@ -18,7 +18,6 @@ export const CheckpointPlot: React.FC<CheckpointPlotProps> = ({
   id,
   colors
 }) => {
-  const dispatch = useDispatch()
   const plotSnapshot = useSelector(
     (state: PlotsState) => state.checkpoint.plotsSnapshots[id]
   )
@@ -37,13 +36,6 @@ export const CheckpointPlot: React.FC<CheckpointPlotProps> = ({
     setPlot(plotDataStore[Section.CHECKPOINT_PLOTS][id])
   }, [plotSnapshot, id])
 
-  const toggleDrag = useCallback(
-    (enabled: boolean, plotId: string) => {
-      dispatch(changeDisabledDragIds(enabled ? [] : [plotId]))
-    },
-    [dispatch]
-  )
-
   if (!plot) {
     return null
   }
@@ -55,7 +47,7 @@ export const CheckpointPlot: React.FC<CheckpointPlotProps> = ({
       <ZoomablePlot
         spec={spec}
         id={id}
-        toggleDrag={toggleDrag}
+        changeDisabledDragIds={changeDisabledDragIds}
         changeSize={changeSize}
         currentSnapPoint={currentSize}
         section={Section.CHECKPOINT_PLOTS}

--- a/webview/src/plots/components/templatePlots/TemplatePlotsGrid.tsx
+++ b/webview/src/plots/components/templatePlots/TemplatePlotsGrid.tsx
@@ -91,13 +91,6 @@ export const TemplatePlotsGrid: React.FC<TemplatePlotsGridProps> = ({
     [styles.multiViewPlot]: multiView
   })
 
-  const toggleDrag = useCallback(
-    (enabled: boolean, id: string) => {
-      dispatch(changeDisabledDragIds(enabled ? [] : [id]))
-    },
-    [dispatch]
-  )
-
   const items = useMemo(
     () =>
       entries.map((plot: string) => {
@@ -117,7 +110,7 @@ export const TemplatePlotsGrid: React.FC<TemplatePlotsGridProps> = ({
             <ZoomablePlot
               id={plot}
               onViewReady={addEventsOnViewReady}
-              toggleDrag={toggleDrag}
+              changeDisabledDragIds={changeDisabledDragIds}
               changeSize={changeSize}
               currentSnapPoint={currentSize}
               shouldNotResize={multiView}
@@ -126,14 +119,7 @@ export const TemplatePlotsGrid: React.FC<TemplatePlotsGridProps> = ({
           </div>
         )
       }),
-    [
-      entries,
-      plotClassName,
-      addEventsOnViewReady,
-      currentSize,
-      multiView,
-      toggleDrag
-    ]
+    [entries, plotClassName, addEventsOnViewReady, currentSize, multiView]
   )
 
   return (


### PR DESCRIPTION
Closes #3334 

Removes stringification of plot contents to see if it changed so that it can update the `ZoomedInPlot` (now the plot contents is not a new reference every time).

Also optimizes the `toggleDrag` function of `CheckpointPlot` to match with the `TemplatePlotGrid`.