### PR TITLE
Add viewable cli process class

### DIFF
--- a/extension/src/cli/util.ts
+++ b/extension/src/cli/util.ts
@@ -1,0 +1,41 @@
+import { EventEmitter } from 'vscode'
+import { CliEvent, CliResult } from '.'
+import { Process } from '../process/execution'
+
+export const notifyStarted = (
+  baseEvent: CliEvent,
+  processStarted: EventEmitter<CliEvent>
+): void => processStarted.fire(baseEvent)
+
+export const notifyOutput = (
+  process: Process,
+  processOutput: EventEmitter<string>
+): void => {
+  process.all?.on('data', chunk =>
+    processOutput.fire(
+      (chunk as Buffer)
+        .toString()
+        .split(/(\r?\n)/g)
+        .join('\r')
+    )
+  )
+}
+
+export const notifyCompleted = (
+  { command, pid, cwd, duration, exitCode, stderr }: CliResult,
+  processCompleted: EventEmitter<CliResult>
+): void =>
+  processCompleted.fire({
+    command,
+    cwd,
+    duration,
+    exitCode,
+    pid,
+    stderr: stderr?.replace(/\n+/g, '\n')
+  })
+
+export const captureStdErr = (process: Process): string => {
+  let stderr = ''
+  process.stderr?.on('data', chunk => (stderr += (chunk as Buffer).toString()))
+  return stderr
+}

