### PR TITLE
Move Connect to Studio button into Actions tree

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1345,11 +1345,6 @@
           "when": "true"
         },
         {
-          "id": "dvc.views.studio",
-          "name": "Studio",
-          "when": "!dvc.studio.connected"
-        },
-        {
           "id": "dvc.views.experimentsColumnsTree",
           "name": "Columns",
           "when": "dvc.commands.available && dvc.project.available"
@@ -1383,18 +1378,18 @@
     "viewsWelcome": [
       {
         "view": "dvc.views.actions",
-        "contents": "[$(beaker) Show Experiments](command:dvc.showExperiments)\n[$(graph-scatter) Show Plots](command:dvc.showPlots)\n[$(play) Run Experiment](command:dvc.runExperiment)",
-        "when": "!dvc.experiment.checkpoints"
+        "contents": "[$(beaker) Show Experiments](command:dvc.showExperiments)\n[$(graph-scatter) Show Plots](command:dvc.showPlots)\n",
+        "when": "true"
       },
       {
         "view": "dvc.views.actions",
-        "contents": "[$(beaker) Show Experiments](command:dvc.showExperiments)\n[$(graph-scatter) Show Plots](command:dvc.showPlots)\n[$(play) Run Experiment](command:dvc.resetAndRunCheckpointExperiment)",
-        "when": "dvc.experiment.checkpoints"
+        "contents": "[$(plug) Connect Studio](command:dvc.showConnect)",
+        "when": "!dvc.studio.connected"
       },
       {
-        "view": "dvc.views.studio",
-        "contents": "[$(plug) Connect](command:dvc.showConnect)",
-        "when": "!dvc.studio.connected"
+        "view": "dvc.views.actions",
+        "contents": "[$(debug-disconnect) Disconnect Studio](command:dvc.removeStudioAccessToken)",
+        "when": "dvc.studio.connected"
       },
       {
         "view": "dvc.views.welcome",


### PR DESCRIPTION
First very small step based on [this feedback](https://iterativeai.slack.com/archives/C01APS0FHDM/p1677657980420979)

Seems like a reasonable step as I try to work out what is next.

### Demo

https://user-images.githubusercontent.com/37993418/222293911-5513b9af-17c3-4c8a-9559-a42c73071fa3.mov

Options I am considering for the 3rd button after Studio is connected:

1. Show settings
2. Share Experiment Live or checkbox or similar
3. Edit Studio Connection
4. No change