### PR TITLE
Provide option to open and focus relevant Setup section through UI

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1398,17 +1398,17 @@
       },
       {
         "view": "dvc.views.studio",
-        "contents": "[$(plug) Connect](command:dvc.showSetup)",
+        "contents": "[$(plug) Connect](command:dvc.showStudioSetup)",
         "when": "!dvc.studio.connected"
       },
       {
         "view": "dvc.views.studio",
-        "contents": "[$(settings-gear) Open Settings](command:dvc.showSetup)",
+        "contents": "[$(settings-gear) Open Settings](command:dvc.showStudioSetup)",
         "when": "dvc.studio.connected"
       },
       {
         "view": "dvc.views.welcome",
-        "contents": "New to the extension?\n[Show Walkthrough](command:dvc.getStarted)\n\nThe extension is currently unable to initialize.\n[Show Setup](command:dvc.showSetup)",
+        "contents": "New to the extension?\n[Show Walkthrough](command:dvc.getStarted)\n\nThe extension is currently unable to initialize.\n[Show Setup](command:dvc.showExperimentsSetup)",
         "when": "true"
       },
       {
@@ -1450,7 +1450,7 @@
           {
             "id": "dvc.installDVC",
             "title": "Install DVC",
-            "description": "This extension requires DVC to be installed.\n\n[Show Setup](command:dvc.showSetup)\n",
+            "description": "This extension requires DVC to be installed.\n\n[Show Setup](command:dvc.showExperimentsSetup)\n",
             "media": {
               "markdown": "resources/walkthrough/install-dvc.md"
             },

--- a/extension/resources/walkthrough/install-dvc.md
+++ b/extension/resources/walkthrough/install-dvc.md
@@ -16,7 +16,7 @@ DVC icon like this in the status bar:
 </p>
 
 If you see instead the crossed circle icon, click on the icon or follow the
-[Setup](command:dvc.showSetup) wizard.
+[Setup](command:dvc.showExperimentsSetup) wizard.
 
 > **Note**: The correct Python interpreter must be set for the current workspace
 > when relying on the Python extension for auto environment activation.

--- a/extension/resources/walkthrough/setup-project.md
+++ b/extension/resources/walkthrough/setup-project.md
@@ -56,4 +56,5 @@ live.log("roc_auc", metrics.roc_auc_score(labels, predictions))
 💡 View
 [Instant Experiment Tracking: Just Add DVC!](https://iterative.ai/blog/exp-tracking-dvc-python)
 for a quick-start guide on migrating an existing project. Use
-[Setup](command:dvc.showSetup) to be guided through the onboarding process.
+[Setup](command:dvc.showExperimentsSetup) to be guided through the onboarding
+process.

--- a/extension/src/cli/dvc/discovery.ts
+++ b/extension/src/cli/dvc/discovery.ts
@@ -15,6 +15,7 @@ import {
 import { getPythonBinPath } from '../../extensions/python'
 import { getFirstWorkspaceFolder } from '../../vscode/workspaceFolders'
 import { delay } from '../../util/time'
+import { Section } from '../../setup/webview/contract'
 
 export const warnUnableToVerifyVersion = () =>
   Toast.warnWithOptions(
@@ -52,7 +53,7 @@ const warnUserCLIInaccessible = async (
 
   switch (response) {
     case Response.SHOW_SETUP:
-      return setup.showSetup()
+      return setup.showSetup(Section.EXPERIMENTS)
     case Response.NEVER:
       return setUserConfigValue(ConfigKey.DO_NOT_SHOW_CLI_UNAVAILABLE, true)
   }

--- a/extension/src/commands/external.ts
+++ b/extension/src/commands/external.ts
@@ -94,6 +94,8 @@ export enum RegisteredCommands {
   TRACKED_EXPLORER_SELECT_FOR_COMPARE = 'dvc.selectForCompare',
 
   SETUP_SHOW = 'dvc.showSetup',
+  SETUP_SHOW_EXPERIMENTS = 'dvc.showExperimentsSetup',
+  SETUP_SHOW_STUDIO = 'dvc.showStudioSetup',
   SELECT_FOCUSED_PROJECTS = 'dvc.selectFocusedProjects',
 
   ADD_STUDIO_ACCESS_TOKEN = 'dvc.addStudioAccessToken',

--- a/extension/src/commands/util.ts
+++ b/extension/src/commands/util.ts
@@ -7,5 +7,5 @@ export const showSetupOrExecuteCommand =
   <T>(setup: Setup, callback: (context: Context) => Promise<T | undefined>) =>
   (context: Context) =>
     setup.shouldBeShown()
-      ? commands.executeCommand(RegisteredCommands.SETUP_SHOW)
+      ? commands.executeCommand(RegisteredCommands.SETUP_SHOW_EXPERIMENTS)
       : callback(context)

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -415,10 +415,6 @@ export class Experiments extends BaseRepository<TableData> {
     return this.experiments.getExperimentsByCommitForTree(commit)
   }
 
-  public sendInitialWebviewData() {
-    return this.webviewMessages.sendWebviewMessage()
-  }
-
   public getSelectedRevisions() {
     if (!this.columns.hasNonDefaultColumns()) {
       return []
@@ -514,6 +510,10 @@ export class Experiments extends BaseRepository<TableData> {
       return
     }
     return this.columns.hasNonDefaultColumns()
+  }
+
+  protected sendInitialWebviewData() {
+    return this.webviewMessages.sendWebviewMessage()
   }
 
   private setupInitialData() {

--- a/extension/src/interfaces.ts
+++ b/extension/src/interfaces.ts
@@ -1,3 +1,5 @@
+import { Section } from './setup/webview/contract'
+
 export interface IExtensionSetup {
   getCliVersion: (
     cwd: string,
@@ -7,7 +9,7 @@ export interface IExtensionSetup {
   hasRoots: () => boolean
   isPythonExtensionUsed: () => Promise<boolean>
 
-  showSetup: () => void
+  showSetup: (focusedSection?: Section) => void
   shouldWarnUserIfCLIUnavailable: () => boolean
 
   initialize: () => Promise<void[]>

--- a/extension/src/plots/index.ts
+++ b/extension/src/plots/index.ts
@@ -73,10 +73,6 @@ export class Plots extends BaseRepository<TPlotsData> {
     this.onDidChangePaths = this.pathsChanged.event
   }
 
-  public sendInitialWebviewData() {
-    return this.fetchMissingOrSendPlots()
-  }
-
   public togglePathStatus(path: string) {
     const status = this.paths.toggleStatus(path)
     this.paths.setTemplateOrder()
@@ -123,6 +119,10 @@ export class Plots extends BaseRepository<TPlotsData> {
 
   public getScale() {
     return collectScale(this.paths.getTerminalNodes())
+  }
+
+  protected sendInitialWebviewData() {
+    return this.fetchMissingOrSendPlots()
   }
 
   private notifyChanged() {

--- a/extension/src/setup/collect.ts
+++ b/extension/src/setup/collect.ts
@@ -1,0 +1,18 @@
+import { DEFAULT_SECTION_COLLAPSED, Section } from './webview/contract'
+
+export const collectSectionCollapsed = (
+  focusedSection?: Section
+): typeof DEFAULT_SECTION_COLLAPSED | undefined => {
+  if (!focusedSection) {
+    return undefined
+  }
+
+  const acc = { ...DEFAULT_SECTION_COLLAPSED }
+  for (const section of Object.keys(acc)) {
+    if (section !== focusedSection) {
+      acc[section as Section] = true
+    }
+  }
+
+  return acc
+}

--- a/extension/src/setup/index.ts
+++ b/extension/src/setup/index.ts
@@ -255,10 +255,6 @@ export class Setup
     return !!this.webview?.isActive
   }
 
-  public sendInitialWebviewData() {
-    return this.sendDataToWebview()
-  }
-
   public shouldBeShown() {
     return !this.cliCompatible || !this.hasRoots() || !this.getHasData()
   }
@@ -332,6 +328,10 @@ export class Setup
 
   public getStudioAccessToken() {
     return this.studioAccessToken
+  }
+
+  public sendInitialWebviewData() {
+    return this.sendDataToWebview()
   }
 
   private async sendDataToWebview() {

--- a/extension/src/setup/register.ts
+++ b/extension/src/setup/register.ts
@@ -1,29 +1,10 @@
 import { commands } from 'vscode'
 import { Setup } from '.'
 import { run } from './runner'
+import { Section } from './webview/contract'
 import { AvailableCommands, InternalCommands } from '../commands/internal'
 import { RegisteredCliCommands, RegisteredCommands } from '../commands/external'
 import { getFirstWorkspaceFolder } from '../vscode/workspaceFolders'
-
-const registerSetupStudioCommands = (
-  setup: Setup,
-  internalCommands: InternalCommands
-): void => {
-  internalCommands.registerExternalCommand(
-    RegisteredCommands.ADD_STUDIO_ACCESS_TOKEN,
-    () => setup.saveStudioAccessToken()
-  )
-
-  internalCommands.registerExternalCommand(
-    RegisteredCommands.UPDATE_STUDIO_ACCESS_TOKEN,
-    () => setup.saveStudioAccessToken()
-  )
-
-  internalCommands.registerExternalCommand(
-    RegisteredCommands.REMOVE_STUDIO_ACCESS_TOKEN,
-    () => setup.removeStudioAccessToken()
-  )
-}
 
 const registerSetupConfigCommands = (
   setup: Setup,
@@ -45,6 +26,52 @@ const registerSetupConfigCommands = (
   )
 }
 
+const registerSetupShowCommands = (
+  setup: Setup,
+  internalCommands: InternalCommands
+): void => {
+  internalCommands.registerExternalCommand(
+    RegisteredCommands.SETUP_SHOW,
+    async () => {
+      await setup.showSetup()
+    }
+  )
+
+  internalCommands.registerExternalCommand(
+    RegisteredCommands.SETUP_SHOW_EXPERIMENTS,
+    async () => {
+      await setup.showSetup(Section.EXPERIMENTS)
+    }
+  )
+
+  internalCommands.registerExternalCommand(
+    RegisteredCommands.SETUP_SHOW_STUDIO,
+    async () => {
+      await setup.showSetup(Section.STUDIO)
+    }
+  )
+}
+
+const registerSetupStudioCommands = (
+  setup: Setup,
+  internalCommands: InternalCommands
+): void => {
+  internalCommands.registerExternalCommand(
+    RegisteredCommands.ADD_STUDIO_ACCESS_TOKEN,
+    () => setup.saveStudioAccessToken()
+  )
+
+  internalCommands.registerExternalCommand(
+    RegisteredCommands.UPDATE_STUDIO_ACCESS_TOKEN,
+    () => setup.saveStudioAccessToken()
+  )
+
+  internalCommands.registerExternalCommand(
+    RegisteredCommands.REMOVE_STUDIO_ACCESS_TOKEN,
+    () => setup.removeStudioAccessToken()
+  )
+}
+
 export const registerSetupCommands = (
   setup: Setup,
   internalCommands: InternalCommands
@@ -59,13 +86,7 @@ export const registerSetupCommands = (
     }
   )
 
-  internalCommands.registerExternalCommand(
-    RegisteredCommands.SETUP_SHOW,
-    async () => {
-      await setup.showSetup()
-    }
-  )
-
   registerSetupConfigCommands(setup, internalCommands)
+  registerSetupShowCommands(setup, internalCommands)
   registerSetupStudioCommands(setup, internalCommands)
 }

--- a/extension/src/setup/webview/contract.ts
+++ b/extension/src/setup/webview/contract.ts
@@ -8,6 +8,7 @@ export type SetupData = {
   needsGitInitialized: boolean | undefined
   projectInitialized: boolean
   pythonBinPath: string | undefined
+  sectionCollapsed: typeof DEFAULT_SECTION_COLLAPSED | undefined
   shareLiveToStudio: boolean
 }
 

--- a/extension/src/setup/webview/messages.ts
+++ b/extension/src/setup/webview/messages.ts
@@ -39,6 +39,7 @@ export class WebviewMessages {
     needsGitInitialized,
     projectInitialized,
     pythonBinPath,
+    sectionCollapsed,
     shareLiveToStudio
   }: SetupData) {
     void this.getWebview()?.show({
@@ -51,6 +52,7 @@ export class WebviewMessages {
       needsGitInitialized,
       projectInitialized,
       pythonBinPath,
+      sectionCollapsed,
       shareLiveToStudio
     })
   }

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -280,6 +280,8 @@ export interface IEventNamePropertyMapping {
   [EventName.VIEWS_SETUP_INSTALL_DVC]: undefined
 
   [EventName.SETUP_SHOW]: undefined
+  [EventName.SETUP_SHOW_EXPERIMENTS]: undefined
+  [EventName.SETUP_SHOW_STUDIO]: undefined
   [EventName.SELECT_FOCUSED_PROJECTS]: undefined
 
   [EventName.ADD_STUDIO_ACCESS_TOKEN]: undefined

--- a/extension/src/test/suite/experiments/workspace.test.ts
+++ b/extension/src/test/suite/experiments/workspace.test.ts
@@ -975,7 +975,9 @@ suite('Workspace Experiments Test Suite', () => {
 
       await commands.executeCommand(RegisteredCommands.EXPERIMENT_SHOW)
 
-      expect(executeCommandSpy).to.have.been.calledWithMatch('dvc.showSetup')
+      expect(executeCommandSpy).to.have.been.calledWithMatch(
+        'dvc.showExperimentsSetup'
+      )
     })
 
     it('should not show the experiments webview if the setup should be shown', async () => {
@@ -999,7 +1001,7 @@ suite('Workspace Experiments Test Suite', () => {
 
       await commands.executeCommand(RegisteredCommands.EXPERIMENT_SHOW)
 
-      expect(executeCommandSpy).not.to.be.calledWith('dvc.showSetup')
+      expect(executeCommandSpy).not.to.be.calledWith('dvc.showExperimentsSetup')
     })
 
     it('should show the experiments webview if the setup should not be shown', async () => {

--- a/extension/src/test/suite/setup/index.test.ts
+++ b/extension/src/test/suite/setup/index.test.ts
@@ -244,6 +244,7 @@ suite('Setup Test Suite', () => {
         needsGitInitialized: true,
         projectInitialized: false,
         pythonBinPath: undefined,
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
     }).timeout(WEBVIEW_TEST_TIMEOUT)
@@ -283,6 +284,7 @@ suite('Setup Test Suite', () => {
         needsGitInitialized: true,
         projectInitialized: false,
         pythonBinPath: undefined,
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
     }).timeout(WEBVIEW_TEST_TIMEOUT)
@@ -328,6 +330,7 @@ suite('Setup Test Suite', () => {
         needsGitInitialized: false,
         projectInitialized: false,
         pythonBinPath: undefined,
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
     }).timeout(WEBVIEW_TEST_TIMEOUT)
@@ -373,6 +376,7 @@ suite('Setup Test Suite', () => {
         needsGitInitialized: false,
         projectInitialized: true,
         pythonBinPath: undefined,
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
     }).timeout(WEBVIEW_TEST_TIMEOUT)

--- a/extension/src/webview/repository.ts
+++ b/extension/src/webview/repository.ts
@@ -91,5 +91,5 @@ export abstract class BaseRepository<
     this.webview = undefined
   }
 
-  abstract sendInitialWebviewData(): void
+  protected abstract sendInitialWebviewData(): void
 }

--- a/webview/src/setup/components/App.test.tsx
+++ b/webview/src/setup/components/App.test.tsx
@@ -5,7 +5,7 @@ import {
 } from 'dvc/src/webview/contract'
 import '@testing-library/jest-dom/extend-expect'
 import React from 'react'
-import { SetupData } from 'dvc/src/setup/webview/contract'
+import { Section, SetupData } from 'dvc/src/setup/webview/contract'
 import { App } from './App'
 import { vsCodeApi } from '../../shared/api'
 
@@ -24,6 +24,7 @@ const renderApp = ({
   needsGitInitialized,
   projectInitialized,
   pythonBinPath,
+  sectionCollapsed,
   shareLiveToStudio
 }: SetupData) => {
   render(<App />)
@@ -40,6 +41,7 @@ const renderApp = ({
           needsGitInitialized,
           projectInitialized,
           pythonBinPath,
+          sectionCollapsed,
           shareLiveToStudio
         },
         type: MessageToWebviewType.SET_DATA
@@ -537,6 +539,57 @@ describe('App', () => {
       expect(mockPostMessage).toHaveBeenCalledWith({
         type: MessageFromWebviewType.SAVE_STUDIO_TOKEN
       })
+    })
+  })
+
+  describe('focused section', () => {
+    const testData = {
+      canGitInitialize: false,
+      cliCompatible: true,
+      hasData: false,
+      isPythonExtensionInstalled: true,
+      isStudioConnected: true,
+      needsGitCommit: false,
+      needsGitInitialized: false,
+      projectInitialized: true,
+      pythonBinPath: 'python',
+      shareLiveToStudio: false
+    }
+    const experimentsText = 'Your project contains no data'
+    const studioButtonText = 'Update Token'
+
+    it('should render the app with the Studio section collapsed if the Experiments section is focused', () => {
+      renderApp({
+        ...testData,
+        sectionCollapsed: {
+          [Section.EXPERIMENTS]: false,
+          [Section.STUDIO]: true
+        }
+      })
+      mockPostMessage.mockClear()
+      const studio = screen.getByText('Studio')
+      expect(studio).toBeVisible()
+      expect(screen.queryByText(studioButtonText)).not.toBeVisible()
+      const experiments = screen.getByText('Experiments')
+      expect(experiments).toBeVisible()
+      expect(screen.getByText(experimentsText)).toBeVisible()
+    })
+
+    it('should render the app with the Experiments section collapsed if the Studio section is focused', () => {
+      renderApp({
+        ...testData,
+        sectionCollapsed: {
+          [Section.EXPERIMENTS]: true,
+          [Section.STUDIO]: false
+        }
+      })
+      mockPostMessage.mockClear()
+      const studio = screen.getByText('Studio')
+      expect(studio).toBeVisible()
+      expect(screen.queryByText(studioButtonText)).toBeVisible()
+      const experiments = screen.getByText('Experiments')
+      expect(experiments).toBeVisible()
+      expect(screen.getByText(experimentsText)).not.toBeVisible()
     })
   })
 })

--- a/webview/src/setup/components/App.test.tsx
+++ b/webview/src/setup/components/App.test.tsx
@@ -69,6 +69,7 @@ describe('App', () => {
         needsGitInitialized: undefined,
         projectInitialized: false,
         pythonBinPath: undefined,
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
 
@@ -94,6 +95,7 @@ describe('App', () => {
         needsGitInitialized: undefined,
         projectInitialized: false,
         pythonBinPath: undefined,
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
 
@@ -113,6 +115,7 @@ describe('App', () => {
         needsGitInitialized: undefined,
         projectInitialized: false,
         pythonBinPath: undefined,
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
 
@@ -136,6 +139,7 @@ describe('App', () => {
         needsGitInitialized: undefined,
         projectInitialized: false,
         pythonBinPath: defaultInterpreter,
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
 
@@ -158,6 +162,7 @@ describe('App', () => {
         needsGitInitialized: undefined,
         projectInitialized: false,
         pythonBinPath: 'python',
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
 
@@ -180,6 +185,7 @@ describe('App', () => {
         needsGitInitialized: undefined,
         projectInitialized: false,
         pythonBinPath: 'python',
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
 
@@ -202,6 +208,7 @@ describe('App', () => {
         needsGitInitialized: undefined,
         projectInitialized: false,
         pythonBinPath: 'python',
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
 
@@ -224,6 +231,7 @@ describe('App', () => {
         needsGitInitialized: undefined,
         projectInitialized: false,
         pythonBinPath: undefined,
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
 
@@ -243,6 +251,7 @@ describe('App', () => {
         needsGitInitialized: true,
         projectInitialized: false,
         pythonBinPath: undefined,
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
 
@@ -260,6 +269,7 @@ describe('App', () => {
         needsGitInitialized: true,
         projectInitialized: false,
         pythonBinPath: undefined,
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
 
@@ -280,6 +290,7 @@ describe('App', () => {
         needsGitInitialized: true,
         projectInitialized: false,
         pythonBinPath: undefined,
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
 
@@ -297,6 +308,7 @@ describe('App', () => {
         needsGitInitialized: undefined,
         projectInitialized: false,
         pythonBinPath: undefined,
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
 
@@ -314,6 +326,7 @@ describe('App', () => {
         needsGitInitialized: undefined,
         projectInitialized: true,
         pythonBinPath: undefined,
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
 
@@ -333,6 +346,7 @@ describe('App', () => {
         needsGitInitialized: undefined,
         projectInitialized: false,
         pythonBinPath: undefined,
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
 
@@ -355,6 +369,7 @@ describe('App', () => {
         needsGitInitialized: undefined,
         projectInitialized: true,
         pythonBinPath: undefined,
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
 
@@ -374,6 +389,7 @@ describe('App', () => {
         needsGitInitialized: undefined,
         projectInitialized: true,
         pythonBinPath: undefined,
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
 
@@ -395,6 +411,7 @@ describe('App', () => {
         needsGitInitialized: false,
         projectInitialized: true,
         pythonBinPath: 'python',
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
       const buttons = await screen.findAllByRole('button')
@@ -412,6 +429,7 @@ describe('App', () => {
         needsGitInitialized: false,
         projectInitialized: true,
         pythonBinPath: 'python',
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
 
@@ -435,6 +453,7 @@ describe('App', () => {
         needsGitInitialized: false,
         projectInitialized: true,
         pythonBinPath: 'python',
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
 
@@ -458,6 +477,7 @@ describe('App', () => {
         needsGitInitialized: false,
         projectInitialized: true,
         pythonBinPath: 'python',
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
 
@@ -484,6 +504,7 @@ describe('App', () => {
         needsGitInitialized: false,
         projectInitialized: true,
         pythonBinPath: 'python',
+        sectionCollapsed: undefined,
         shareLiveToStudio: shareExperimentsLive
       })
 
@@ -507,6 +528,7 @@ describe('App', () => {
         needsGitInitialized: false,
         projectInitialized: true,
         pythonBinPath: 'python',
+        sectionCollapsed: undefined,
         shareLiveToStudio: false
       })
       mockPostMessage.mockClear()

--- a/webview/src/setup/components/App.tsx
+++ b/webview/src/setup/components/App.tsx
@@ -32,9 +32,9 @@ export const App: React.FC = () => {
   const [isPythonExtensionInstalled, setIsPythonExtensionInstalled] =
     useState<boolean>(false)
   const [hasData, setHasData] = useState<boolean | undefined>(false)
-  const [sectionCollapsed, setSectionCollapsed] = useState<
-    typeof DEFAULT_SECTION_COLLAPSED
-  >(DEFAULT_SECTION_COLLAPSED)
+  const [sectionCollapsed, setSectionCollapsed] = useState(
+    DEFAULT_SECTION_COLLAPSED
+  )
 
   const [isStudioConnected, setIsStudioConnected] = useState<boolean>(false)
   const [shareLiveToStudio, setShareLiveToStudioValue] =
@@ -52,6 +52,9 @@ export const App: React.FC = () => {
         setProjectInitialized(data.data.projectInitialized)
         setPythonBinPath(data.data.pythonBinPath)
         setIsStudioConnected(data.data.isStudioConnected)
+        if (data.data.sectionCollapsed) {
+          setSectionCollapsed(data.data.sectionCollapsed)
+        }
         setShareLiveToStudioValue(data.data.shareLiveToStudio)
       },
       [
@@ -64,6 +67,7 @@ export const App: React.FC = () => {
         setProjectInitialized,
         setPythonBinPath,
         setIsStudioConnected,
+        setSectionCollapsed,
         setShareLiveToStudioValue
       ]
     )


### PR DESCRIPTION
# 3/4 `main` <- #3448 <-#3452 <- this <- #3463

Related to https://github.com/iterative/vscode-dvc/issues/3434

This PR add the option to open the Setup webview with a section focused by collapsing all of the other sections.

### Demo

https://user-images.githubusercontent.com/37993418/224904670-66e74e9b-716e-48c0-b281-959be8ab0724.mov

