### PR TITLE
Update demo project and latest tested CLI version (2.47.0)

### DIFF
--- a/extension/src/cli/dvc/contract.ts
+++ b/extension/src/cli/dvc/contract.ts
@@ -1,7 +1,7 @@
 import { Plot } from '../../plots/webview/contract'
 
 export const MIN_CLI_VERSION = '2.30.0'
-export const LATEST_TESTED_CLI_VERSION = '2.45.1'
+export const LATEST_TESTED_CLI_VERSION = '2.47.0'
 export const MAX_CLI_VERSION = '3'
 
 type ErrorContents = { type: string; msg: string }


### PR DESCRIPTION
`2.46.0` broke the e2e tests but we can skip to this version. 

Edit: demo project now needs DVCLive as a dependency (https://github.com/iterative/dvc/pull/9105)