--- a/extension/src/cli/viewable.ts
+++ b/extension/src/cli/viewable.ts
@@ -58,15 +58,11 @@ export class ViewableCliProcess extends DeferredDisposable {
     processOutput: EventEmitter<string>,
     processCompleted: EventEmitter<CliResult>
   ) {
-    processOutput.fire(
-      `Running: ${
-        options.executable === 'git' ? 'git' : 'dvc'
-      } ${options.args.join(' ')}\r\n\n`
-    )
     const stopWatch = new StopWatch()
+    const command = getCommandString(options)
+    processOutput.fire(`Running: ${command}\r\n\n`)
     const process = this.dispose.track(createProcess(options))
 
-    const command = getCommandString(options)
     const baseEvent = { command, cwd: options.cwd, pid: process.pid }
 
     notifyStarted(baseEvent, processStarted)

--- a/extension/src/cli/viewable.ts
+++ b/extension/src/cli/viewable.ts
@@ -1,0 +1,92 @@
+import { Event, EventEmitter } from 'vscode'
+import { CliEvent, CliResult, CliStarted } from '.'
+import {
+  captureStdErr,
+  notifyCompleted,
+  notifyOutput,
+  notifyStarted
+} from './util'
+import { getCommandString } from './command'
+import { ProcessOptions, createProcess } from '../process/execution'
+import { StopWatch } from '../util/time'
+import { PseudoTerminal } from '../vscode/pseudoTerminal'
+import { DeferredDisposable } from '../class/deferred'
+
+export class ViewableCliProcess extends DeferredDisposable {
+  public readonly onDidDispose: Event<void>
+
+  private readonly pseudoTerminal: PseudoTerminal
+
+  constructor(
+    termName: string,
+    options: ProcessOptions,
+    processStarted: EventEmitter<CliStarted>,
+    processCompleted: EventEmitter<CliResult>
+  ) {
+    super()
+    const processOutput = this.dispose.track(new EventEmitter<string>())
+    const terminalClosed = this.dispose.track(new EventEmitter<void>())
+    const onDidCloseTerminal = terminalClosed.event
+
+    this.pseudoTerminal = this.dispose.track(
+      new PseudoTerminal(processOutput, terminalClosed, termName)
+    )
+
+    this.pseudoTerminal.setBlocked(true)
+    void this.show().then(() => this.deferred.resolve())
+
+    this.createProcess(options, processStarted, processOutput, processCompleted)
+
+    const disposed = this.dispose.track(new EventEmitter<void>())
+    this.onDidDispose = disposed.event
+
+    this.dispose.track(
+      onDidCloseTerminal(() => {
+        disposed.fire()
+        this.dispose()
+      })
+    )
+  }
+
+  public show() {
+    return this.pseudoTerminal.openCurrentInstance()
+  }
+
+  private createProcess(
+    options: ProcessOptions,
+    processStarted: EventEmitter<CliEvent>,
+    processOutput: EventEmitter<string>,
+    processCompleted: EventEmitter<CliResult>
+  ) {
+    processOutput.fire(
+      `Running: ${
+        options.executable === 'git' ? 'git' : 'dvc'
+      } ${options.args.join(' ')}\r\n\n`
+    )
+    const stopWatch = new StopWatch()
+    const process = this.dispose.track(createProcess(options))
+
+    const command = getCommandString(options)
+    const baseEvent = { command, cwd: options.cwd, pid: process.pid }
+
+    notifyStarted(baseEvent, processStarted)
+
+    notifyOutput(process, processOutput)
+
+    const stderr = captureStdErr(process)
+
+    void process.on('close', exitCode => {
+      void this.dispose.untrack(process)
+      notifyCompleted(
+        {
+          ...baseEvent,
+          duration: stopWatch.getElapsedTime(),
+          exitCode,
+          stderr
+        },
+        processCompleted
+      )
+      processOutput.fire('\r\nPress any key to close\r\n\n')
+    })
+  }
+}

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -22,8 +22,6 @@ export type ViewOpenedEventName =
 
 export const EventName = Object.assign(
   {
-    EXPERIMENTS_RUNNER_COMPLETED: 'experiments.runner.completed',
-
     EXTENSION_EXECUTION_DETAILS_CHANGED: 'extension.executionDetails.changed',
     EXTENSION_LOAD: 'extension.load',
 
@@ -117,12 +115,6 @@ type WebviewFocusChangedProperties = {
 export interface IEventNamePropertyMapping {
   [EventName.EXTENSION_EXECUTION_DETAILS_CHANGED]: ExtensionProperties
   [EventName.EXTENSION_LOAD]: ExtensionProperties
-
-  [EventName.EXPERIMENTS_RUNNER_COMPLETED]: {
-    command: string
-    exitCode: number | null
-    wasStopped?: boolean
-  }
 
   [EventName.EXPERIMENT_AND_PLOTS_SHOW]: undefined
   [EventName.EXPERIMENT_APPLY]: undefined

--- a/extension/src/telemetry/index.ts
+++ b/extension/src/telemetry/index.ts
@@ -62,7 +62,12 @@ const sanitizeProperties = (
     if (value === undefined || value === null) {
       continue
     }
-    sanitizeProperty(eventName as string, sanitizedProperties, key, value)
+    sanitizeProperty(
+      eventName,
+      sanitizedProperties,
+      key,
+      value as string | number | boolean
+    )
   }
   return sanitizedProperties
 }

--- a/extension/src/test/suite/cli/viewable.test.ts
+++ b/extension/src/test/suite/cli/viewable.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, it, suite } from 'mocha'
+import { restore, stub } from 'sinon'
+import { EventEmitter, Terminal, window } from 'vscode'
+import { expect } from 'chai'
+import { Disposable } from '../../../extension'
+import { CliResult, CliStarted } from '../../../cli'
+import { ProcessOptions } from '../../../process/execution'
+import { ViewableCliProcess } from '../../../cli/viewable'
+import { dvcDemoPath } from '../../util'
+import { closeAllTerminals } from '../util'
+
+suite('Viewable CLI Process Test Suite', () => {
+  const disposable = Disposable.fn()
+
+  beforeEach(() => {
+    restore()
+  })
+
+  afterEach(() => {
+    disposable.dispose()
+  })
+
+  describe('ViewableCliProcess', () => {
+    it('should open a pseudoTerminal when created', async () => {
+      const termName = 'I open'
+      const options: ProcessOptions = {
+        args: ['100'],
+        cwd: dvcDemoPath,
+        executable: 'sleep'
+      }
+      const processStarted = disposable.track(new EventEmitter<CliStarted>())
+      const processCompleted = disposable.track(new EventEmitter<CliResult>())
+
+      const onDidStartProcess = processStarted.event
+
+      const processStartedEvent = new Promise(resolve =>
+        onDidStartProcess(() => resolve(undefined))
+      )
+
+      const mockCreateTerminal = stub(window, 'createTerminal').returns({
+        dispose: () => undefined
+      } as Terminal)
+
+      const viewableCliProcess = disposable.track(
+        new ViewableCliProcess(
+          termName,
+          options,
+          processStarted,
+          processCompleted
+        )
+      )
+
+      await processStartedEvent
+      expect(mockCreateTerminal).to.be.called
+
+      viewableCliProcess.dispose()
+    }).timeout(8000)
+
+    it('should call dispose when the pseudoTerminal is closed', async () => {
+      const termName = 'Close Me'
+      const options: ProcessOptions = {
+        args: ['10000000'],
+        cwd: dvcDemoPath,
+        executable: 'sleep'
+      }
+      const processStarted = disposable.track(new EventEmitter<CliStarted>())
+      const processCompleted = disposable.track(new EventEmitter<CliResult>())
+
+      const viewableCliProcess = disposable.track(
+        new ViewableCliProcess(
+          termName,
+          options,
+          processStarted,
+          processCompleted
+        )
+      )
+
+      const disposedEvent = new Promise(resolve =>
+        disposable.track(
+          viewableCliProcess.onDidDispose(() => {
+            resolve(undefined)
+          })
+        )
+      )
+
+      await viewableCliProcess.isReady()
+
+      await closeAllTerminals()
+
+      await disposedEvent
+    }).timeout(8000)
+  })
+})

--- a/extension/src/test/suite/util.ts
+++ b/extension/src/test/suite/util.ts
@@ -113,6 +113,9 @@ export const closeAllEditors = async () => {
   }
 }
 
+export const closeAllTerminals = () =>
+  commands.executeCommand('workbench.action.terminal.killAll')
+
 export const mockDuration = (duration: number) =>
   stub(Time, 'getCurrentEpoch')
     .onFirstCall()


### PR DESCRIPTION
# 2/5 `main` <- #3356 <- this <- #3359 <- #3361 <- #3362 

This PR adds a `ViewableCliProcess` class which groups together a process with a pseudoterminal instance. This will be used for things like showing logs for experiments running the queue and long-running processes like pull under certain circumstances.