### PR TITLE
Delete unused code in Plots

### DIFF
--- a/webview/src/plots/components/PlotsContainer.tsx
+++ b/webview/src/plots/components/PlotsContainer.tsx
@@ -23,11 +23,7 @@ import {
 import { isSelecting } from '../../util/strings'
 import { isTooltip } from '../../util/helpers'
 
-export interface CommonPlotsContainerProps {
-  onResize: (size: number) => void
-}
-
-export interface PlotsContainerProps extends CommonPlotsContainerProps {
+export interface PlotsContainerProps {
   sectionCollapsed: boolean
   sectionKey: Section
   title: string

--- a/webview/src/plots/components/checkpointPlots/CheckpointPlotsWrapper.tsx
+++ b/webview/src/plots/components/checkpointPlots/CheckpointPlotsWrapper.tsx
@@ -1,15 +1,13 @@
 import { Section } from 'dvc/src/plots/webview/contract'
 import { MessageFromWebviewType } from 'dvc/src/webview/contract'
 import React, { useEffect, useState } from 'react'
-import { useSelector, useDispatch } from 'react-redux'
+import { useSelector } from 'react-redux'
 import { CheckpointPlots } from './CheckpointPlots'
-import { changeSize } from './checkpointPlotsSlice'
 import { PlotsContainer } from '../PlotsContainer'
 import { sendMessage } from '../../../shared/vscode'
 import { PlotsState } from '../../store'
 
 export const CheckpointPlotsWrapper: React.FC = () => {
-  const dispatch = useDispatch()
   const { plotsIds, size, selectedMetrics, isCollapsed, colors } = useSelector(
     (state: PlotsState) => state.checkpoint
   )
@@ -29,10 +27,6 @@ export const CheckpointPlotsWrapper: React.FC = () => {
     })
   }
 
-  const handleResize = (size: number) => {
-    dispatch(changeSize(size))
-  }
-
   const menu =
     plotsIds.length > 0
       ? {
@@ -49,7 +43,6 @@ export const CheckpointPlotsWrapper: React.FC = () => {
       menu={menu}
       currentSize={size}
       sectionCollapsed={isCollapsed}
-      onResize={handleResize}
     >
       <CheckpointPlots plotsIds={selectedPlots} colors={colors} />
     </PlotsContainer>

--- a/webview/src/plots/components/comparisonTable/ComparisonTableWrapper.tsx
+++ b/webview/src/plots/components/comparisonTable/ComparisonTableWrapper.tsx
@@ -1,19 +1,14 @@
 import { Section } from 'dvc/src/plots/webview/contract'
 import React from 'react'
-import { useSelector, useDispatch } from 'react-redux'
+import { useSelector } from 'react-redux'
 import { ComparisonTable } from './ComparisonTable'
-import { changeSize } from './comparisonTableSlice'
 import { PlotsContainer } from '../PlotsContainer'
 import { PlotsState } from '../../store'
 
 export const ComparisonTableWrapper: React.FC = () => {
-  const dispatch = useDispatch()
   const { size, isCollapsed } = useSelector(
     (state: PlotsState) => state.comparison
   )
-  const handleResize = (size: number) => {
-    dispatch(changeSize(size))
-  }
 
   return (
     <PlotsContainer
@@ -21,7 +16,6 @@ export const ComparisonTableWrapper: React.FC = () => {
       sectionKey={Section.COMPARISON_TABLE}
       currentSize={size}
       sectionCollapsed={isCollapsed}
-      onResize={handleResize}
     >
       <ComparisonTable />
     </PlotsContainer>

--- a/webview/src/plots/components/templatePlots/TemplatePlotsWrapper.tsx
+++ b/webview/src/plots/components/templatePlots/TemplatePlotsWrapper.tsx
@@ -1,28 +1,20 @@
 import { Section } from 'dvc/src/plots/webview/contract'
 import React from 'react'
-import { useSelector, useDispatch } from 'react-redux'
+import { useSelector } from 'react-redux'
 import { TemplatePlots } from './TemplatePlots'
-import { changeSize } from './templatePlotsSlice'
 import { PlotsContainer } from '../PlotsContainer'
 import { PlotsState } from '../../store'
 
 export const TemplatePlotsWrapper: React.FC = () => {
-  const dispatch = useDispatch()
   const { size, isCollapsed } = useSelector(
     (state: PlotsState) => state.template
   )
-
-  const handleResize = (size: number) => {
-    dispatch(changeSize(size))
-  }
-
   return (
     <PlotsContainer
       title="Data Series"
       sectionKey={Section.TEMPLATE_PLOTS}
       currentSize={size}
       sectionCollapsed={isCollapsed}
-      onResize={handleResize}
     >
       <TemplatePlots />
     </PlotsContainer>


### PR DESCRIPTION
* removes an `onResize` prop in `PlotsContainer` since it's no longer being used anywhere ([see #3342 comment](https://github.com/iterative/vscode-dvc/pull/3342#discussion_r1120210682))