### PR TITLE
Move e2e tests to insiders

### DIFF
--- a/extension/src/test/e2e/wdio.conf.ts
+++ b/extension/src/test/e2e/wdio.conf.ts
@@ -47,7 +47,7 @@ export const config: Options.Testrunner = {
   capabilities: [
     {
       browserName: 'vscode',
-      browserVersion: 'stable',
+      browserVersion: 'insiders',
       'wdio:vscodeOptions': {
         extensionPath,
         userSettings: {


### PR DESCRIPTION
Not the source of the bug, but might the version seems to work now, so better go back to it.