### PR TITLE
Use plot errors to display correct messages for missing plots

### DIFF
--- a/extension/src/cli/dvc/contract.ts
+++ b/extension/src/cli/dvc/contract.ts
@@ -100,7 +100,7 @@ export interface PlotsData {
   [path: string]: Plot[]
 }
 
-type PlotError = {
+export type PlotError = {
   name: string
   rev: string
   source?: string

--- a/extension/src/plots/errors/collect.test.ts
+++ b/extension/src/plots/errors/collect.test.ts
@@ -1,0 +1,137 @@
+import { join } from 'path'
+import { collectErrors, collectImageErrors } from './collect'
+import { EXPERIMENT_WORKSPACE_ID } from '../../cli/dvc/contract'
+
+describe('collectErrors', () => {
+  it('should remove errors that belong to revisions that have been fetched', () => {
+    const errors = collectErrors(
+      { data: {} },
+      [EXPERIMENT_WORKSPACE_ID],
+      [
+        {
+          msg: 'unexpected error',
+          name: 'fun::plot',
+          rev: EXPERIMENT_WORKSPACE_ID,
+          source: 'metrics.json',
+          type: 'unexpected'
+        }
+      ],
+      {}
+    )
+
+    expect(errors).toStrictEqual([])
+  })
+
+  it('should collect new errors', () => {
+    const newError = {
+      msg: 'Blue screen of death',
+      name: 'fun::plot',
+      rev: 'd7ad114',
+      source: 'metrics.json',
+      type: 'unexpected'
+    }
+
+    const errors = collectErrors(
+      {
+        data: {},
+        errors: [newError]
+      },
+      [EXPERIMENT_WORKSPACE_ID, 'd7ad114'],
+      [
+        {
+          msg: 'unexpected error',
+          name: 'fun::plot',
+          rev: EXPERIMENT_WORKSPACE_ID,
+          source: 'metrics.json',
+          type: 'unexpected'
+        }
+      ],
+      { d7ad114: 'main' }
+    )
+
+    expect(errors).toStrictEqual([{ ...newError, rev: 'main' }])
+  })
+})
+
+describe('collectImageErrors', () => {
+  it('should return undefined if there are no errors for the image', () => {
+    const error = collectImageErrors(
+      'misclassified.jpg',
+      EXPERIMENT_WORKSPACE_ID,
+      []
+    )
+    expect(error).toBeUndefined()
+  })
+
+  it('should collect a single error for an image', () => {
+    const path = join('training', 'plots', 'images', 'mispredicted.jpg')
+    const otherPath = 'other'
+
+    const errors = [
+      {
+        msg: `${otherPath} - file type error\nOnly JSON, YAML, CSV and TSV formats are supported.`,
+        name: otherPath,
+        rev: EXPERIMENT_WORKSPACE_ID,
+        source: otherPath,
+        type: 'PlotMetricTypeError'
+      },
+      {
+        msg: "Could not find provided field ('ste') in data fields ('step, test/acc').",
+        name: otherPath,
+        rev: EXPERIMENT_WORKSPACE_ID,
+        source: otherPath,
+        type: 'FieldNotFoundError'
+      },
+      {
+        msg: '',
+        name: path,
+        rev: EXPERIMENT_WORKSPACE_ID,
+        source: path,
+        type: 'FileNotFoundError'
+      },
+      {
+        msg: '',
+        name: path,
+        rev: 'main',
+        source: path,
+        type: 'FileNotFoundError'
+      }
+    ]
+
+    const error = collectImageErrors(path, EXPERIMENT_WORKSPACE_ID, errors)
+    expect(error).toStrictEqual(`FileNotFoundError: ${path} not found.`)
+  })
+
+  it('should concatenate errors together to give a single string', () => {
+    const path = join('training', 'plots', 'images', 'mispredicted.jpg')
+
+    const errors = [
+      {
+        msg: '',
+        name: path,
+        rev: EXPERIMENT_WORKSPACE_ID,
+        source: path,
+        type: 'FileNotFoundError'
+      },
+      {
+        msg: 'catastrophic error',
+        name: path,
+        rev: EXPERIMENT_WORKSPACE_ID,
+        source: path,
+        type: 'SomeError'
+      },
+      {
+        msg: '',
+        name: path,
+        rev: EXPERIMENT_WORKSPACE_ID,
+        source: path,
+        type: 'UNEXPECTEDERRRRROR'
+      }
+    ]
+
+    const error = collectImageErrors(path, EXPERIMENT_WORKSPACE_ID, errors)
+    expect(error).toStrictEqual(
+      `FileNotFoundError: ${path} not found.\nSomeError: catastrophic error\nUNEXPECTEDERRRRROR`
+    )
+  })
+})

--- a/extension/src/plots/errors/collect.ts
+++ b/extension/src/plots/errors/collect.ts
@@ -1,0 +1,53 @@
+import { PlotError, PlotsOutput } from '../../cli/dvc/contract'
+
+export const collectErrors = (
+  data: PlotsOutput,
+  revs: string[],
+  errors: PlotError[],
+  cliIdToLabel: { [id: string]: string }
+) => {
+  const existingErrors = errors.filter(
+    ({ rev }) => !revs.includes(cliIdToLabel[rev] || rev)
+  )
+  const newErrors = data?.errors || []
+
+  return [
+    ...existingErrors,
+    ...newErrors.map(error => {
+      const { rev } = error
+      return {
+        ...error,
+        rev: cliIdToLabel[rev] || rev
+      }
+    })
+  ]
+}
+
+const getMessage = (error: PlotError): string => {
+  const { msg, type, source } = error
+
+  if (type === 'FileNotFoundError' && source && !msg) {
+    return `${type}: ${source} not found.`
+  }
+  return [type, msg].filter(Boolean).join(': ')
+}
+
+export const collectImageErrors = (
+  path: string,
+  revision: string,
+  errors: PlotError[]
+): string | undefined => {
+  const msgs: string[] = []
+  for (const error of errors) {
+    if (error.rev === revision && error.name === path) {
+      const msg = getMessage(error)
+      msgs.push(msg)
+    }
+  }
+
+  if (msgs.length === 0) {
+    return undefined
+  }
+
+  return msgs.join('\n')
+}

--- a/extension/src/plots/errors/model.ts
+++ b/extension/src/plots/errors/model.ts
@@ -1,0 +1,31 @@
+import { collectErrors, collectImageErrors } from './collect'
+import { Disposable } from '../../class/dispose'
+import { PlotError, PlotsOutputOrError } from '../../cli/dvc/contract'
+import { isDvcError } from '../../cli/dvc/reader'
+
+export class ErrorsModel extends Disposable {
+  private readonly dvcRoot: string
+
+  private errors: PlotError[] = []
+
+  constructor(dvcRoot: string) {
+    super()
+    this.dvcRoot = dvcRoot
+  }
+
+  public transformAndSet(
+    data: PlotsOutputOrError,
+    revs: string[],
+    cliIdToLabel: { [id: string]: string }
+  ) {
+    if (isDvcError(data)) {
+      return
+    }
+
+    this.errors = collectErrors(data, revs, this.errors, cliIdToLabel)
+  }
+
+  public getImageErrors(path: string, revision: string) {
+    return collectImageErrors(path, revision, this.errors)
+  }
+}

--- a/extension/src/plots/model/index.test.ts
+++ b/extension/src/plots/model/index.test.ts
@@ -11,6 +11,7 @@ import { Experiments } from '../../experiments'
 import { PersistenceKey } from '../../persistence/constants'
 import { EXPERIMENT_WORKSPACE_ID } from '../../cli/dvc/contract'
 import { customPlotsOrderFixture } from '../../test/fixtures/expShow/base/customPlots'
+import { ErrorsModel } from '../errors/model'
 
 const mockedRevisions = [
   { displayColor: 'white', label: EXPERIMENT_WORKSPACE_ID },
@@ -41,6 +42,7 @@ describe('plotsModel', () => {
         getSelectedRevisions: mockedGetSelectedRevisions,
         isReady: () => Promise.resolve(undefined)
       } as unknown as Experiments,
+      { getImageErrors: () => undefined } as unknown as ErrorsModel,
       memento
     )
     jest.clearAllMocks()
@@ -64,6 +66,7 @@ describe('plotsModel', () => {
         getSelectedRevisions: mockedGetSelectedRevisions,
         isReady: () => Promise.resolve(undefined)
       } as unknown as Experiments,
+      { getImageErrors: () => undefined } as unknown as ErrorsModel,
       memento
     )
     expect(model.getCustomPlotsOrder()).toStrictEqual([

--- a/extension/src/plots/model/index.ts
+++ b/extension/src/plots/model/index.ts
@@ -52,11 +52,13 @@ import {
   MultiSourceVariations
 } from '../multiSource/collect'
 import { isDvcError } from '../../cli/dvc/reader'
+import { ErrorsModel } from '../errors/model'
 
 export type CustomCheckpointPlots = { [metric: string]: CheckpointPlot }
 
 export class PlotsModel extends ModelWithPersistence {
   private readonly experiments: Experiments
+  private readonly errors: ErrorsModel
 
   private nbItemsPerRowOrWidth: Record<PlotsSection, number>
   private height: Record<PlotsSection, PlotHeight>
@@ -77,10 +79,12 @@ export class PlotsModel extends ModelWithPersistence {
   constructor(
     dvcRoot: string,
     experiments: Experiments,
+    errors: ErrorsModel,
     workspaceState: Memento
   ) {
     super(dvcRoot, workspaceState)
     this.experiments = experiments
+    this.errors = errors
 
     this.nbItemsPerRowOrWidth = this.revive(
       PersistenceKey.PLOT_NB_ITEMS_PER_ROW_OR_WIDTH,
@@ -494,7 +498,9 @@ export class PlotsModel extends ModelWithPersistence {
 
     for (const revision of selectedRevisions) {
       const image = this.comparisonData?.[revision]?.[path]
+      const error = this.errors.getImageErrors(path, revision)
       pathRevisions.revisions[revision] = {
+        error,
         revision,
         url: image?.url
       }

--- a/extension/src/plots/paths/collect.test.ts
+++ b/extension/src/plots/paths/collect.test.ts
@@ -13,7 +13,7 @@ import plotsDiffFixture from '../../test/fixtures/plotsDiff/output'
 import { Shape, StrokeDash } from '../multiSource/constants'
 import { EXPERIMENT_WORKSPACE_ID } from '../../cli/dvc/contract'
 
-describe('collectPath', () => {
+describe('collectPaths', () => {
   const revisions = [
     EXPERIMENT_WORKSPACE_ID,
     '53c3851',
@@ -223,6 +223,56 @@ describe('collectPath', () => {
         path: 'predictions.json',
         revisions: new Set(revisions),
         type: new Set(['template-multi'])
+      }
+    ])
+  })
+
+  it('should correctly collect error paths', () => {
+    const misspeltJpg = join('training', 'plots', 'images', 'mip.jpg')
+    const revisions = new Set([EXPERIMENT_WORKSPACE_ID])
+
+    const paths = collectPaths(
+      [],
+      {
+        data: {},
+        errors: [
+          {
+            msg: '',
+            name: misspeltJpg,
+            rev: EXPERIMENT_WORKSPACE_ID,
+            source: misspeltJpg,
+            type: 'FileNotFoundError'
+          }
+        ]
+      },
+      [],
+      {}
+    )
+    expect(paths).toHaveLength(4)
+    expect(paths).toStrictEqual([
+      {
+        hasChildren: false,
+        parentPath: join('training', 'plots', 'images'),
+        path: misspeltJpg,
+        revisions
+      },
+      {
+        hasChildren: true,
+        parentPath: join('training', 'plots'),
+        path: join('training', 'plots', 'images'),
+        revisions
+      },
+      {
+        hasChildren: true,
+        parentPath: 'training',
+        path: join('training', 'plots'),
+        revisions
+      },
+      {
+        hasChildren: true,
+        parentPath: undefined,
+        path: 'training',
+        revisions
       }
     ])
   })

--- a/extension/src/plots/webview/contract.ts
+++ b/extension/src/plots/webview/contract.ts
@@ -170,8 +170,9 @@ export interface TemplatePlotsData {
 }
 
 export type ComparisonPlot = {
-  url?: string
+  url: string | undefined
   revision: string
+  error: string | undefined
 }
 
 export enum PlotsDataKeys {

--- a/extension/src/test/fixtures/plotsDiff/index.ts
+++ b/extension/src/test/fixtures/plotsDiff/index.ts
@@ -699,7 +699,8 @@ export const getComparisonWebviewMessage = (
       }
       revisionsAcc[revision] = {
         url: `${url}?${MOCK_IMAGE_MTIME}`,
-        revision
+        revision,
+        error: undefined
       }
     }
 

--- a/webview/src/experiments/components/table/Cell.tsx
+++ b/webview/src/experiments/components/table/Cell.tsx
@@ -1,12 +1,12 @@
 import { flexRender } from '@tanstack/react-table'
 import React, { ReactNode } from 'react'
 import cx from 'classnames'
-import { ErrorTooltip } from './Errors'
 import styles from './styles.module.scss'
 import { CellProp, RowProp } from './interfaces'
 import { CellRowActionsProps, CellRowActions } from './CellRowActions'
 import { CellValue, isValueWithChanges } from './content/Cell'
 import { clickAndEnterProps } from '../../../util/props'
+import { ErrorTooltip } from '../../../shared/components/errorTooltip/ErrorTooltip'
 
 const cellHasChanges = (cellValue: CellValue) =>
   isValueWithChanges(cellValue) ? cellValue.changes : false

--- a/webview/src/experiments/components/table/content/ErrorCell.tsx
+++ b/webview/src/experiments/components/table/content/ErrorCell.tsx
@@ -1,7 +1,7 @@
 import cx from 'classnames'
 import React from 'react'
 import { CellContents } from './CellContent'
-import { ErrorTooltip } from '../Errors'
+import { ErrorTooltip } from '../../../../shared/components/errorTooltip/ErrorTooltip'
 import styles from '../styles.module.scss'
 
 interface ErrorCellProps {

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -760,22 +760,6 @@ $bullet-size: calc(var(--design-unit) * 4px);
   color: $error-color;
 }
 
-.errorIcon {
-  margin-left: 6px;
-  margin-top: 3px;
-}
-
-.errorTooltip {
-  white-space: pre-wrap;
-  display: flex;
-  gap: 4px;
-
-  svg {
-    min-width: 16px;
-    min-height: 16px;
-  }
-}
-
 .headerCellWrapper {
   @extend %headerCellPadding;
 }

--- a/webview/src/plots/components/App.test.tsx
+++ b/webview/src/plots/components/App.test.tsx
@@ -247,7 +247,9 @@ describe('App', () => {
         plots: [
           {
             path: 'training/plots/images/misclassified.jpg',
-            revisions: { ad2b5ec: { revision: 'ad2b5ec' } }
+            revisions: {
+              ad2b5ec: { error: undefined, revision: 'ad2b5ec', url: undefined }
+            }
           }
         ],
         revisions: [

--- a/webview/src/plots/components/comparisonTable/ComparisonTable.test.tsx
+++ b/webview/src/plots/components/comparisonTable/ComparisonTable.test.tsx
@@ -263,7 +263,7 @@ describe('ComparisonTable', () => {
     expect(headers).toStrictEqual([...namedRevisions, newRevName])
   })
 
-  it('should display a refresh button for each revision that has a missing image', () => {
+  it('should not display a refresh button for a revision that does not contain an image', () => {
     const revisionWithNoData = 'missing-data'
 
     renderTable({
@@ -273,6 +273,39 @@ describe('ComparisonTable', () => {
         revisions: {
           ...revisions,
           [revisionWithNoData]: {
+            error: undefined,
+            revision: revisionWithNoData,
+            url: undefined
+          }
+        }
+      })),
+      revisions: [
+        ...comparisonTableFixture.revisions,
+        {
+          displayColor: '#f56565',
+          fetched: true,
+          firstThreeColumns: [],
+          group: undefined,
+          id: 'noData',
+          revision: revisionWithNoData
+        }
+      ]
+    })
+
+    expect(screen.queryByText('Refresh')).not.toBeInTheDocument()
+  })
+
+  it('should display a refresh button for each revision that has an image with an error', () => {
+    const revisionWithNoData = 'missing-data'
+
+    renderTable({
+      ...comparisonTableFixture,
+      plots: comparisonTableFixture.plots.map(({ path, revisions }) => ({
+        path,
+        revisions: {
+          ...revisions,
+          [revisionWithNoData]: {
+            error: 'this is an error',
             revision: revisionWithNoData,
             url: undefined
           }

--- a/webview/src/plots/components/comparisonTable/ComparisonTableCell.tsx
+++ b/webview/src/plots/components/comparisonTable/ComparisonTableCell.tsx
@@ -5,6 +5,8 @@ import styles from './styles.module.scss'
 import { RefreshButton } from '../../../shared/components/button/RefreshButton'
 import { sendMessage } from '../../../shared/vscode'
 import { zoomPlot } from '../messages'
+import { Error } from '../../../shared/components/icons'
+import { ErrorTooltip } from '../../../shared/components/errorTooltip/ErrorTooltip'
 
 type ComparisonTableCellProps = {
   path: string
@@ -15,6 +17,7 @@ export const ComparisonTableCell: React.FC<ComparisonTableCellProps> = ({
   path,
   plot
 }) => {
+  const error = plot?.error
   const missing = plot?.fetched && !plot?.url
 
   if (!plot?.fetched) {
@@ -28,15 +31,25 @@ export const ComparisonTableCell: React.FC<ComparisonTableCellProps> = ({
   if (missing) {
     return (
       <div className={styles.noImageContent}>
-        <p>No Plot to Display.</p>
-        <RefreshButton
-          onClick={() =>
-            sendMessage({
-              payload: plot.revision,
-              type: MessageFromWebviewType.REFRESH_REVISION
-            })
-          }
-        />
+        {error ? (
+          <>
+            <ErrorTooltip error={error}>
+              <div>
+                <Error height={48} width={48} className={styles.errorIcon} />
+              </div>
+            </ErrorTooltip>
+            <RefreshButton
+              onClick={() =>
+                sendMessage({
+                  payload: plot.revision,
+                  type: MessageFromWebviewType.REFRESH_REVISION
+                })
+              }
+            />
+          </>
+        ) : (
+          <p className={styles.emptyIcon}>-</p>
+        )}
       </div>
     )
   }

--- a/webview/src/plots/components/comparisonTable/styles.module.scss
+++ b/webview/src/plots/components/comparisonTable/styles.module.scss
@@ -98,7 +98,7 @@ $gap: 4px;
   background-color: $bg-color;
   border-style: solid;
   border-width: thin;
-  border-color: $watermark-color;
+  border-color: $bg-color;
 }
 
 .noImageContent {
@@ -216,4 +216,13 @@ $gap: 4px;
   text-overflow: ellipsis;
   direction: rtl;
   white-space: nowrap;
+}
+
+.errorIcon {
+  color: $error-color;
+  margin: 6px;
+}
+
+.emptyIcon {
+  font-size: 32px;
 }

--- a/webview/src/shared/components/errorTooltip/ErrorTooltip.tsx
+++ b/webview/src/shared/components/errorTooltip/ErrorTooltip.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react'
 import styles from './styles.module.scss'
-import { Error } from '../../../shared/components/icons'
-import Tooltip from '../../../shared/components/tooltip/Tooltip'
+import { Error } from '../icons'
+import Tooltip from '../tooltip/Tooltip'
 
 export const ErrorTooltip: React.FC<{
   error?: string

--- a/webview/src/shared/components/errorTooltip/styles.module.scss
+++ b/webview/src/shared/components/errorTooltip/styles.module.scss
@@ -1,0 +1,15 @@
+.errorIcon {
+  margin-left: 6px;
+  margin-top: 3px;
+}
+
+.errorTooltip {
+  white-space: pre-wrap;
+  display: flex;
+  gap: 4px;
+
+  svg {
+    min-width: 16px;
+    min-height: 16px;
+  }
+}

--- a/webview/src/stories/ComparisonTable.stories.tsx
+++ b/webview/src/stories/ComparisonTable.stories.tsx
@@ -73,13 +73,23 @@ WithPinnedColumn.play = async ({ canvasElement }) => {
 const removeImages = (
   path: string,
   revisionsData: ComparisonRevisionData
+  // eslint-disable-next-line sonarjs/cognitive-complexity
 ): ComparisonRevisionData => {
   const filteredRevisionData: ComparisonRevisionData = {}
   for (const [revision, data] of Object.entries(revisionsData)) {
     if (
-      (path === comparisonTableFixture.plots[0].path && revision === 'main') ||
+      (path === comparisonTableFixture.plots[0].path &&
+        ['main', '4fb124a'].includes(revision)) ||
       revision === EXPERIMENT_WORKSPACE_ID
     ) {
+      filteredRevisionData[revision] = {
+        error:
+          revision === 'main'
+            ? `FileNotFoundError: ${path} not found.`
+            : undefined,
+        revision,
+        url: undefined
+      }
       continue
     }
     filteredRevisionData[revision] = data


### PR DESCRIPTION
# 2/4 `main` <- #3477 <- this <- #3522 <- #3532

Part of https://github.com/iterative/vscode-dvc/issues/2277

### Screenshot

![image](https://user-images.githubusercontent.com/37993418/226783401-695c5a5c-0224-49c7-8619-986dbb79658f.png)

with tooltip shown

![image](https://user-images.githubusercontent.com/37993418/226784215-ffcf9b12-cf8d-4f33-853c-06e2dab0a015.png)

I tried to make a `!` work to fit in with the errors shown in the experiments table but it did not look very good.

Note: If an image is completely broken/missing for all revisions then we do not know that it is an image so we won't be able to display it like this. We will still be able to add an error indicator into the tree for this.

Previous idea:

<img width="1728" alt="Screenshot 2023-03-21 at 1 08 52 pm" src="https://user-images.githubusercontent.com/37993418/226514606-1695641d-2145-4d11-840b-1e8ed9d01e3e.png">