### PR TITLE
Remove legacy test code from DvcRunner

### DIFF
--- a/extension/src/cli/dvc/runner.ts
+++ b/extension/src/cli/dvc/runner.ts
@@ -43,31 +43,16 @@ export class DvcRunner extends Disposable implements ICli {
   private readonly processTerminated: EventEmitter<void>
   private readonly onDidTerminateProcess: Event<void>
 
-  private readonly executable: string | undefined
-
   private readonly pseudoTerminal: PseudoTerminal
   private currentProcess: Process | undefined
   private readonly config: Config
 
-  constructor(
-    config: Config,
-    executable?: string,
-    emitters?: {
-      processCompleted: EventEmitter<CliResult>
-      processOutput: EventEmitter<string>
-      processStarted: EventEmitter<CliStarted>
-      processTerminated?: EventEmitter<void>
-    }
-  ) {
+  constructor(config: Config) {
     super()
 
     this.config = config
 
-    this.executable = executable
-
-    this.processCompleted =
-      emitters?.processCompleted ||
-      this.dispose.track(new EventEmitter<CliResult>())
+    this.processCompleted = this.dispose.track(new EventEmitter<CliResult>())
     this.onDidCompleteProcess = this.processCompleted.event
     this.dispose.track(
       this.onDidCompleteProcess(() => {
@@ -79,17 +64,12 @@ export class DvcRunner extends Disposable implements ICli {
       })
     )
 
-    this.processOutput =
-      emitters?.processOutput || this.dispose.track(new EventEmitter<string>())
+    this.processOutput = this.dispose.track(new EventEmitter<string>())
 
-    this.processStarted =
-      emitters?.processStarted ||
-      this.dispose.track(new EventEmitter<CliStarted>())
+    this.processStarted = this.dispose.track(new EventEmitter<CliStarted>())
     this.onDidStartProcess = this.processStarted.event
 
-    this.processTerminated =
-      emitters?.processTerminated ||
-      this.dispose.track(new EventEmitter<void>())
+    this.processTerminated = this.dispose.track(new EventEmitter<void>())
     this.onDidTerminateProcess = this.processTerminated.event
     this.dispose.track(
       this.onDidTerminateProcess(() => {
@@ -161,13 +141,6 @@ export class DvcRunner extends Disposable implements ICli {
     return this.currentProcess
   }
 
-  private getOverrideOrCliPath() {
-    if (this.executable) {
-      return this.executable
-    }
-    return this.config.getCliPath()
-  }
-
   private createProcess({ cwd, args }: { cwd: string; args: Args }): Process {
     const options = this.getOptions(cwd, args)
     const command = getCommandString(options)
@@ -200,7 +173,7 @@ export class DvcRunner extends Disposable implements ICli {
   private getOptions(cwd: string, args: Args) {
     return getOptions(
       this.config.getPythonBinPath(),
-      this.getOverrideOrCliPath(),
+      this.config.getCliPath(),
       cwd,
       ...args
     )

--- a/extension/src/test/suite/cli/dvc/runner.test.ts
+++ b/extension/src/test/suite/cli/dvc/runner.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, it, suite } from 'mocha'
 import { expect } from 'chai'
 import { restore, spy } from 'sinon'
-import { window, Event, EventEmitter } from 'vscode'
+import { window, Event } from 'vscode'
 import { Disposable, Disposer } from '../../../../extension'
 import { Config } from '../../../../config'
 import { DvcRunner } from '../../../../cli/dvc/runner'
@@ -22,8 +22,11 @@ suite('DVC Runner Test Suite', () => {
 
   describe('DvcRunner', () => {
     it('should only be able to run a single command at a time', async () => {
-      const mockConfig = { getPythonBinPath: () => undefined } as Config
-      const dvcRunner = disposable.track(new DvcRunner(mockConfig, 'sleep'))
+      const mockConfig = {
+        getCliPath: () => 'sleep',
+        getPythonBinPath: () => undefined
+      } as Config
+      const dvcRunner = disposable.track(new DvcRunner(mockConfig))
 
       const windowErrorMessageSpy = spy(window, 'showErrorMessage')
       const cwd = __dirname
@@ -35,8 +38,11 @@ suite('DVC Runner Test Suite', () => {
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should be able to stop a started command', async () => {
-      const mockConfig = { getPythonBinPath: () => undefined } as Config
-      const dvcRunner = disposable.track(new DvcRunner(mockConfig, 'sleep'))
+      const mockConfig = {
+        getCliPath: () => 'sleep',
+        getPythonBinPath: () => undefined
+      } as Config
+      const dvcRunner = disposable.track(new DvcRunner(mockConfig))
       const cwd = __dirname
 
       const onDidCompleteProcess = (): Promise<void> =>
@@ -67,10 +73,6 @@ suite('DVC Runner Test Suite', () => {
     it('should be able to execute a command and provide the correct events in the correct order', async () => {
       const text = ':weeeee:'
 
-      const processCompleted = disposable.track(new EventEmitter<CliResult>())
-      const processOutput = disposable.track(new EventEmitter<string>())
-      const processStarted = disposable.track(new EventEmitter<CliStarted>())
-
       const onDidOutputProcess = (
         text: string,
         event: Event<string>,
@@ -97,23 +99,25 @@ suite('DVC Runner Test Suite', () => {
           })
         })
       }
-      const started = onDidStartOrCompleteProcess(processStarted.event)
-      const completed = onDidStartOrCompleteProcess(processCompleted.event)
-      const eventStream = onDidOutputProcess(
-        text,
-        processOutput.event,
-        disposable
-      )
 
       const cwd = __dirname
 
-      const mockConfig = { getPythonBinPath: () => undefined } as Config
-      const dvcRunner = disposable.track(
-        new DvcRunner(mockConfig, 'echo', {
-          processCompleted,
-          processOutput,
-          processStarted
-        })
+      const mockConfig = {
+        getCliPath: () => 'echo',
+        getPythonBinPath: () => undefined
+      } as Config
+
+      const dvcRunner = disposable.track(new DvcRunner(mockConfig))
+
+      const started = onDidStartOrCompleteProcess(dvcRunner.onDidStartProcess)
+      const completed = onDidStartOrCompleteProcess(
+        dvcRunner.onDidCompleteProcess
+      )
+      const eventStream = onDidOutputProcess(
+        text,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (dvcRunner as any).processOutput.event,
+        disposable
       )
 
       void dvcRunner.run(cwd, text)


### PR DESCRIPTION
# 4/5 `main` <- #3356 <- #3358 <-#3359 <- this <- #3362 

This PR removes some legacy code from the `DvcRunner`. This code was previously needed for testing purposes but we can now work around those limitations.