### PR TITLE
Make className optional in SectionContainer

### DIFF
--- a/webview/src/shared/components/sectionContainer/SectionContainer.tsx
+++ b/webview/src/shared/components/sectionContainer/SectionContainer.tsx
@@ -65,7 +65,7 @@ export interface SectionContainerProps<T extends PlotsSection> {
   sectionCollapsed: boolean
   sectionKey: T
   title: string
-  className: string
+  className?: string
 }
 
 const InfoIcon = () => (


### PR DESCRIPTION
Added the `className` prop to fix a merge with main for the size sliders and didn't make this optional. No idea how everything from tests to linting passed as the `Setup` views don't provide it, but I'm glad I caught it fast.