### PR TITLE
Change the aspect ratio of plots through picker

### DIFF
--- a/extension/src/persistence/constants.ts
+++ b/extension/src/persistence/constants.ts
@@ -9,7 +9,7 @@ export enum PersistenceKey {
   PLOT_PATH_STATUS = 'plotPathStatus:',
   PLOT_COMPARISON_ORDER = 'plotComparisonOrder:',
   PLOT_COMPARISON_PATHS_ORDER = 'plotComparisonPathsOrder',
-  PLOT_HEIGHT = 'plotHeight',
+  PLOT_ASPECT_RATIO = 'plotASpectRatio',
   PLOT_METRIC_ORDER = 'plotMetricOrder:',
   PLOT_NB_ITEMS_PER_ROW = 'plotNbItemsPerRow:',
   PLOTS_CUSTOM_ORDER = 'plotCustomOrder:',

--- a/extension/src/plots/model/index.ts
+++ b/extension/src/plots/model/index.ts
@@ -28,7 +28,8 @@ import {
   SectionCollapsed,
   CustomPlotData,
   PlotNumberOfItemsPerRow,
-  DEFAULT_HEIGHT
+  PlotAspectRatio,
+  DEFAULT_ASPECT_RATIO
 } from '../webview/contract'
 import {
   ExperimentsOutput,
@@ -56,7 +57,7 @@ export class PlotsModel extends ModelWithPersistence {
   private readonly experiments: Experiments
 
   private nbItemsPerRow: Record<Section, number>
-  private height: Record<Section, number | undefined>
+  private aspectRatio: Record<Section, PlotAspectRatio>
   private customPlotsOrder: CustomPlotsOrderValue[]
   private sectionCollapsed: SectionCollapsed
   private commitRevisions: Record<string, string> = {}
@@ -88,7 +89,10 @@ export class PlotsModel extends ModelWithPersistence {
       PersistenceKey.PLOT_NB_ITEMS_PER_ROW,
       DEFAULT_SECTION_NB_ITEMS_PER_ROW
     )
-    this.height = this.revive(PersistenceKey.PLOT_HEIGHT, DEFAULT_HEIGHT)
+    this.aspectRatio = this.revive(
+      PersistenceKey.PLOT_ASPECT_RATIO,
+      DEFAULT_ASPECT_RATIO
+    )
 
     this.sectionCollapsed = this.revive(
       PersistenceKey.PLOT_SECTION_COLLAPSED,
@@ -181,7 +185,7 @@ export class PlotsModel extends ModelWithPersistence {
 
     return {
       colors,
-      height: this.getHeight(Section.CHECKPOINT_PLOTS),
+      aspectRatio: this.getASpectRatio(Section.CHECKPOINT_PLOTS),
       nbItemsPerRow: this.getNbItemsPerRow(Section.CHECKPOINT_PLOTS),
       plots: this.getPlots(this.checkpointPlots, selectedExperiments),
       selectedMetrics: this.getSelectedMetrics()
@@ -193,7 +197,7 @@ export class PlotsModel extends ModelWithPersistence {
       return
     }
     return {
-      height: this.getHeight(Section.CUSTOM_PLOTS),
+      aspectRatio: this.getASpectRatio(Section.CUSTOM_PLOTS),
       nbItemsPerRow: this.getNbItemsPerRow(Section.CUSTOM_PLOTS),
       plots: this.customPlots
     }
@@ -422,13 +426,13 @@ export class PlotsModel extends ModelWithPersistence {
     return PlotNumberOfItemsPerRow.TWO
   }
 
-  public setHeight(section: Section, height: number | undefined) {
-    this.height[section] = height
-    this.persist(PersistenceKey.PLOT_HEIGHT, this.height)
+  public setAspectRatio(section: Section, aspectRatio: PlotAspectRatio) {
+    this.aspectRatio[section] = aspectRatio
+    this.persist(PersistenceKey.PLOT_ASPECT_RATIO, this.aspectRatio)
   }
 
-  public getHeight(section: Section) {
-    return this.height[section]
+  public getASpectRatio(section: Section) {
+    return this.aspectRatio[section]
   }
 
   public setSectionCollapsed(newState: Partial<SectionCollapsed>) {

--- a/extension/src/plots/webview/contract.ts
+++ b/extension/src/plots/webview/contract.ts
@@ -11,6 +11,16 @@ export const PlotNumberOfItemsPerRow = {
 }
 /* eslint-enable sort-keys-fix/sort-keys-fix */
 
+export const PlotAspectRatio = {
+  NORMAL: '9/5',
+  DOUBLE: '2/1',
+  SQUARE: '1',
+  VERTICAL_NORMAL: '5/9',
+  VERTICAL_DOUBLE: '1/2'
+}
+export type PlotAspectRatio =
+  (typeof PlotAspectRatio)[keyof typeof PlotAspectRatio]
+
 export enum Section {
   CHECKPOINT_PLOTS = 'checkpoint-plots',
   TEMPLATE_PLOTS = 'template-plots',
@@ -25,12 +35,11 @@ export const DEFAULT_SECTION_NB_ITEMS_PER_ROW = {
   [Section.CUSTOM_PLOTS]: PlotNumberOfItemsPerRow.TWO
 }
 
-// Height is undefined by default because it is calculated by ratio of the width it'll fill (calculated by the webview)
-export const DEFAULT_HEIGHT = {
-  [Section.CHECKPOINT_PLOTS]: undefined,
-  [Section.TEMPLATE_PLOTS]: undefined,
-  [Section.COMPARISON_TABLE]: undefined,
-  [Section.CUSTOM_PLOTS]: undefined
+export const DEFAULT_ASPECT_RATIO = {
+  [Section.CHECKPOINT_PLOTS]: PlotAspectRatio.NORMAL,
+  [Section.TEMPLATE_PLOTS]: PlotAspectRatio.NORMAL,
+  [Section.COMPARISON_TABLE]: PlotAspectRatio.NORMAL,
+  [Section.CUSTOM_PLOTS]: PlotAspectRatio.NORMAL
 }
 
 export const DEFAULT_SECTION_COLLAPSED = {
@@ -68,7 +77,7 @@ export type Revision = {
 export interface PlotsComparisonData {
   plots: ComparisonPlots
   nbItemsPerRow: number
-  height: number | undefined
+  aspectRatio: PlotAspectRatio
   revisions: Revision[]
 }
 
@@ -101,7 +110,7 @@ export type CustomPlotData = {
 export type CustomPlotsData = {
   plots: CustomPlotData[]
   nbItemsPerRow: number
-  height: number | undefined
+  aspectRatio: PlotAspectRatio
 }
 
 export type CheckpointPlotData = CheckpointPlot & { title: string }
@@ -110,7 +119,7 @@ export type CheckpointPlotsData = {
   plots: CheckpointPlotData[]
   colors: ColorScale
   nbItemsPerRow: number
-  height: number | undefined
+  aspectRatio: PlotAspectRatio
   selectedMetrics?: string[]
 }
 
@@ -159,7 +168,7 @@ export type TemplatePlotSection = {
 export interface TemplatePlotsData {
   plots: TemplatePlotSection[]
   nbItemsPerRow: number
-  height: number | undefined
+  aspectRatio: PlotAspectRatio
 }
 
 export type ComparisonPlot = {

--- a/extension/src/plots/webview/messages.ts
+++ b/extension/src/plots/webview/messages.ts
@@ -2,6 +2,7 @@ import isEmpty from 'lodash.isempty'
 import {
   ComparisonPlot,
   ComparisonRevisionData,
+  PlotAspectRatio,
   PlotsData as TPlotsData,
   Revision,
   Section,
@@ -84,7 +85,7 @@ export class WebviewMessages {
         return this.setPlotSize(
           message.payload.section,
           message.payload.nbItemsPerRow,
-          message.payload.height
+          message.payload.aspectRatio
         )
       case MessageFromWebviewType.TOGGLE_PLOTS_SECTION:
         return this.setSectionCollapsed(message.payload)
@@ -123,13 +124,13 @@ export class WebviewMessages {
   private setPlotSize(
     section: Section,
     nbItemsPerRow: number,
-    height?: number
+    aspectRatio: PlotAspectRatio
   ) {
     this.plots.setNbItemsPerRow(section, nbItemsPerRow)
-    this.plots.setHeight(section, height)
+    this.plots.setAspectRatio(section, aspectRatio)
     sendTelemetryEvent(
       EventName.VIEWS_PLOTS_SECTION_RESIZED,
-      { height, nbItemsPerRow, section },
+      { aspectRatio, nbItemsPerRow, section },
       undefined
     )
   }
@@ -344,7 +345,7 @@ export class WebviewMessages {
     }
 
     return {
-      height: this.plots.getHeight(Section.TEMPLATE_PLOTS),
+      aspectRatio: this.plots.getASpectRatio(Section.TEMPLATE_PLOTS),
       nbItemsPerRow: this.plots.getNbItemsPerRow(Section.TEMPLATE_PLOTS),
       plots
     }
@@ -361,7 +362,7 @@ export class WebviewMessages {
     }
 
     return {
-      height: this.plots.getHeight(Section.COMPARISON_TABLE),
+      aspectRatio: this.plots.getASpectRatio(Section.COMPARISON_TABLE),
       nbItemsPerRow: this.plots.getNbItemsPerRow(Section.COMPARISON_TABLE),
       plots: comparison.map(({ path, revisions }) => {
         return { path, revisions: this.getRevisionsWithCorrectUrls(revisions) }

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -2,7 +2,11 @@ import { ViewColumn } from 'vscode'
 import { WorkspaceScale } from './collect'
 import { RegisteredCliCommands, RegisteredCommands } from '../commands/external'
 import { SortDefinition } from '../experiments/model/sortBy'
-import { Section, SectionCollapsed } from '../plots/webview/contract'
+import {
+  PlotAspectRatio,
+  Section,
+  SectionCollapsed
+} from '../plots/webview/contract'
 
 export const APPLICATION_INSIGHTS_KEY = '46e8e554-d50a-471a-a53b-4af2b1cd6594'
 
@@ -255,7 +259,7 @@ export interface IEventNamePropertyMapping {
   [EventName.VIEWS_PLOTS_SECTION_RESIZED]: {
     section: Section
     nbItemsPerRow: number
-    height: number | undefined
+    aspectRatio: PlotAspectRatio
   }
   [EventName.VIEWS_PLOTS_SECTION_TOGGLE]: Partial<SectionCollapsed>
   [EventName.VIEWS_PLOTS_SELECT_EXPERIMENTS]: undefined

--- a/extension/src/test/fixtures/expShow/base/checkpointPlots.ts
+++ b/extension/src/test/fixtures/expShow/base/checkpointPlots.ts
@@ -1,6 +1,7 @@
 import { copyOriginalColors } from '../../../../experiments/model/status/colors'
 import {
   CheckpointPlotsData,
+  PlotAspectRatio,
   PlotNumberOfItemsPerRow
 } from '../../../../plots/webview/contract'
 
@@ -92,7 +93,7 @@ const data: CheckpointPlotsData = {
     'summary.json:val_accuracy'
   ],
   nbItemsPerRow: PlotNumberOfItemsPerRow.TWO,
-  height: undefined
+  aspectRatio: PlotAspectRatio.NORMAL
 }
 
 export default data

--- a/extension/src/test/fixtures/expShow/base/customPlots.ts
+++ b/extension/src/test/fixtures/expShow/base/customPlots.ts
@@ -1,5 +1,6 @@
 import {
   CustomPlotsData,
+  PlotAspectRatio,
   PlotNumberOfItemsPerRow
 } from '../../../../plots/webview/contract'
 
@@ -51,7 +52,7 @@ const data: CustomPlotsData = {
     }
   ],
   nbItemsPerRow: PlotNumberOfItemsPerRow.TWO,
-  height: undefined
+  aspectRatio: PlotAspectRatio.NORMAL
 }
 
 export default data

--- a/extension/src/test/fixtures/plotsDiff/index.ts
+++ b/extension/src/test/fixtures/plotsDiff/index.ts
@@ -13,7 +13,8 @@ import {
   TemplatePlots,
   PlotNumberOfItemsPerRow,
   Revision,
-  PlotsComparisonData
+  PlotsComparisonData,
+  PlotAspectRatio
 } from '../../../plots/webview/contract'
 import { join } from '../../util/path'
 import { copyOriginalColors } from '../../../experiments/model/status/colors'
@@ -660,14 +661,14 @@ export const getRevisions = (): Revision[] => {
 export const getMinimalWebviewMessage = () => ({
   plots: extendedSpecs(basicVega),
   nbItemsPerRow: PlotNumberOfItemsPerRow.TWO,
-  height: undefined,
+  aspectRatio: PlotAspectRatio.NORMAL,
   revisions: getRevisions()
 })
 
 export const getTemplateWebviewMessage = (): TemplatePlotsData => ({
   plots: extendedSpecs({ ...basicVega, ...require('./vega').default }),
   nbItemsPerRow: PlotNumberOfItemsPerRow.TWO,
-  height: undefined
+  aspectRatio: PlotAspectRatio.NORMAL
 })
 
 export const getManyTemplatePlotsWebviewMessage = (
@@ -677,7 +678,7 @@ export const getManyTemplatePlotsWebviewMessage = (
     ...multipleVega(length)
   }),
   nbItemsPerRow: PlotNumberOfItemsPerRow.TWO,
-  height: undefined
+  aspectRatio: PlotAspectRatio.NORMAL
 })
 
 export const MOCK_IMAGE_MTIME = 946684800000
@@ -704,6 +705,6 @@ export const getComparisonWebviewMessage = (
     revisions: getRevisions(),
     plots: plotAcc,
     nbItemsPerRow: PlotNumberOfItemsPerRow.TWO,
-    height: undefined
+    aspectRatio: PlotAspectRatio.NORMAL
   }
 }

--- a/extension/src/test/suite/plots/index.test.ts
+++ b/extension/src/test/suite/plots/index.test.ts
@@ -28,7 +28,8 @@ import {
   PlotNumberOfItemsPerRow,
   Section,
   TemplatePlotGroup,
-  TemplatePlotsData
+  TemplatePlotsData,
+  PlotAspectRatio
 } from '../../../plots/webview/contract'
 import { TEMP_PLOTS_DIR } from '../../../cli/dvc/constants'
 import { WEBVIEW_TEST_TIMEOUT } from '../timeouts'
@@ -247,7 +248,7 @@ suite('Plots Test Suite', () => {
 
       mockMessageReceived.fire({
         payload: {
-          height: undefined,
+          aspectRatio: PlotAspectRatio.NORMAL,
           nbItemsPerRow: PlotNumberOfItemsPerRow.THREE,
           section: Section.TEMPLATE_PLOTS
         },
@@ -263,7 +264,7 @@ suite('Plots Test Suite', () => {
       expect(mockSendTelemetryEvent).to.be.calledWithExactly(
         EventName.VIEWS_PLOTS_SECTION_RESIZED,
         {
-          height: undefined,
+          aspectRatio: PlotAspectRatio.NORMAL,
           nbItemsPerRow: PlotNumberOfItemsPerRow.THREE,
           section: Section.TEMPLATE_PLOTS
         },
@@ -729,7 +730,11 @@ suite('Plots Test Suite', () => {
       const expectedPlotsData: TPlotsData = {
         checkpoint: checkpointPlotsFixture,
         comparison: comparisonPlotsFixture,
-        custom: { height: undefined, nbItemsPerRow: 2, plots: [] },
+        custom: {
+          aspectRatio: PlotAspectRatio.NORMAL,
+          nbItemsPerRow: 2,
+          plots: []
+        },
         hasPlots: true,
         hasUnselectedPlots: false,
         sectionCollapsed: DEFAULT_SECTION_COLLAPSED,

--- a/extension/src/test/suite/plots/util.ts
+++ b/extension/src/test/suite/plots/util.ts
@@ -131,7 +131,7 @@ export const getExpectedCheckpointPlotsData = (
   domain: string[],
   range: Color[]
 ) => {
-  const { plots, selectedMetrics, nbItemsPerRow, height } =
+  const { plots, selectedMetrics, nbItemsPerRow, aspectRatio } =
     checkpointPlotsFixture
   return {
     checkpoint: {
@@ -139,7 +139,7 @@ export const getExpectedCheckpointPlotsData = (
         domain,
         range
       },
-      height,
+      aspectRatio,
       nbItemsPerRow,
       plots: plots.map(plot => ({
         id: plot.id,

--- a/extension/src/webview/contract.ts
+++ b/extension/src/webview/contract.ts
@@ -2,6 +2,7 @@ import { ConnectData } from '../connect/webview/contract'
 import { SortDefinition } from '../experiments/model/sortBy'
 import { TableData } from '../experiments/webview/contract'
 import {
+  PlotAspectRatio,
   PlotsData,
   Section,
   SectionCollapsed,
@@ -76,7 +77,7 @@ export type ColumnResizePayload = {
 export type PlotsResizedPayload = {
   section: Section
   nbItemsPerRow: number
-  height: number | undefined
+  aspectRatio: PlotAspectRatio
 }
 export type PlotSectionRenamedPayload = {
   section: Section

--- a/webview/src/plots/components/App.test.tsx
+++ b/webview/src/plots/components/App.test.tsx
@@ -28,7 +28,8 @@ import {
   Revision,
   Section,
   TemplatePlotGroup,
-  TemplatePlotsData
+  TemplatePlotsData,
+  PlotAspectRatio
 } from 'dvc/src/plots/webview/contract'
 import {
   MessageFromWebviewType,
@@ -263,7 +264,7 @@ describe('App', () => {
     renderAppWithOptionalData({
       checkpoint: null,
       comparison: {
-        height: undefined,
+        aspectRatio: PlotAspectRatio.NORMAL,
         nbItemsPerRow: PlotNumberOfItemsPerRow.TWO,
         plots: [
           {

--- a/webview/src/plots/components/PlotsContainer.tsx
+++ b/webview/src/plots/components/PlotsContainer.tsx
@@ -8,7 +8,10 @@ import React, {
 } from 'react'
 import { AnyAction } from '@reduxjs/toolkit'
 import { useDispatch } from 'react-redux'
-import { Section } from 'dvc/src/plots/webview/contract'
+import {
+  PlotNumberOfItemsPerRow,
+  Section
+} from 'dvc/src/plots/webview/contract'
 import { MessageFromWebviewType } from 'dvc/src/webview/contract'
 import { PlotsPicker, PlotsPickerProps } from './PlotsPicker'
 import styles from './styles.module.scss'
@@ -117,7 +120,7 @@ export const PlotsContainer: React.FC<PlotsContainerProps> = ({
       icon: ArrowBoth,
       onClickNode: (
         <SingleSelect
-          items={[1, 2, 3, 4].map(nb => ({
+          items={Object.values(PlotNumberOfItemsPerRow).map(nb => ({
             id: nb.toString(),
             isSelected: nbItemsPerRow === nb,
             label: nb.toString()

--- a/webview/src/plots/components/PlotsContainer.tsx
+++ b/webview/src/plots/components/PlotsContainer.tsx
@@ -3,8 +3,11 @@ import React, {
   MouseEvent,
   useEffect,
   DetailedHTMLProps,
-  HTMLAttributes
+  HTMLAttributes,
+  useCallback
 } from 'react'
+import { AnyAction } from '@reduxjs/toolkit'
+import { useDispatch } from 'react-redux'
 import { Section } from 'dvc/src/plots/webview/contract'
 import { MessageFromWebviewType } from 'dvc/src/webview/contract'
 import { PlotsPicker, PlotsPickerProps } from './PlotsPicker'
@@ -20,16 +23,19 @@ import {
   Info,
   Lines,
   Add,
-  Trash
+  Trash,
+  ArrowBoth
 } from '../../shared/components/icons'
 import { isSelecting } from '../../util/strings'
 import { isTooltip } from '../../util/helpers'
+import { SingleSelect } from '../../shared/components/selectMenu/SingleSelect'
 
 export interface PlotsContainerProps {
   sectionCollapsed: boolean
   sectionKey: Section
   title: string
   nbItemsPerRow: number
+  changeNbItemsPerRow: (nb: number) => AnyAction
   menu?: PlotsPickerProps
   addPlotsButton?: { onClick: () => void }
   removePlotsButton?: { onClick: () => void }
@@ -96,15 +102,36 @@ export const PlotsContainer: React.FC<PlotsContainerProps> = ({
   nbItemsPerRow,
   menu,
   addPlotsButton,
-  removePlotsButton
+  removePlotsButton,
+  changeNbItemsPerRow
 }) => {
   const open = !sectionCollapsed
+  const dispatch = useDispatch()
 
   useEffect(() => {
     window.dispatchEvent(new Event('resize'))
   }, [nbItemsPerRow])
 
-  const menuItems: IconMenuItemProps[] = []
+  const menuItems: IconMenuItemProps[] = [
+    {
+      icon: ArrowBoth,
+      onClickNode: (
+        <SingleSelect
+          items={[1, 2, 3, 4].map(nb => ({
+            id: nb.toString(),
+            isSelected: nbItemsPerRow === nb,
+            label: nb.toString()
+          }))}
+          setSelected={useCallback(
+            (nb: string) =>
+              dispatch(changeNbItemsPerRow(Number.parseInt(nb, 10))),
+            [dispatch, changeNbItemsPerRow]
+          )}
+        />
+      ),
+      tooltip: 'Change the number of plots per row'
+    }
+  ]
 
   if (menu) {
     menuItems.unshift({

--- a/webview/src/plots/components/ZoomablePlot.tsx
+++ b/webview/src/plots/components/ZoomablePlot.tsx
@@ -1,20 +1,15 @@
 import { AnyAction } from '@reduxjs/toolkit'
-import cx from 'classnames'
-import { MessageFromWebviewType } from 'dvc/src/webview/contract'
 import { Section } from 'dvc/src/plots/webview/contract'
-import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import React, { useEffect, useRef } from 'react'
+import { useDispatch } from 'react-redux'
 import { VisualizationSpec } from 'react-vega'
 import { Renderers } from 'vega'
 import VegaLite, { VegaLiteProps } from 'react-vega/lib/VegaLite'
 import { setZoomedInPlot } from './webviewSlice'
 import styles from './styles.module.scss'
-import { Resizer } from './Resizer'
 import { config } from './constants'
-import { PlotsState } from '../store'
 import { useGetPlot } from '../hooks/useGetPlot'
 import { GripIcon } from '../../shared/components/dragDrop/GripIcon'
-import { sendMessage } from '../../shared/vscode'
 
 interface ZoomablePlotProps {
   spec?: VisualizationSpec
@@ -31,22 +26,11 @@ export const ZoomablePlot: React.FC<ZoomablePlotProps> = ({
   spec: createdSpec,
   id,
   onViewReady,
-  changeDisabledDragIds,
-  changeSize,
-  currentSnapPoint,
-  section,
-  shouldNotResize
+  section
 }) => {
-  const snapPoints = useSelector(
-    (state: PlotsState) => state.webview.snapPoints
-  )
   const { data, content: spec } = useGetPlot(section, id, createdSpec)
   const dispatch = useDispatch()
   const currentPlotProps = useRef<VegaLiteProps>()
-  const clickDisabled = useRef(false)
-  const enableClickTimeout = useRef(0)
-  const [isExpanding, setIsExpanding] = useState(false)
-  const size = snapPoints[currentSnapPoint - 1]
 
   const plotProps: VegaLiteProps = {
     actions: false,
@@ -64,63 +48,16 @@ export const ZoomablePlot: React.FC<ZoomablePlotProps> = ({
     )
   }, [data, spec, dispatch, id])
 
-  useEffect(() => {
-    return () => {
-      window.clearTimeout(enableClickTimeout.current)
-    }
-  }, [])
+  const handleOnClick = () => dispatch(setZoomedInPlot({ id, plot: plotProps }))
 
-  const handleOnClick = () =>
-    !clickDisabled.current && dispatch(setZoomedInPlot({ id, plot: plotProps }))
-
-  const onResize = useCallback(
-    (newSnapPoint: number) => {
-      dispatch(changeSize(newSnapPoint))
-      sendMessage({
-        payload: { height: undefined, nbItemsPerRow: newSnapPoint, section },
-        type: MessageFromWebviewType.RESIZE_PLOTS
-      })
-    },
-    [dispatch, changeSize, section]
-  )
-
-  const commonResizerProps = {
-    onGrab: () => {
-      clickDisabled.current = true
-      dispatch(changeDisabledDragIds([id]))
-    },
-    onRelease: () => {
-      dispatch(changeDisabledDragIds([]))
-      enableClickTimeout.current = window.setTimeout(
-        () => (clickDisabled.current = false),
-        0
-      )
-    },
-    onResize
-  }
   if (!data && !spec) {
     return null
   }
   return (
-    <button
-      className={cx(styles.zoomablePlot, {
-        [styles.plotExpanding]: isExpanding
-      })}
-      onClick={handleOnClick}
-    >
+    <button className={styles.zoomablePlot} onClick={handleOnClick}>
       <GripIcon className={styles.plotGripIcon} />
       {currentPlotProps.current && (
         <VegaLite {...plotProps} onNewView={onViewReady} />
-      )}
-      {!shouldNotResize && (
-        <Resizer
-          className={styles.plotVerticalResizer}
-          {...commonResizerProps}
-          snapPoints={snapPoints}
-          currentSnapPoint={currentSnapPoint}
-          sizeBetweenResizers={size} // 20 is the $gap set in styles.module.scss
-          setIsExpanding={setIsExpanding}
-        />
       )}
     </button>
   )

--- a/webview/src/plots/components/checkpointPlots/CheckpointPlotsWrapper.tsx
+++ b/webview/src/plots/components/checkpointPlots/CheckpointPlotsWrapper.tsx
@@ -3,14 +3,20 @@ import { MessageFromWebviewType } from 'dvc/src/webview/contract'
 import React, { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { CheckpointPlots } from './CheckpointPlots'
-import { changeSize } from './checkpointPlotsSlice'
+import { changeAspectRatio, changeSize } from './checkpointPlotsSlice'
 import { PlotsContainer } from '../PlotsContainer'
 import { sendMessage } from '../../../shared/vscode'
 import { PlotsState } from '../../store'
 
 export const CheckpointPlotsWrapper: React.FC = () => {
-  const { plotsIds, nbItemsPerRow, selectedMetrics, isCollapsed, colors } =
-    useSelector((state: PlotsState) => state.checkpoint)
+  const {
+    plotsIds,
+    nbItemsPerRow,
+    selectedMetrics,
+    isCollapsed,
+    colors,
+    aspectRatio
+  } = useSelector((state: PlotsState) => state.checkpoint)
   const [metrics, setMetrics] = useState<string[]>([])
   const [selectedPlots, setSelectedPlots] = useState<string[]>([])
 
@@ -44,6 +50,8 @@ export const CheckpointPlotsWrapper: React.FC = () => {
       nbItemsPerRow={nbItemsPerRow}
       sectionCollapsed={isCollapsed}
       changeNbItemsPerRow={changeSize}
+      changeAspectRatio={changeAspectRatio}
+      aspectRatio={aspectRatio}
     >
       <CheckpointPlots plotsIds={selectedPlots} colors={colors} />
     </PlotsContainer>

--- a/webview/src/plots/components/checkpointPlots/CheckpointPlotsWrapper.tsx
+++ b/webview/src/plots/components/checkpointPlots/CheckpointPlotsWrapper.tsx
@@ -3,6 +3,7 @@ import { MessageFromWebviewType } from 'dvc/src/webview/contract'
 import React, { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { CheckpointPlots } from './CheckpointPlots'
+import { changeSize } from './checkpointPlotsSlice'
 import { PlotsContainer } from '../PlotsContainer'
 import { sendMessage } from '../../../shared/vscode'
 import { PlotsState } from '../../store'
@@ -42,6 +43,7 @@ export const CheckpointPlotsWrapper: React.FC = () => {
       menu={menu}
       nbItemsPerRow={nbItemsPerRow}
       sectionCollapsed={isCollapsed}
+      changeNbItemsPerRow={changeSize}
     >
       <CheckpointPlots plotsIds={selectedPlots} colors={colors} />
     </PlotsContainer>

--- a/webview/src/plots/components/checkpointPlots/checkpointPlotsSlice.ts
+++ b/webview/src/plots/components/checkpointPlots/checkpointPlotsSlice.ts
@@ -1,9 +1,10 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import {
   CheckpointPlotsData,
-  DEFAULT_HEIGHT,
+  DEFAULT_ASPECT_RATIO,
   DEFAULT_SECTION_COLLAPSED,
   DEFAULT_SECTION_NB_ITEMS_PER_ROW,
+  PlotAspectRatio,
   Section
 } from 'dvc/src/plots/webview/contract'
 import { addPlotsWithSnapshots, removePlots } from '../plotDataStore'
@@ -18,10 +19,10 @@ export interface CheckpointPlotsState
 }
 
 export const checkpointPlotsInitialState: CheckpointPlotsState = {
+  aspectRatio: DEFAULT_ASPECT_RATIO[Section.CHECKPOINT_PLOTS],
   colors: { domain: [], range: [] },
   disabledDragPlotIds: [],
   hasData: false,
-  height: DEFAULT_HEIGHT[Section.CHECKPOINT_PLOTS],
   isCollapsed: DEFAULT_SECTION_COLLAPSED[Section.CHECKPOINT_PLOTS],
   nbItemsPerRow: DEFAULT_SECTION_NB_ITEMS_PER_ROW[Section.CHECKPOINT_PLOTS],
   plotsIds: [],
@@ -33,6 +34,9 @@ export const checkpointPlotsSlice = createSlice({
   initialState: checkpointPlotsInitialState,
   name: 'checkpoint',
   reducers: {
+    changeAspectRatio: (state, action: PayloadAction<PlotAspectRatio>) => {
+      state.aspectRatio = action.payload
+    },
     changeDisabledDragIds: (state, action: PayloadAction<string[]>) => {
       state.disabledDragPlotIds = action.payload
     },
@@ -61,7 +65,12 @@ export const checkpointPlotsSlice = createSlice({
   }
 })
 
-export const { update, setCollapsed, changeSize, changeDisabledDragIds } =
-  checkpointPlotsSlice.actions
+export const {
+  update,
+  setCollapsed,
+  changeSize,
+  changeDisabledDragIds,
+  changeAspectRatio
+} = checkpointPlotsSlice.actions
 
 export default checkpointPlotsSlice.reducer

--- a/webview/src/plots/components/comparisonTable/ComparisonTableWrapper.tsx
+++ b/webview/src/plots/components/comparisonTable/ComparisonTableWrapper.tsx
@@ -1,6 +1,7 @@
 import { Section } from 'dvc/src/plots/webview/contract'
 import React from 'react'
 import { useSelector } from 'react-redux'
+import { changeSize } from './comparisonTableSlice'
 import { ComparisonTable } from './ComparisonTable'
 import { PlotsContainer } from '../PlotsContainer'
 import { PlotsState } from '../../store'
@@ -16,6 +17,7 @@ export const ComparisonTableWrapper: React.FC = () => {
       sectionKey={Section.COMPARISON_TABLE}
       nbItemsPerRow={nbItemsPerRow}
       sectionCollapsed={isCollapsed}
+      changeNbItemsPerRow={changeSize}
     >
       <ComparisonTable />
     </PlotsContainer>

--- a/webview/src/plots/components/comparisonTable/ComparisonTableWrapper.tsx
+++ b/webview/src/plots/components/comparisonTable/ComparisonTableWrapper.tsx
@@ -1,13 +1,13 @@
 import { Section } from 'dvc/src/plots/webview/contract'
 import React from 'react'
 import { useSelector } from 'react-redux'
-import { changeSize } from './comparisonTableSlice'
+import { changeAspectRatio, changeSize } from './comparisonTableSlice'
 import { ComparisonTable } from './ComparisonTable'
 import { PlotsContainer } from '../PlotsContainer'
 import { PlotsState } from '../../store'
 
 export const ComparisonTableWrapper: React.FC = () => {
-  const { nbItemsPerRow, isCollapsed } = useSelector(
+  const { nbItemsPerRow, isCollapsed, aspectRatio } = useSelector(
     (state: PlotsState) => state.comparison
   )
 
@@ -18,6 +18,8 @@ export const ComparisonTableWrapper: React.FC = () => {
       nbItemsPerRow={nbItemsPerRow}
       sectionCollapsed={isCollapsed}
       changeNbItemsPerRow={changeSize}
+      changeAspectRatio={changeAspectRatio}
+      aspectRatio={aspectRatio}
     >
       <ComparisonTable />
     </PlotsContainer>

--- a/webview/src/plots/components/comparisonTable/comparisonTableSlice.ts
+++ b/webview/src/plots/components/comparisonTable/comparisonTableSlice.ts
@@ -1,8 +1,9 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import {
-  DEFAULT_HEIGHT,
+  DEFAULT_ASPECT_RATIO,
   DEFAULT_SECTION_COLLAPSED,
   DEFAULT_SECTION_NB_ITEMS_PER_ROW,
+  PlotAspectRatio,
   PlotsComparisonData,
   Section
 } from 'dvc/src/plots/webview/contract'
@@ -16,8 +17,8 @@ export interface ComparisonTableState extends PlotsComparisonData {
 export const DEFAULT_ROW_HEIGHT = 200
 
 export const comparisonTableInitialState: ComparisonTableState = {
+  aspectRatio: DEFAULT_ASPECT_RATIO[Section.COMPARISON_TABLE],
   hasData: false,
-  height: DEFAULT_HEIGHT[Section.COMPARISON_TABLE],
   isCollapsed: DEFAULT_SECTION_COLLAPSED[Section.COMPARISON_TABLE],
   nbItemsPerRow: DEFAULT_SECTION_NB_ITEMS_PER_ROW[Section.COMPARISON_TABLE],
   plots: [],
@@ -29,6 +30,9 @@ export const comparisonTableSlice = createSlice({
   initialState: comparisonTableInitialState,
   name: 'comparison',
   reducers: {
+    changeAspectRatio: (state, action: PayloadAction<PlotAspectRatio>) => {
+      state.aspectRatio = action.payload
+    },
     changeRowHeight: (state, action: PayloadAction<number>) => {
       state.rowHeight = action.payload
     },
@@ -51,7 +55,12 @@ export const comparisonTableSlice = createSlice({
   }
 })
 
-export const { update, setCollapsed, changeSize, changeRowHeight } =
-  comparisonTableSlice.actions
+export const {
+  update,
+  setCollapsed,
+  changeSize,
+  changeRowHeight,
+  changeAspectRatio
+} = comparisonTableSlice.actions
 
 export default comparisonTableSlice.reducer

--- a/webview/src/plots/components/customPlots/CustomPlotsWrapper.tsx
+++ b/webview/src/plots/components/customPlots/CustomPlotsWrapper.tsx
@@ -3,13 +3,13 @@ import React, { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { MessageFromWebviewType } from 'dvc/src/webview/contract'
 import { CustomPlots } from './CustomPlots'
-import { changeSize } from './customPlotsSlice'
+import { changeAspectRatio, changeSize } from './customPlotsSlice'
 import { PlotsContainer } from '../PlotsContainer'
 import { PlotsState } from '../../store'
 import { sendMessage } from '../../../shared/vscode'
 
 export const CustomPlotsWrapper: React.FC = () => {
-  const { plotsIds, nbItemsPerRow, isCollapsed } = useSelector(
+  const { plotsIds, nbItemsPerRow, isCollapsed, aspectRatio } = useSelector(
     (state: PlotsState) => state.custom
   )
   const [selectedPlots, setSelectedPlots] = useState<string[]>([])
@@ -35,6 +35,8 @@ export const CustomPlotsWrapper: React.FC = () => {
         plotsIds.length > 0 ? { onClick: removeCustomPlots } : undefined
       }
       changeNbItemsPerRow={changeSize}
+      changeAspectRatio={changeAspectRatio}
+      aspectRatio={aspectRatio}
     >
       <CustomPlots plotsIds={selectedPlots} />
     </PlotsContainer>

--- a/webview/src/plots/components/customPlots/CustomPlotsWrapper.tsx
+++ b/webview/src/plots/components/customPlots/CustomPlotsWrapper.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { MessageFromWebviewType } from 'dvc/src/webview/contract'
 import { CustomPlots } from './CustomPlots'
+import { changeSize } from './customPlotsSlice'
 import { PlotsContainer } from '../PlotsContainer'
 import { PlotsState } from '../../store'
 import { sendMessage } from '../../../shared/vscode'
@@ -33,6 +34,7 @@ export const CustomPlotsWrapper: React.FC = () => {
       removePlotsButton={
         plotsIds.length > 0 ? { onClick: removeCustomPlots } : undefined
       }
+      changeNbItemsPerRow={changeSize}
     >
       <CustomPlots plotsIds={selectedPlots} />
     </PlotsContainer>

--- a/webview/src/plots/components/customPlots/customPlotsSlice.ts
+++ b/webview/src/plots/components/customPlots/customPlotsSlice.ts
@@ -1,9 +1,10 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import {
   CustomPlotsData,
-  DEFAULT_HEIGHT,
+  DEFAULT_ASPECT_RATIO,
   DEFAULT_SECTION_COLLAPSED,
   DEFAULT_SECTION_NB_ITEMS_PER_ROW,
+  PlotAspectRatio,
   Section
 } from 'dvc/src/plots/webview/contract'
 import { addPlotsWithSnapshots, removePlots } from '../plotDataStore'
@@ -17,9 +18,9 @@ export interface CustomPlotsState extends Omit<CustomPlotsData, 'plots'> {
 }
 
 export const customPlotsInitialState: CustomPlotsState = {
+  aspectRatio: DEFAULT_ASPECT_RATIO[Section.CUSTOM_PLOTS],
   disabledDragPlotIds: [],
   hasData: false,
-  height: DEFAULT_HEIGHT[Section.CUSTOM_PLOTS],
   isCollapsed: DEFAULT_SECTION_COLLAPSED[Section.CUSTOM_PLOTS],
   nbItemsPerRow: DEFAULT_SECTION_NB_ITEMS_PER_ROW[Section.CUSTOM_PLOTS],
   plotsIds: [],
@@ -30,6 +31,9 @@ export const customPlotsSlice = createSlice({
   initialState: customPlotsInitialState,
   name: 'custom',
   reducers: {
+    changeAspectRatio: (state, action: PayloadAction<PlotAspectRatio>) => {
+      state.aspectRatio = action.payload
+    },
     changeDisabledDragIds: (state, action: PayloadAction<string[]>) => {
       state.disabledDragPlotIds = action.payload
     },
@@ -58,7 +62,12 @@ export const customPlotsSlice = createSlice({
   }
 })
 
-export const { update, setCollapsed, changeSize, changeDisabledDragIds } =
-  customPlotsSlice.actions
+export const {
+  update,
+  setCollapsed,
+  changeSize,
+  changeDisabledDragIds,
+  changeAspectRatio
+} = customPlotsSlice.actions
 
 export default customPlotsSlice.reducer

--- a/webview/src/plots/components/styles.module.scss
+++ b/webview/src/plots/components/styles.module.scss
@@ -124,7 +124,6 @@ $gap: 20px;
 }
 
 .plot {
-  aspect-ratio: 9 / 5;
   overflow: visible;
   cursor: grab;
   position: relative;
@@ -157,6 +156,26 @@ $gap: 20px;
       opacity: 0.5;
     }
   }
+}
+
+.ratioNormal .plot {
+  aspect-ratio: 9 / 5;
+}
+
+.ratioDouble .plot {
+  aspect-ratio: 2 / 1;
+}
+
+.ratioSquare .plot {
+  aspect-ratio: 1;
+}
+
+.ratioVerticalNormal .plot {
+  aspect-ratio: 2 / 1;
+}
+
+.ratioVerticalDouble .plot {
+  aspect-ratio: 1 / 2;
 }
 
 .plotHorizontalResizer,

--- a/webview/src/plots/components/templatePlots/TemplatePlotsWrapper.tsx
+++ b/webview/src/plots/components/templatePlots/TemplatePlotsWrapper.tsx
@@ -2,6 +2,7 @@ import { Section } from 'dvc/src/plots/webview/contract'
 import React from 'react'
 import { useSelector } from 'react-redux'
 import { TemplatePlots } from './TemplatePlots'
+import { changeSize } from './templatePlotsSlice'
 import { PlotsContainer } from '../PlotsContainer'
 import { PlotsState } from '../../store'
 
@@ -16,6 +17,7 @@ export const TemplatePlotsWrapper: React.FC = () => {
       sectionKey={Section.TEMPLATE_PLOTS}
       nbItemsPerRow={nbItemsPerRow}
       sectionCollapsed={isCollapsed}
+      changeNbItemsPerRow={changeSize}
     >
       <TemplatePlots />
     </PlotsContainer>

--- a/webview/src/plots/components/templatePlots/TemplatePlotsWrapper.tsx
+++ b/webview/src/plots/components/templatePlots/TemplatePlotsWrapper.tsx
@@ -2,12 +2,12 @@ import { Section } from 'dvc/src/plots/webview/contract'
 import React from 'react'
 import { useSelector } from 'react-redux'
 import { TemplatePlots } from './TemplatePlots'
-import { changeSize } from './templatePlotsSlice'
+import { changeAspectRatio, changeSize } from './templatePlotsSlice'
 import { PlotsContainer } from '../PlotsContainer'
 import { PlotsState } from '../../store'
 
 export const TemplatePlotsWrapper: React.FC = () => {
-  const { nbItemsPerRow, isCollapsed } = useSelector(
+  const { nbItemsPerRow, isCollapsed, aspectRatio } = useSelector(
     (state: PlotsState) => state.template
   )
 
@@ -18,6 +18,8 @@ export const TemplatePlotsWrapper: React.FC = () => {
       nbItemsPerRow={nbItemsPerRow}
       sectionCollapsed={isCollapsed}
       changeNbItemsPerRow={changeSize}
+      changeAspectRatio={changeAspectRatio}
+      aspectRatio={aspectRatio}
     >
       <TemplatePlots />
     </PlotsContainer>

--- a/webview/src/plots/components/templatePlots/templatePlotsSlice.ts
+++ b/webview/src/plots/components/templatePlots/templatePlotsSlice.ts
@@ -1,8 +1,9 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import {
-  DEFAULT_HEIGHT,
+  DEFAULT_ASPECT_RATIO,
   DEFAULT_SECTION_COLLAPSED,
   DEFAULT_SECTION_NB_ITEMS_PER_ROW,
+  PlotAspectRatio,
   Section,
   TemplatePlotGroup,
   TemplatePlotsData
@@ -19,9 +20,9 @@ export interface TemplatePlotsState extends Omit<TemplatePlotsData, 'plots'> {
 }
 
 export const templatePlotsInitialState: TemplatePlotsState = {
+  aspectRatio: DEFAULT_ASPECT_RATIO[Section.TEMPLATE_PLOTS],
   disabledDragPlotIds: [],
   hasData: false,
-  height: DEFAULT_HEIGHT[Section.TEMPLATE_PLOTS],
   isCollapsed: DEFAULT_SECTION_COLLAPSED[Section.TEMPLATE_PLOTS],
   nbItemsPerRow: DEFAULT_SECTION_NB_ITEMS_PER_ROW[Section.TEMPLATE_PLOTS],
   plotsSnapshots: {},
@@ -32,6 +33,9 @@ export const templatePlotsSlice = createSlice({
   initialState: templatePlotsInitialState,
   name: 'template',
   reducers: {
+    changeAspectRatio: (state, action: PayloadAction<PlotAspectRatio>) => {
+      state.aspectRatio = action.payload
+    },
     changeDisabledDragIds: (state, action: PayloadAction<string[]>) => {
       state.disabledDragPlotIds = action.payload
     },
@@ -58,6 +62,7 @@ export const templatePlotsSlice = createSlice({
 
       return {
         ...state,
+        aspectRatio: action.payload.aspectRatio,
         hasData: !!action.payload,
         nbItemsPerRow: action.payload.nbItemsPerRow,
         plotsSnapshots: snapShots,
@@ -79,6 +84,7 @@ export const templatePlotsSlice = createSlice({
 export const {
   update,
   setCollapsed,
+  changeAspectRatio,
   changeSize,
   changeDisabledDragIds,
   updateSections

--- a/webview/src/shared/components/iconMenu/styles.module.scss
+++ b/webview/src/shared/components/iconMenu/styles.module.scss
@@ -21,6 +21,10 @@
   background: inherit;
   color: $fg-color;
 
+  svg {
+    fill: $fg-color;
+  }
+
   &:hover {
     background-color: var(--editor-foreground-transparency-1);
   }

--- a/webview/src/shared/components/icons/ArrowBoth.tsx
+++ b/webview/src/shared/components/icons/ArrowBoth.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react'
+
+function SvgArrowBoth(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      {...props}
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M3 9l2.146 2.146-.707.708-3-3v-.708l3-3 .707.708L3 8h10l-2.146-2.146.707-.708 3 3v.708l-3 3-.707-.707L13 9H3z"
+      />
+    </svg>
+  )
+}
+
+export default SvgArrowBoth

--- a/webview/src/shared/components/icons/ArrowBothVertical.tsx
+++ b/webview/src/shared/components/icons/ArrowBothVertical.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+
+function SvgArrowBoth(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      transform="rotate(90 0 0)"
+      {...props}
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M3 9l2.146 2.146-.707.708-3-3v-.708l3-3 .707.708L3 8h10l-2.146-2.146.707-.708 3 3v.708l-3 3-.707-.707L13 9H3z"
+      />
+    </svg>
+  )
+}
+
+export default SvgArrowBoth

--- a/webview/src/shared/components/icons/index.ts
+++ b/webview/src/shared/components/icons/index.ts
@@ -1,5 +1,6 @@
 export { default as Add } from './Add'
 export { default as ArrowBoth } from './ArrowBoth'
+export { default as ArrowBothVertical } from './ArrowBothVertical'
 export { default as Check } from './Check'
 export { default as ChevronDown } from './ChevronDown'
 export { default as ChevronRight } from './ChevronRight'

--- a/webview/src/shared/components/icons/index.ts
+++ b/webview/src/shared/components/icons/index.ts
@@ -1,4 +1,5 @@
 export { default as Add } from './Add'
+export { default as ArrowBoth } from './ArrowBoth'
 export { default as Check } from './Check'
 export { default as ChevronDown } from './ChevronDown'
 export { default as ChevronRight } from './ChevronRight'

--- a/webview/src/shared/components/selectMenu/SingleSelect.tsx
+++ b/webview/src/shared/components/selectMenu/SingleSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { SelectMenu } from './SelectMenu'
 import { SelectMenuOptionProps } from './SelectMenuOption'
 
@@ -11,9 +11,7 @@ export const SingleSelect: React.FC<{
     setOptions(
       options.map(option => ({ ...option, isSelected: option.id === id }))
     )
+    setSelected(id)
   }
-  useEffect(() => {
-    setSelected(options.find(option => option.isSelected)?.id || '')
-  }, [options, setSelected])
   return <SelectMenu options={options} onClick={onClick} />
 }

--- a/webview/src/stories/ComparisonTable.stories.tsx
+++ b/webview/src/stories/ComparisonTable.stories.tsx
@@ -7,7 +7,9 @@ import { Provider, useDispatch } from 'react-redux'
 import {
   ComparisonRevisionData,
   PlotsComparisonData,
-  PlotNumberOfItemsPerRow
+  PlotNumberOfItemsPerRow,
+  DEFAULT_ASPECT_RATIO,
+  Section
 } from 'dvc/src/plots/webview/contract'
 import comparisonTableFixture from 'dvc/src/test/fixtures/plotsDiff/comparison'
 import { EXPERIMENT_WORKSPACE_ID } from 'dvc/src/cli/dvc/contract'
@@ -43,7 +45,7 @@ const Template: Story = ({ plots, revisions }) => {
     <Provider store={store}>
       <MockedState
         data={{
-          height: undefined,
+          aspectRatio: DEFAULT_ASPECT_RATIO[Section.COMPARISON_TABLE],
           nbItemsPerRow: PlotNumberOfItemsPerRow.TWO,
           plots,
           revisions

--- a/webview/src/stories/Icons.stories.tsx
+++ b/webview/src/stories/Icons.stories.tsx
@@ -1,0 +1,123 @@
+import { Story, Meta } from '@storybook/react/types-6-0'
+import React from 'react'
+
+import './test-vscode-styles.scss'
+import '../shared/style.scss'
+import { IconWrapper } from './components/IconWrapper'
+import { IconsWrapper } from './components/IconsWrapper'
+import { Icon } from '../shared/components/Icon'
+import {
+  Add,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  Close,
+  Copy,
+  Dots,
+  DownArrow,
+  Ellipsis,
+  Error,
+  Filter,
+  GitCommit,
+  GraphLine,
+  GraphScatter,
+  Gripper,
+  Lines,
+  Pin,
+  Refresh,
+  SortPrecedence,
+  StarEmpty,
+  StarFull,
+  Trash,
+  UpArrow
+} from '../shared/components/icons'
+
+export default {
+  args: {
+    data: {}
+  },
+  component: Icon,
+  title: 'Icons'
+} as Meta
+
+const Template: Story = () => {
+  return (
+    <IconsWrapper>
+      <IconWrapper name="Add">
+        <Icon icon={Add} />
+      </IconWrapper>
+      <IconWrapper name="Check">
+        <Icon icon={Check} />
+      </IconWrapper>
+      <IconWrapper name="ChevronDown">
+        <Icon icon={ChevronDown} />
+      </IconWrapper>
+      <IconWrapper name="ChevronRight">
+        <Icon icon={ChevronRight} />
+      </IconWrapper>
+      <IconWrapper name="Clock">
+        <Icon icon={Clock} />
+      </IconWrapper>
+      <IconWrapper name="Close">
+        <Icon icon={Close} />
+      </IconWrapper>
+      <IconWrapper name="Copy">
+        <Icon icon={Copy} />
+      </IconWrapper>
+      <IconWrapper name="Dots">
+        <Icon icon={Dots} />
+      </IconWrapper>
+      <IconWrapper name="DownArrow">
+        <Icon icon={DownArrow} />
+      </IconWrapper>
+      <IconWrapper name="Ellipsis">
+        <Icon icon={Ellipsis} />
+      </IconWrapper>
+      <IconWrapper name="Error">
+        <Icon icon={Error} />
+      </IconWrapper>
+      <IconWrapper name="Filter">
+        <Icon icon={Filter} />
+      </IconWrapper>
+      <IconWrapper name="GitCommit">
+        <Icon icon={GitCommit} />
+      </IconWrapper>
+      <IconWrapper name="GraphLine">
+        <Icon icon={GraphLine} />
+      </IconWrapper>
+      <IconWrapper name="GraphScatter">
+        <Icon icon={GraphScatter} />
+      </IconWrapper>
+      <IconWrapper name="Gripper">
+        <Icon icon={Gripper} />
+      </IconWrapper>
+      <IconWrapper name="Lines">
+        <Icon icon={Lines} />
+      </IconWrapper>
+      <IconWrapper name="Pin">
+        <Icon icon={Pin} />
+      </IconWrapper>
+      <IconWrapper name="Refresh">
+        <Icon icon={Refresh} />
+      </IconWrapper>
+      <IconWrapper name="SortPrecedence">
+        <Icon icon={SortPrecedence} />
+      </IconWrapper>
+      <IconWrapper name="StarEmpty">
+        <Icon icon={StarEmpty} />
+      </IconWrapper>
+      <IconWrapper name="StarFull">
+        <Icon icon={StarFull} />
+      </IconWrapper>
+      <IconWrapper name="Trash">
+        <Icon icon={Trash} />
+      </IconWrapper>
+      <IconWrapper name="UpArrow">
+        <Icon icon={UpArrow} />
+      </IconWrapper>
+    </IconsWrapper>
+  )
+}
+
+export const AllIcons = Template.bind({})

--- a/webview/src/stories/Icons.stories.tsx
+++ b/webview/src/stories/Icons.stories.tsx
@@ -5,6 +5,7 @@ import './test-vscode-styles.scss'
 import '../shared/style.scss'
 import { IconWrapper } from './components/IconWrapper'
 import { IconsWrapper } from './components/IconsWrapper'
+import { DISABLE_CHROMATIC_SNAPSHOTS } from './util'
 import { Icon } from '../shared/components/Icon'
 import {
   Add,
@@ -38,6 +39,7 @@ export default {
     data: {}
   },
   component: Icon,
+  parameters: DISABLE_CHROMATIC_SNAPSHOTS,
   title: 'Icons'
 } as Meta
 

--- a/webview/src/stories/Icons.stories.tsx
+++ b/webview/src/stories/Icons.stories.tsx
@@ -10,6 +10,7 @@ import { Icon } from '../shared/components/Icon'
 import {
   Add,
   ArrowBoth,
+  ArrowBothVertical,
   Check,
   ChevronDown,
   ChevronRight,
@@ -52,6 +53,9 @@ const Template: Story = () => {
       </IconWrapper>
       <IconWrapper name="ArrowBoth">
         <Icon icon={ArrowBoth} />
+      </IconWrapper>
+      <IconWrapper name="ArrowBothVertical">
+        <Icon icon={ArrowBothVertical} />
       </IconWrapper>
       <IconWrapper name="Check">
         <Icon icon={Check} />

--- a/webview/src/stories/Icons.stories.tsx
+++ b/webview/src/stories/Icons.stories.tsx
@@ -9,6 +9,7 @@ import { DISABLE_CHROMATIC_SNAPSHOTS } from './util'
 import { Icon } from '../shared/components/Icon'
 import {
   Add,
+  ArrowBoth,
   Check,
   ChevronDown,
   ChevronRight,
@@ -48,6 +49,9 @@ const Template: Story = () => {
     <IconsWrapper>
       <IconWrapper name="Add">
         <Icon icon={Add} />
+      </IconWrapper>
+      <IconWrapper name="ArrowBoth">
+        <Icon icon={ArrowBoth} />
       </IconWrapper>
       <IconWrapper name="Check">
         <Icon icon={Check} />

--- a/webview/src/stories/components/IconWrapper.tsx
+++ b/webview/src/stories/components/IconWrapper.tsx
@@ -1,0 +1,12 @@
+import React, { ReactNode } from 'react'
+import styles from './styles.module.scss'
+
+export const IconWrapper: React.FC<{ children: ReactNode; name: string }> = ({
+  children,
+  name
+}) => (
+  <div className={styles.iconWrapper}>
+    {children}
+    <h3 className={styles.iconTitle}>{name}</h3>
+  </div>
+)

--- a/webview/src/stories/components/IconsWrapper.tsx
+++ b/webview/src/stories/components/IconsWrapper.tsx
@@ -1,0 +1,6 @@
+import React, { ReactNode } from 'react'
+import styles from './styles.module.scss'
+
+export const IconsWrapper: React.FC<{ children: ReactNode }> = ({
+  children
+}) => <div className={styles.iconsWrapper}>{children}</div>

--- a/webview/src/stories/components/styles.module.scss
+++ b/webview/src/stories/components/styles.module.scss
@@ -1,0 +1,31 @@
+@import '../../shared/variables.scss';
+
+.iconsWrapper {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  max-width: 100%;
+}
+
+.iconWrapper {
+  padding: 5px;
+  border: 1px solid $fg-color;
+  border-radius: 3px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100px;
+  height: 80px;
+
+  svg {
+    fill: $fg-color;
+    width: 20px;
+    height: 20px;
+  }
+}
+
+.iconTitle {
+  font-size: 0.6rem;
+  padding: 3px;
+}


### PR DESCRIPTION
Part of #2585 


https://user-images.githubusercontent.com/3683420/223207832-9a3abc70-2079-4221-a811-73cf3100125e.mov

Similar to #3405 

Currently using "random" aspect ratio. Could test more to get something that look nicer. Maybe we could have a resize quick pick / input with two steps (select number items per plots and then the aspect ratio), but I do like the fact that there you can see the impact of each choice from the picker directly and pick something else quickly if it's not what you like.