### PR TITLE
Increase CodeClimate method line count threshold to 40

### DIFF
--- a/.codeclimate.json
+++ b/.codeclimate.json
@@ -17,7 +17,7 @@
     "method-count": { "config": { "threshold": 30 } },
     "method-lines": {
       "config": {
-        "threshold": 30
+        "threshold": 40
       }
     }
   }


### PR DESCRIPTION
As discussed in the retro.

I could not find a way to disable only React components so I updated the base number to 40.