### PR TITLE
Have queue workers respect dvc.studio.shareExperimentsLive

### DIFF
--- a/extension/src/cli/dvc/executor.test.ts
+++ b/extension/src/cli/dvc/executor.test.ts
@@ -5,7 +5,7 @@ import { Flag, GcPreserveFlag } from './constants'
 import { DvcExecutor } from './executor'
 import { CliResult, CliStarted } from '..'
 import { createProcess } from '../../process/execution'
-import { getMockedProcess } from '../../test/util/jest'
+import { flushPromises, getMockedProcess } from '../../test/util/jest'
 import { getProcessEnv } from '../../env'
 import { Config } from '../../config'
 import { ContextKey, setContextValue } from '../../vscode/context'
@@ -29,6 +29,7 @@ const mockedEnv = {
 const mockedSetContextValue = jest.mocked(setContextValue)
 
 const mockedGetStudioLiveShareToken = jest.fn()
+const mockedGetRepoUrl = jest.fn()
 
 beforeEach(() => {
   jest.resetAllMocks()
@@ -51,6 +52,7 @@ describe('CliExecutor', () => {
       getPythonBinPath: () => undefined
     } as unknown as Config,
     mockedGetStudioLiveShareToken,
+    mockedGetRepoUrl,
     {
       processCompleted: {
         event: jest.fn(),
@@ -606,24 +608,35 @@ describe('CliExecutor', () => {
       })
     })
 
-    it("should call createProcess with the correct parameters to start the experiment's queue and send live updates to Studio", () => {
+    it("should call createProcess with the correct parameters to start the experiment's queue and send live updates to Studio", async () => {
       const cwd = __dirname
       const jobs = '91231324'
       const mockedToken = 'isat_notarealtoken'
+      const mockedUrl = 'git@github.com:iterative/vscode-dvc-demo.git'
 
       mockedGetStudioLiveShareToken.mockReturnValueOnce(mockedToken)
+      mockedGetRepoUrl.mockResolvedValueOnce(
+        'git@github.com:iterative/vscode-dvc-demo.git'
+      )
 
       const stdout = `Started '${jobs}' new experiments task queue workers.`
 
       mockedCreateProcess.mockReturnValueOnce(getMockedProcess(stdout))
 
       void dvcExecutor.queueStart(cwd, jobs)
+      await flushPromises()
+
+      expect(mockedGetRepoUrl).toHaveBeenCalledWith(cwd)
 
       expect(mockedCreateProcess).toHaveBeenCalledWith({
         args: ['queue', 'start', '-j', jobs],
         cwd,
         detached: true,
-        env: { ...mockedEnv, STUDIO_TOKEN: mockedToken },
+        env: {
+          ...mockedEnv,
+          STUDIO_REPO_URL: mockedUrl,
+          STUDIO_TOKEN: mockedToken
+        },
         executable: 'dvc'
       })
     })

--- a/extension/src/cli/dvc/executor.ts
+++ b/extension/src/cli/dvc/executor.ts
@@ -42,11 +42,13 @@ export class DvcExecutor extends DvcCli {
   )
 
   private readonly getStudioLiveShareToken: () => string | undefined
+  private readonly getRepoUrl: (cwd: string) => Promise<string>
   private scmCommandRunning = false
 
   constructor(
     config: Config,
     getStudioLiveShareToken: () => string | undefined,
+    getRepoUrl: (cwd: string) => Promise<string>,
     emitters?: {
       processStarted: EventEmitter<CliStarted>
       processCompleted: EventEmitter<CliResult>
@@ -54,6 +56,7 @@ export class DvcExecutor extends DvcCli {
   ) {
     super(config, emitters)
     this.getStudioLiveShareToken = getStudioLiveShareToken
+    this.getRepoUrl = getRepoUrl
   }
 
   public add(cwd: string, target: string) {
@@ -155,7 +158,7 @@ export class DvcExecutor extends DvcCli {
     )
   }
 
-  public queueStart(cwd: string, jobs: string) {
+  public async queueStart(cwd: string, jobs: string) {
     const options = this.getOptions(
       cwd,
       Command.QUEUE,
@@ -164,8 +167,10 @@ export class DvcExecutor extends DvcCli {
       jobs
     )
     const studioAccessToken = this.getStudioLiveShareToken()
+    const repoUrl = studioAccessToken ? await this.getRepoUrl(cwd) : undefined
+
     return this.createBackgroundProcess(
-      addStudioAccessToken(options, studioAccessToken)
+      addStudioAccessToken(options, studioAccessToken, repoUrl)
     )
   }
 

--- a/extension/src/cli/dvc/index.ts
+++ b/extension/src/cli/dvc/index.ts
@@ -34,7 +34,7 @@ export class DvcCli extends Cli {
     return this.createBackgroundProcess(options)
   }
 
-  private getOptions(cwd: string, ...args: Args) {
+  protected getOptions(cwd: string, ...args: Args) {
     return getOptions(
       this.config.getPythonBinPath(),
       this.config.getCliPath(),

--- a/extension/src/cli/dvc/options.ts
+++ b/extension/src/cli/dvc/options.ts
@@ -52,14 +52,26 @@ export const getOptions = (
 
 export const addStudioAccessToken = (
   options: ExecutionOptions,
-  studioAccessToken: string | undefined
+  studioAccessToken: string | undefined,
+  repoUrl?: string
 ): ExecutionOptions => {
   if (!studioAccessToken) {
     return options
   }
 
+  if (!repoUrl) {
+    return {
+      ...options,
+      env: { ...options.env, STUDIO_TOKEN: studioAccessToken }
+    }
+  }
+
   return {
     ...options,
-    env: { ...options.env, STUDIO_TOKEN: studioAccessToken }
+    env: {
+      ...options.env,
+      STUDIO_REPO_URL: repoUrl,
+      STUDIO_TOKEN: studioAccessToken
+    }
   }
 }

--- a/extension/src/cli/dvc/options.ts
+++ b/extension/src/cli/dvc/options.ts
@@ -49,3 +49,17 @@ export const getOptions = (
     executable
   }
 }
+
+export const addStudioAccessToken = (
+  options: ExecutionOptions,
+  studioAccessToken: string | undefined
+): ExecutionOptions => {
+  if (!studioAccessToken) {
+    return options
+  }
+
+  return {
+    ...options,
+    env: { ...options.env, STUDIO_TOKEN: studioAccessToken }
+  }
+}

--- a/extension/src/cli/dvc/runner.ts
+++ b/extension/src/cli/dvc/runner.ts
@@ -5,7 +5,7 @@ import {
   ExperimentFlag,
   ExperimentSubCommand
 } from './constants'
-import { getOptions } from './options'
+import { addStudioAccessToken, getOptions } from './options'
 import { CliResult, CliStarted, ICli, typeCheckCommands } from '..'
 import { getCommandString } from '../command'
 import { Config } from '../../config'
@@ -183,15 +183,7 @@ export class DvcRunner extends Disposable implements ICli {
     )
 
     const studioAccessToken = this.getStudioLiveShareToken()
-
-    if (!studioAccessToken) {
-      return options
-    }
-
-    return {
-      ...options,
-      env: { ...options.env, STUDIO_TOKEN: studioAccessToken }
-    }
+    return addStudioAccessToken(options, studioAccessToken)
   }
 
   private startProcess(cwd: string, args: Args) {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -94,10 +94,14 @@ export class Extension extends Disposable {
       new Connect(context, this.resourceLocator.dvcIcon)
     )
 
-    this.dvcExecutor = this.dispose.track(new DvcExecutor(config))
+    const getStudioLiveShareToken = () => this.connect.getStudioLiveShareToken()
+
+    this.dvcExecutor = this.dispose.track(
+      new DvcExecutor(config, getStudioLiveShareToken)
+    )
     this.dvcReader = this.dispose.track(new DvcReader(config))
     this.dvcRunner = this.dispose.track(
-      new DvcRunner(config, () => this.connect.getStudioLiveShareToken())
+      new DvcRunner(config, getStudioLiveShareToken)
     )
     this.dvcViewer = this.dispose.track(new DvcViewer(config))
 

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -94,19 +94,22 @@ export class Extension extends Disposable {
       new Connect(context, this.resourceLocator.dvcIcon)
     )
 
+    this.gitExecutor = this.dispose.track(new GitExecutor())
+    this.gitReader = this.dispose.track(new GitReader())
+
     const getStudioLiveShareToken = () => this.connect.getStudioLiveShareToken()
 
     this.dvcExecutor = this.dispose.track(
-      new DvcExecutor(config, getStudioLiveShareToken)
+      new DvcExecutor(config, getStudioLiveShareToken, cwd =>
+        this.gitReader.getRemoteUrl(cwd)
+      )
     )
+
     this.dvcReader = this.dispose.track(new DvcReader(config))
     this.dvcRunner = this.dispose.track(
       new DvcRunner(config, getStudioLiveShareToken)
     )
     this.dvcViewer = this.dispose.track(new DvcViewer(config))
-
-    this.gitExecutor = this.dispose.track(new GitExecutor())
-    this.gitReader = this.dispose.track(new GitReader())
 
     const clis = [
       this.dvcExecutor,

--- a/extension/src/test/cli/util.ts
+++ b/extension/src/test/cli/util.ts
@@ -15,7 +15,11 @@ const config = {
 } as Config
 
 export const dvcReader = new DvcReader(config)
-export const dvcExecutor = new DvcExecutor(config, () => undefined)
+export const dvcExecutor = new DvcExecutor(
+  config,
+  () => undefined,
+  () => Promise.resolve('')
+)
 const gitExecutor = new GitExecutor()
 
 let demoInitialized: Promise<string>

--- a/extension/src/test/cli/util.ts
+++ b/extension/src/test/cli/util.ts
@@ -15,7 +15,7 @@ const config = {
 } as Config
 
 export const dvcReader = new DvcReader(config)
-export const dvcExecutor = new DvcExecutor(config)
+export const dvcExecutor = new DvcExecutor(config, () => undefined)
 const gitExecutor = new GitExecutor()
 
 let demoInitialized: Promise<string>

--- a/extension/src/test/suite/util.ts
+++ b/extension/src/test/suite/util.ts
@@ -142,7 +142,7 @@ export const buildInternalCommands = (disposer: Disposer) => {
   const config = disposer.track(new Config())
   const dvcReader = disposer.track(new DvcReader(config))
   const dvcRunner = disposer.track(new DvcRunner(config, () => undefined))
-  const dvcExecutor = disposer.track(new DvcExecutor(config))
+  const dvcExecutor = disposer.track(new DvcExecutor(config, () => undefined))
   const dvcViewer = disposer.track(new DvcViewer(config))
   const gitReader = disposer.track(new GitReader())
 

--- a/extension/src/test/suite/util.ts
+++ b/extension/src/test/suite/util.ts
@@ -142,7 +142,13 @@ export const buildInternalCommands = (disposer: Disposer) => {
   const config = disposer.track(new Config())
   const dvcReader = disposer.track(new DvcReader(config))
   const dvcRunner = disposer.track(new DvcRunner(config, () => undefined))
-  const dvcExecutor = disposer.track(new DvcExecutor(config, () => undefined))
+  const dvcExecutor = disposer.track(
+    new DvcExecutor(
+      config,
+      () => undefined,
+      () => Promise.resolve('')
+    )
+  )
   const dvcViewer = disposer.track(new DvcViewer(config))
   const gitReader = disposer.track(new GitReader())
 


### PR DESCRIPTION
Related to #3077

This PR connects new queue workers with Studio. If an access token is present then the queue will start processing with the correct environment variables to send everything to Studio. This is handy because the functionality is not currently available locally.

### Demo


https://user-images.githubusercontent.com/37993418/222999310-096341cf-4438-42b2-b590-0923f8e8af52.mov

