### PR TITLE
Add Studio settings page

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1343,6 +1343,11 @@
           "when": "true"
         },
         {
+          "id": "dvc.views.studio",
+          "name": "Studio",
+          "when": "true"
+        },
+        {
           "id": "dvc.views.experimentsColumnsTree",
           "name": "Columns",
           "when": "dvc.commands.available && dvc.project.available"
@@ -1376,17 +1381,22 @@
     "viewsWelcome": [
       {
         "view": "dvc.views.actions",
-        "contents": "[$(beaker) Show Experiments](command:dvc.showExperiments)\n[$(graph-scatter) Show Plots](command:dvc.showPlots)\n",
-        "when": "true"
+        "contents": "[$(beaker) Show Experiments](command:dvc.showExperiments)\n[$(graph-scatter) Show Plots](command:dvc.showPlots)\n[$(play) Run Experiment](command:dvc.runExperiment)",
+        "when": "!dvc.experiment.checkpoints"
       },
       {
         "view": "dvc.views.actions",
-        "contents": "[$(plug) Connect Studio](command:dvc.showConnect)",
+        "contents": "[$(beaker) Show Experiments](command:dvc.showExperiments)\n[$(graph-scatter) Show Plots](command:dvc.showPlots)\n[$(play) Run Experiment](command:dvc.resetAndRunCheckpointExperiment)",
+        "when": "dvc.experiment.checkpoints"
+      },
+      {
+        "view": "dvc.views.studio",
+        "contents": "[$(plug) Connect](command:dvc.showConnect)",
         "when": "!dvc.studio.connected"
       },
       {
-        "view": "dvc.views.actions",
-        "contents": "[$(settings-gear) Open Studio Settings](command:dvc.showConnect)",
+        "view": "dvc.views.studio",
+        "contents": "[$(settings-gear) Open Settings](command:dvc.showConnect)",
         "when": "dvc.studio.connected"
       },
       {

--- a/extension/package.json
+++ b/extension/package.json
@@ -1343,11 +1343,6 @@
           "when": "true"
         },
         {
-          "id": "dvc.views.studio",
-          "name": "Studio",
-          "when": "!dvc.studio.connected"
-        },
-        {
           "id": "dvc.views.experimentsColumnsTree",
           "name": "Columns",
           "when": "dvc.commands.available && dvc.project.available"
@@ -1381,18 +1376,18 @@
     "viewsWelcome": [
       {
         "view": "dvc.views.actions",
-        "contents": "[$(beaker) Show Experiments](command:dvc.showExperiments)\n[$(graph-scatter) Show Plots](command:dvc.showPlots)\n[$(play) Run Experiment](command:dvc.runExperiment)",
-        "when": "!dvc.experiment.checkpoints"
+        "contents": "[$(beaker) Show Experiments](command:dvc.showExperiments)\n[$(graph-scatter) Show Plots](command:dvc.showPlots)\n",
+        "when": "true"
       },
       {
         "view": "dvc.views.actions",
-        "contents": "[$(beaker) Show Experiments](command:dvc.showExperiments)\n[$(graph-scatter) Show Plots](command:dvc.showPlots)\n[$(play) Run Experiment](command:dvc.resetAndRunCheckpointExperiment)",
-        "when": "dvc.experiment.checkpoints"
+        "contents": "[$(plug) Connect Studio](command:dvc.showConnect)",
+        "when": "!dvc.studio.connected"
       },
       {
-        "view": "dvc.views.studio",
-        "contents": "[$(plug) Connect](command:dvc.showConnect)",
-        "when": "!dvc.studio.connected"
+        "view": "dvc.views.actions",
+        "contents": "[$(debug-disconnect) Disconnect Studio](command:dvc.removeStudioAccessToken)",
+        "when": "dvc.studio.connected"
       },
       {
         "view": "dvc.views.welcome",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1386,7 +1386,7 @@
       },
       {
         "view": "dvc.views.actions",
-        "contents": "[$(debug-disconnect) Disconnect Studio](command:dvc.removeStudioAccessToken)",
+        "contents": "[$(settings-gear) Open Studio Settings](command:dvc.showConnect)",
         "when": "dvc.studio.connected"
       },
       {

--- a/extension/src/connect/index.ts
+++ b/extension/src/connect/index.ts
@@ -36,7 +36,7 @@ export class Connect extends BaseRepository<ConnectData> {
     void this.getSecret(STUDIO_ACCESS_TOKEN_KEY).then(
       async studioAccessToken => {
         this.studioAccessToken = studioAccessToken
-        await this.setContext()
+        await this.updateIsStudioConnected()
         this.deferred.resolve()
       }
     )
@@ -46,8 +46,9 @@ export class Connect extends BaseRepository<ConnectData> {
         if (e.key !== STUDIO_ACCESS_TOKEN_KEY) {
           return
         }
+
         this.studioAccessToken = await this.getSecret(STUDIO_ACCESS_TOKEN_KEY)
-        return this.setContext()
+        return this.updateIsStudioConnected()
       })
     )
 
@@ -133,17 +134,16 @@ export class Connect extends BaseRepository<ConnectData> {
     return openUrl(`${STUDIO_URL}/user/_/profile?section=accessToken`)
   }
 
-  private setContext() {
+  private updateIsStudioConnected() {
     const storedToken = this.getStudioAccessToken()
-    if (isStudioAccessToken(storedToken)) {
-      this.studioIsConnected = true
-      this.sendWebviewMessage()
-      return setContextValue(ContextKey.STUDIO_CONNECTED, true)
-    }
+    const isConnected = isStudioAccessToken(storedToken)
+    return this.setStudioIsConnected(isConnected)
+  }
 
-    this.studioIsConnected = false
+  private setStudioIsConnected(isConnected: boolean) {
+    this.studioIsConnected = isConnected
     this.sendWebviewMessage()
-    return setContextValue(ContextKey.STUDIO_CONNECTED, false)
+    return setContextValue(ContextKey.STUDIO_CONNECTED, isConnected)
   }
 
   private getSecret(key: string) {

--- a/extension/src/connect/webview/contract.ts
+++ b/extension/src/connect/webview/contract.ts
@@ -1,1 +1,6 @@
 export const STUDIO_URL = 'https://studio.iterative.ai'
+
+export type ConnectData = {
+  isStudioConnected: boolean
+  shareLiveToStudio: boolean
+}

--- a/extension/src/test/suite/connect/index.test.ts
+++ b/extension/src/test/suite/connect/index.test.ts
@@ -6,9 +6,11 @@ import {
   ExtensionContext,
   SecretStorage,
   Uri,
+  WorkspaceConfiguration,
   commands,
   env,
-  window
+  window,
+  workspace
 } from 'vscode'
 import { Disposable } from '../../../extension'
 import {
@@ -22,6 +24,7 @@ import { WEBVIEW_TEST_TIMEOUT } from '../timeouts'
 import { ContextKey } from '../../../vscode/context'
 import { STUDIO_ACCESS_TOKEN_KEY } from '../../../connect/token'
 import { RegisteredCommands } from '../../../commands/external'
+import { ConfigKey } from '../../../vscode/config'
 
 suite('Connect Test Suite', () => {
   const disposable = Disposable.fn()
@@ -153,6 +156,27 @@ suite('Connect Test Suite', () => {
         true
       )
     }).timeout(WEBVIEW_TEST_TIMEOUT)
+
+    it('should handle a message to set dvc.studio.shareExperimentsLive', async () => {
+      const { connect, mockMessageReceived } = await buildConnect()
+      await connect.isReady()
+
+      const mockUpdate = stub()
+
+      stub(workspace, 'getConfiguration').returns({
+        update: mockUpdate
+      } as unknown as WorkspaceConfiguration)
+
+      mockMessageReceived.fire({
+        payload: false,
+        type: MessageFromWebviewType.SET_STUDIO_SHARE_EXPERIMENTS_LIVE
+      })
+
+      expect(mockUpdate).to.be.calledWithExactly(
+        ConfigKey.STUDIO_SHARE_EXPERIMENTS_LIVE,
+        false
+      )
+    })
 
     it('should be able to delete the Studio access token from secrets storage', async () => {
       const mockDelete = stub()

--- a/extension/src/test/suite/util.ts
+++ b/extension/src/test/suite/util.ts
@@ -35,6 +35,7 @@ import { DvcExecutor } from '../../cli/dvc/executor'
 import { GitReader } from '../../cli/git/reader'
 import { SetupData } from '../../setup/webview/contract'
 import { DvcViewer } from '../../cli/dvc/viewer'
+import { ConnectData } from '../../connect/webview/contract'
 
 export const mockDisposable = {
   dispose: stub()
@@ -244,7 +245,7 @@ export const buildDependencies = (
 }
 
 export const getMessageReceivedEmitter = (
-  webview: BaseWebview<PlotsData | TableData | SetupData>
+  webview: BaseWebview<PlotsData | TableData | SetupData | ConnectData>
 ): EventEmitter<MessageFromWebview> => (webview as any).messageReceived
 
 export const getInputBoxEvent = (mockInputValue: string) => {

--- a/extension/src/webview/contract.ts
+++ b/extension/src/webview/contract.ts
@@ -1,3 +1,4 @@
+import { ConnectData } from '../connect/webview/contract'
 import { SortDefinition } from '../experiments/model/sortBy'
 import { TableData } from '../experiments/webview/contract'
 import {
@@ -8,7 +9,7 @@ import {
 } from '../plots/webview/contract'
 import { SetupData } from '../setup/webview/contract'
 
-export type WebviewData = TableData | PlotsData | SetupData | {}
+export type WebviewData = TableData | PlotsData | SetupData | ConnectData
 
 export enum MessageFromWebviewType {
   INITIALIZED = 'initialized',
@@ -54,6 +55,7 @@ export enum MessageFromWebviewType {
   TOGGLE_METRIC = 'toggle-metric',
   TOGGLE_PLOTS_SECTION = 'toggle-plots-section',
   REMOVE_CUSTOM_PLOTS = 'remove-custom-plots',
+  REMOVE_STUDIO_TOKEN = 'remove-studio-token',
   MODIFY_EXPERIMENT_PARAMS_AND_QUEUE = 'modify-experiment-params-and-queue',
   MODIFY_EXPERIMENT_PARAMS_AND_RUN = 'modify-experiment-params-and-run',
   MODIFY_EXPERIMENT_PARAMS_RESET_AND_RUN = 'modify-experiment-params-reset-and-run',
@@ -163,6 +165,7 @@ export type MessageFromWebview =
   | {
       type: MessageFromWebviewType.REMOVE_CUSTOM_PLOTS
     }
+  | { type: MessageFromWebviewType.REMOVE_STUDIO_TOKEN }
   | {
       type: MessageFromWebviewType.REORDER_PLOTS_COMPARISON
       payload: string[]

--- a/extension/src/webview/contract.ts
+++ b/extension/src/webview/contract.ts
@@ -50,6 +50,7 @@ export enum MessageFromWebviewType {
   SELECT_PYTHON_INTERPRETER = 'select-python-interpreter',
   SET_EXPERIMENTS_FOR_PLOTS = 'set-experiments-for-plots',
   SET_EXPERIMENTS_AND_OPEN_PLOTS = 'set-experiments-and-open-plots',
+  SET_STUDIO_SHARE_EXPERIMENTS_LIVE = 'set-studio-share-experiments-live',
   SHARE_EXPERIMENT_AS_BRANCH = 'share-experiment-as-branch',
   SHARE_EXPERIMENT_AS_COMMIT = 'share-experiment-as-commit',
   TOGGLE_METRIC = 'toggle-metric',
@@ -211,6 +212,10 @@ export type MessageFromWebview =
   | {
       type: MessageFromWebviewType.SET_EXPERIMENTS_AND_OPEN_PLOTS
       payload: string[]
+    }
+  | {
+      type: MessageFromWebviewType.SET_STUDIO_SHARE_EXPERIMENTS_LIVE
+      payload: boolean
     }
   | {
       type: MessageFromWebviewType.SHARE_EXPERIMENT_AS_BRANCH

--- a/webview/src/connect/components/App.test.tsx
+++ b/webview/src/connect/components/App.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { MessageFromWebviewType } from 'dvc/src/webview/contract'
+import {
+  MessageFromWebviewType,
+  MessageToWebviewType
+} from 'dvc/src/webview/contract'
+import { ConnectData } from 'dvc/src/connect/webview/contract'
 import { App } from './App'
 import { vsCodeApi } from '../../shared/api'
 
@@ -18,47 +22,79 @@ afterEach(() => {
   cleanup()
 })
 
-const renderApp = () => {
-  return render(<App />)
+const setData = ({ isStudioConnected, shareLiveToStudio }: ConnectData) => {
+  fireEvent(
+    window,
+    new MessageEvent('message', {
+      data: {
+        data: {
+          isStudioConnected,
+          shareLiveToStudio
+        },
+        type: MessageToWebviewType.SET_DATA
+      }
+    })
+  )
+}
+
+const renderApp = (isStudioConnected = false, shareLiveToStudio = false) => {
+  render(<App />)
+  setData({ isStudioConnected, shareLiveToStudio })
 }
 
 describe('App', () => {
-  it('should show three buttons which walk the user through saving a token', async () => {
-    renderApp()
-    const buttons = await screen.findAllByRole('button')
-    expect(buttons).toHaveLength(3)
-  })
+  describe('Studio not connected', () => {
+    it('should show three buttons which walk the user through saving a token', async () => {
+      renderApp()
+      const buttons = await screen.findAllByRole('button')
+      expect(buttons).toHaveLength(3)
+    })
 
-  it('should show a button which opens Studio', () => {
-    renderApp()
-    mockPostMessage.mockClear()
-    const button = screen.getByText('Sign In')
-    fireEvent.click(button)
-    expect(mockPostMessage).toHaveBeenCalledTimes(1)
-    expect(mockPostMessage).toHaveBeenCalledWith({
-      type: MessageFromWebviewType.OPEN_STUDIO
+    it('should show a button which opens Studio', () => {
+      renderApp()
+      mockPostMessage.mockClear()
+      const button = screen.getByText('Sign In')
+      fireEvent.click(button)
+      expect(mockPostMessage).toHaveBeenCalledTimes(1)
+      expect(mockPostMessage).toHaveBeenCalledWith({
+        type: MessageFromWebviewType.OPEN_STUDIO
+      })
+    })
+
+    it("should show a button which opens the user's Studio profile", () => {
+      renderApp()
+      mockPostMessage.mockClear()
+      const button = screen.getByText('Get Token')
+      fireEvent.click(button)
+      expect(mockPostMessage).toHaveBeenCalledTimes(1)
+      expect(mockPostMessage).toHaveBeenCalledWith({
+        type: MessageFromWebviewType.OPEN_STUDIO_PROFILE
+      })
+    })
+
+    it("should show a button which allows the user's to save their Studio access token", () => {
+      renderApp()
+      mockPostMessage.mockClear()
+      const button = screen.getByText('Save')
+      fireEvent.click(button)
+      expect(mockPostMessage).toHaveBeenCalledTimes(1)
+      expect(mockPostMessage).toHaveBeenCalledWith({
+        type: MessageFromWebviewType.SAVE_STUDIO_TOKEN
+      })
     })
   })
 
-  it("should show a button which opens the user's Studio profile", () => {
-    renderApp()
-    mockPostMessage.mockClear()
-    const button = screen.getByText('Get Token')
-    fireEvent.click(button)
-    expect(mockPostMessage).toHaveBeenCalledTimes(1)
-    expect(mockPostMessage).toHaveBeenCalledWith({
-      type: MessageFromWebviewType.OPEN_STUDIO_PROFILE
-    })
-  })
-
-  it("should show a button which allows the user's to save their Studio access token", () => {
-    renderApp()
-    mockPostMessage.mockClear()
-    const button = screen.getByText('Save')
-    fireEvent.click(button)
-    expect(mockPostMessage).toHaveBeenCalledTimes(1)
-    expect(mockPostMessage).toHaveBeenCalledWith({
-      type: MessageFromWebviewType.SAVE_STUDIO_TOKEN
+  describe('Studio connected', () => {
+    it('should render a checkbox which can be used to update dvc.studio.shareExperimentsLive', () => {
+      const shareExperimentsLive = false
+      renderApp(true, shareExperimentsLive)
+      mockPostMessage.mockClear()
+      const checkbox = screen.getByRole('checkbox')
+      fireEvent.click(checkbox)
+      expect(mockPostMessage).toHaveBeenCalledWith({
+        payload: !shareExperimentsLive,
+        type: MessageFromWebviewType.SET_STUDIO_SHARE_EXPERIMENTS_LIVE
+      })
     })
   })
 })

--- a/webview/src/connect/components/App.tsx
+++ b/webview/src/connect/components/App.tsx
@@ -1,21 +1,34 @@
 import React, { useCallback, useState } from 'react'
-import { MessageToWebview } from 'dvc/src/webview/contract'
+import {
+  MessageFromWebviewType,
+  MessageToWebview
+} from 'dvc/src/webview/contract'
 import { ConnectData } from 'dvc/src/connect/webview/contract'
 import { Studio } from './Studio'
 import { useVsCodeMessaging } from '../../shared/hooks/useVsCodeMessaging'
+import { sendMessage } from '../../shared/vscode'
 
 export const App: React.FC = () => {
   const [isStudioConnected, setIsStudioConnected] = useState<boolean>(false)
-  const [shareLiveToStudio, setShareLiveToStudio] = useState<boolean>(false)
+  const [shareLiveToStudio, setShareLiveToStudioValue] =
+    useState<boolean>(false)
   useVsCodeMessaging(
     useCallback(
       ({ data }: { data: MessageToWebview<ConnectData> }) => {
         setIsStudioConnected(data.data.isStudioConnected)
-        setShareLiveToStudio(data.data.isStudioConnected)
+        setShareLiveToStudioValue(data.data.shareLiveToStudio)
       },
-      [setIsStudioConnected, setShareLiveToStudio]
+      [setIsStudioConnected, setShareLiveToStudioValue]
     )
   )
+
+  const setShareLiveToStudio = (shouldShareLive: boolean) => {
+    setShareLiveToStudioValue(shouldShareLive)
+    sendMessage({
+      payload: shouldShareLive,
+      type: MessageFromWebviewType.SET_STUDIO_SHARE_EXPERIMENTS_LIVE
+    })
+  }
 
   return (
     <Studio

--- a/webview/src/connect/components/App.tsx
+++ b/webview/src/connect/components/App.tsx
@@ -1,9 +1,27 @@
-import React from 'react'
+import React, { useCallback, useState } from 'react'
+import { MessageToWebview } from 'dvc/src/webview/contract'
+import { ConnectData } from 'dvc/src/connect/webview/contract'
 import { Studio } from './Studio'
 import { useVsCodeMessaging } from '../../shared/hooks/useVsCodeMessaging'
 
 export const App: React.FC = () => {
-  useVsCodeMessaging()
+  const [isStudioConnected, setIsStudioConnected] = useState<boolean>(false)
+  const [shareLiveToStudio, setShareLiveToStudio] = useState<boolean>(false)
+  useVsCodeMessaging(
+    useCallback(
+      ({ data }: { data: MessageToWebview<ConnectData> }) => {
+        setIsStudioConnected(data.data.isStudioConnected)
+        setShareLiveToStudio(data.data.isStudioConnected)
+      },
+      [setIsStudioConnected, setShareLiveToStudio]
+    )
+  )
 
-  return <Studio />
+  return (
+    <Studio
+      isStudioConnected={isStudioConnected}
+      shareLiveToStudio={shareLiveToStudio}
+      setShareLiveToStudio={setShareLiveToStudio}
+    />
+  )
 }

--- a/webview/src/connect/components/Studio.tsx
+++ b/webview/src/connect/components/Studio.tsx
@@ -72,10 +72,7 @@ const Settings: React.FC<{
         </p>
         <p>
           <VSCodeCheckbox
-            onClick={() => {
-              setShareLiveToStudio(!shareLiveToStudio)
-              // send message
-            }}
+            onClick={() => setShareLiveToStudio(!shareLiveToStudio)}
             checked={shareLiveToStudio}
           >
             Share New Experiments Live

--- a/webview/src/connect/components/Studio.tsx
+++ b/webview/src/connect/components/Studio.tsx
@@ -1,10 +1,16 @@
 import React from 'react'
-import { STUDIO_URL } from 'dvc/src/connect/webview/contract'
-import { openStudio, openStudioProfile, saveStudioToken } from './messages'
+import { VSCodeCheckbox } from '@vscode/webview-ui-toolkit/react'
+import { ConnectData, STUDIO_URL } from 'dvc/src/connect/webview/contract'
+import {
+  openStudio,
+  openStudioProfile,
+  saveStudioToken,
+  removeStudioToken
+} from './messages'
 import { EmptyState } from '../../shared/components/emptyState/EmptyState'
 import { Button } from '../../shared/components/button/Button'
 
-export const Studio: React.FC = () => {
+const Connect: React.FC = () => {
   return (
     <EmptyState>
       <div>
@@ -45,5 +51,62 @@ export const Studio: React.FC = () => {
         </p>
       </div>
     </EmptyState>
+  )
+}
+
+const Settings: React.FC<{
+  shareLiveToStudio: boolean
+  setShareLiveToStudio: (shareLiveToStudio: boolean) => void
+}> = ({ shareLiveToStudio, setShareLiveToStudio }) => {
+  return (
+    <EmptyState>
+      <div>
+        <h1>Studio Settings</h1>
+        <p>
+          Experiment metrics and plots logged with DVCLive <br />
+          can be{' '}
+          <a href="https://dvc.org/doc/studio/user-guide/projects-and-experiments/live-metrics-and-plots#send-and-view-live-metrics-and-plots">
+            automatically shared to Studio
+          </a>
+          .
+        </p>
+        <p>
+          <VSCodeCheckbox
+            onClick={() => {
+              setShareLiveToStudio(!shareLiveToStudio)
+              // send message
+            }}
+            checked={shareLiveToStudio}
+          >
+            Share New Experiments Live
+          </VSCodeCheckbox>
+        </p>
+        <Button
+          appearance="primary"
+          isNested={false}
+          text={'Update Token'}
+          onClick={openStudio}
+        />
+        <Button
+          appearance="secondary"
+          isNested={true}
+          text={'Disconnect'}
+          onClick={removeStudioToken}
+        />
+      </div>
+    </EmptyState>
+  )
+}
+
+export const Studio: React.FC<
+  ConnectData & { setShareLiveToStudio: (shareLiveToStudio: boolean) => void }
+> = ({ isStudioConnected, shareLiveToStudio, setShareLiveToStudio }) => {
+  return isStudioConnected ? (
+    <Settings
+      shareLiveToStudio={shareLiveToStudio}
+      setShareLiveToStudio={setShareLiveToStudio}
+    />
+  ) : (
+    <Connect />
   )
 }

--- a/webview/src/connect/components/messages.ts
+++ b/webview/src/connect/components/messages.ts
@@ -9,3 +9,6 @@ export const openStudioProfile = () =>
 
 export const saveStudioToken = () =>
   sendMessage({ type: MessageFromWebviewType.SAVE_STUDIO_TOKEN })
+
+export const removeStudioToken = () =>
+  sendMessage({ type: MessageFromWebviewType.REMOVE_STUDIO_TOKEN })

--- a/webview/src/stories/Connect.stories.tsx
+++ b/webview/src/stories/Connect.stories.tsx
@@ -1,22 +1,38 @@
 import { Story, Meta } from '@storybook/react/types-6-0'
-import React from 'react'
+import React, { useState } from 'react'
 import { DISABLE_CHROMATIC_SNAPSHOTS } from './util'
 
 import './test-vscode-styles.scss'
 import '../shared/style.scss'
-import { App } from '../connect/components/App'
+import { Studio } from '../connect/components/Studio'
 
 export default {
   args: {
     data: {}
   },
-  component: App,
+  component: Studio,
   parameters: DISABLE_CHROMATIC_SNAPSHOTS,
   title: 'Connect'
 } as Meta
 
-const Template: Story = () => {
-  return <App />
+const Template: Story = ({
+  isStudioConnected,
+  shareLiveToStudio: initialShareLiveToStudio
+}) => {
+  const [shareLiveToStudio, setShareLiveToStudio] = useState<boolean>(
+    !!initialShareLiveToStudio
+  )
+  return (
+    <Studio
+      isStudioConnected={isStudioConnected}
+      shareLiveToStudio={shareLiveToStudio}
+      setShareLiveToStudio={setShareLiveToStudio}
+    />
+  )
 }
 
-export const Studio = Template.bind({})
+export const ConnectToStudio = Template.bind({})
+ConnectToStudio.args = { isStudioConnected: false }
+
+export const StudioSettings = Template.bind({})
+StudioSettings.args = { isStudioConnected: true, shareLiveToStudio: true }


### PR DESCRIPTION
# 2/2 `main` <- #3387 <- this

This PR adds a studio settings page and wires it up with the sidebar once Studio is connected.

### Demo

#### E2E Flow

https://user-images.githubusercontent.com/37993418/222616041-20e18bc0-5e56-49c9-b9f8-ac3ec7726399.mov



#### View checkbox updates config

https://user-images.githubusercontent.com/37993418/222615607-d3680975-2e42-4877-bf45-23240efa1584.mov


Notes: 

I played around with adding different buttons on the LHS a lot but there is no room/not enough text to provide all of the required details. Whatever is there seems very vague, this seems like the best option for now.

There really isn't much to add into a settings page at the moment but this moves in that general direction. 


I also adjusted the approach based on feedback provided in #3378.