### PR TITLE
Move e2e tests to stable (wdio chromedriver issue)

### DIFF
--- a/extension/src/test/e2e/wdio.conf.ts
+++ b/extension/src/test/e2e/wdio.conf.ts
@@ -47,7 +47,7 @@ export const config: Options.Testrunner = {
   capabilities: [
     {
       browserName: 'vscode',
-      browserVersion: 'insiders',
+      browserVersion: 'stable',
       'wdio:vscodeOptions': {
         extensionPath,
         userSettings: {


### PR DESCRIPTION
See [thread](https://iterativeai.slack.com/archives/C01RB7BTG4C/p1677617774116919)