### PR TITLE
Create custom plots when the data is requested

### DIFF
--- a/extension/src/plots/webview/messages.ts
+++ b/extension/src/plots/webview/messages.ts
@@ -37,6 +37,7 @@ import {
   doesCustomPlotAlreadyExist,
   isCheckpointValue
 } from '../model/custom'
+import { getCustomPlotId } from '../model/collect'
 
 export class WebviewMessages {
   private readonly paths: PathsModel
@@ -278,20 +279,23 @@ export class WebviewMessages {
   }
 
   private setCustomPlotsOrder(plotIds: string[]) {
-    const customPlots = this.plots.getCustomPlots()?.plots
-    if (!customPlots) {
-      return
-    }
+    const customPlotsOrderWithId = this.plots
+      .getCustomPlotsOrder()
+      .map(value => ({
+        ...value,
+        id: getCustomPlotId(value.metric, value.param)
+      }))
 
     const newOrder: CustomPlotsOrderValue[] = reorderObjectList(
       plotIds,
-      customPlots,
+      customPlotsOrderWithId,
       'id'
     ).map(({ metric, param, type }) => ({
       metric,
       param,
       type
     }))
+
     this.plots.setCustomPlotsOrder(newOrder)
     this.sendCustomPlotsAndEvent(EventName.VIEWS_REORDER_PLOTS_CUSTOM)
   }


### PR DESCRIPTION
# 3/3 `main` <= #3404 <= #3466 <= this

* creates custom plots when the plots are requested in `getCustomPlots` instead of creating them earlier and filtering through the trends plot values. This reduces code complexity and improves performance. 

Resolves https://github.com/iterative/vscode-dvc/pull/3466#discussion_r1139579071