### PR TITLE
Switch add Studio access token to update when Studio is connected

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -118,6 +118,11 @@
         "category": "DVC"
       },
       {
+        "title": "Update Studio Access Token",
+        "command": "dvc.updateStudioAccessToken",
+        "category": "DVC"
+      },
+      {
         "title": "Add",
         "command": "dvc.addTarget",
         "category": "DVC",
@@ -635,7 +640,11 @@
         },
         {
           "command": "dvc.addStudioAccessToken",
-          "when": "dvc.commands.available && dvc.project.available"
+          "when": "dvc.commands.available && dvc.project.available && !dvc.studio.connected"
+        },
+        {
+          "command": "dvc.updateStudioAccessToken",
+          "when": "dvc.commands.available && dvc.project.available && dvc.studio.connected"
         },
         {
           "command": "dvc.addTarget",

--- a/extension/src/commands/external.ts
+++ b/extension/src/commands/external.ts
@@ -99,6 +99,7 @@ export enum RegisteredCommands {
   CONNECT_SHOW = 'dvc.showConnect',
   OPEN_STUDIO_SETTINGS = 'dvc.showStudioSettings',
   ADD_STUDIO_ACCESS_TOKEN = 'dvc.addStudioAccessToken',
+  UPDATE_STUDIO_ACCESS_TOKEN = 'dvc.updateStudioAccessToken',
   REMOVE_STUDIO_ACCESS_TOKEN = 'dvc.removeStudioAccessToken',
   EXPERIMENT_VIEW_SHARE_TO_STUDIO = 'dvc.views.experiments.shareExperimentToStudio'
 }

--- a/extension/src/connect/register.ts
+++ b/extension/src/connect/register.ts
@@ -22,6 +22,11 @@ export const registerConnectCommands = (
   )
 
   internalCommands.registerExternalCommand(
+    RegisteredCommands.UPDATE_STUDIO_ACCESS_TOKEN,
+    () => connect.saveStudioAccessToken()
+  )
+
+  internalCommands.registerExternalCommand(
     RegisteredCommands.REMOVE_STUDIO_ACCESS_TOKEN,
     () => connect.removeStudioAccessToken()
   )

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -287,5 +287,6 @@ export interface IEventNamePropertyMapping {
   [EventName.CONNECT_SHOW]: undefined
   [EventName.OPEN_STUDIO_SETTINGS]: undefined
   [EventName.ADD_STUDIO_ACCESS_TOKEN]: undefined
+  [EventName.UPDATE_STUDIO_ACCESS_TOKEN]: undefined
   [EventName.REMOVE_STUDIO_ACCESS_TOKEN]: undefined
 }

--- a/webview/src/connect/components/App.test.tsx
+++ b/webview/src/connect/components/App.test.tsx
@@ -96,5 +96,16 @@ describe('App', () => {
         type: MessageFromWebviewType.SET_STUDIO_SHARE_EXPERIMENTS_LIVE
       })
     })
+
+    it('should enable the user to update their studio token', () => {
+      const shareExperimentsLive = false
+      renderApp(true, shareExperimentsLive)
+      mockPostMessage.mockClear()
+      const button = screen.getByText('Update Token')
+      fireEvent.click(button)
+      expect(mockPostMessage).toHaveBeenCalledWith({
+        type: MessageFromWebviewType.SAVE_STUDIO_TOKEN
+      })
+    })
   })
 })

--- a/webview/src/connect/components/Studio.tsx
+++ b/webview/src/connect/components/Studio.tsx
@@ -82,7 +82,7 @@ const Settings: React.FC<{
           appearance="primary"
           isNested={false}
           text={'Update Token'}
-          onClick={openStudio}
+          onClick={saveStudioToken}
         />
         <Button
           appearance="secondary"


### PR DESCRIPTION
# 2/2 `main` <- #3399 <- this

Related to #3077 

This PR switches `dvc.addStudioAccessToken` to `dvc.updateStudioAccessToken` when Studio is connected.

As per [this thread](https://iterativeai.slack.com/archives/C01APS0FHDM/p1677657980420979).

### Demo


https://user-images.githubusercontent.com/37993418/223007143-c3256467-4e54-4890-8bb7-c104ea58d16b.mov

