### PR TITLE
Move filter by and sort by views to the bottom and collapse for new users

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1381,18 +1381,20 @@
           "when": "dvc.commands.available && dvc.project.available"
         },
         {
+          "id": "dvc.views.support",
+          "name": "Support"
+        },
+        {
           "id": "dvc.views.experimentsSortByTree",
           "name": "Sort By",
-          "when": "dvc.commands.available && dvc.project.available"
+          "when": "dvc.commands.available && dvc.project.available",
+          "visibility": "collapsed"
         },
         {
           "id": "dvc.views.experimentsFilterByTree",
           "name": "Filter By",
-          "when": "dvc.commands.available && dvc.project.available"
-        },
-        {
-          "id": "dvc.views.support",
-          "name": "Support"
+          "when": "dvc.commands.available && dvc.project.available",
+          "visibility": "collapsed"
         }
       ]
     },


### PR DESCRIPTION
This PR moves the filter by and sort by trees to the bottom of our view container and collapses them for new users. I think we can do this because we have decided these are "advanced features". From the docs:

```
A view can also have an optional visibility property which can be set to visible, collapsed, or hidden. 
This property is only respected by VS Code the first time a workspace is opened with this view. 
After that, the visibility is set to whatever the user has chosen. 
If you have a view container with many views, or if your view will not be useful to every user of your extension, consider setting the view the collapsed or hidden. 
```

This will be the screen that a new user sees when they get setup for the first time:

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/37993418/223858818-925cbd1d-92be-46b6-bb06-93378bbce4a6.png">

For comparison, Gitlens collapses all of the views it adds to the SCM tree. I only expand them when I use them. E.g:

https://user-images.githubusercontent.com/37993418/223859999-6c406b13-f024-4c8b-9896-fe49de212d31.mov

[Q] Which other (if any) tree views should get the same treatment?