### PR TITLE
Hide Studio view during onboarding process/startup

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1363,7 +1363,7 @@
         {
           "id": "dvc.views.studio",
           "name": "Studio",
-          "when": "true"
+          "when": "dvc.commands.available && dvc.project.available"
         },
         {
           "id": "dvc.views.experimentsColumnsTree",


### PR DESCRIPTION
Seem silly that this view is exposed when nothing else works.

### Demo

https://user-images.githubusercontent.com/37993418/223861051-aaebfbfe-cb77-44d0-8edd-05a9317365b0.mov

