### PR TITLE
Ensure unfetched image plots are on disk before providing URL to webview

### DIFF
--- a/extension/src/plots/model/collect.ts
+++ b/extension/src/plots/model/collect.ts
@@ -51,6 +51,7 @@ import {
   SelectedExperimentWithColor
 } from '../../experiments/model'
 import { Color } from '../../experiments/model/status/colors'
+import { exists } from '../../fileSystem'
 
 export const getCustomPlotId = (metric: string, param = CHECKPOINTS_PARAM) =>
   `custom-${metric}-${param}`
@@ -741,4 +742,20 @@ export const collectOrderedRevisions = (
     }
     return (b.Created || '').localeCompare(a.Created || '')
   })
+}
+
+export const collectImageUrl = (
+  image: ImagePlot | undefined,
+  fetched: boolean
+): string | undefined => {
+  const url = image?.url
+  if (!url) {
+    return
+  }
+
+  if (!fetched && !exists(url)) {
+    return undefined
+  }
+
+  return url
 }

--- a/extension/src/plots/model/index.ts
+++ b/extension/src/plots/model/index.ts
@@ -12,7 +12,8 @@ import {
   collectOverrideRevisionDetails,
   collectCustomPlots,
   getCustomPlotId,
-  collectOrderedRevisions
+  collectOrderedRevisions,
+  collectImageUrl
 } from './collect'
 import { getRevisionFirstThreeColumns } from './util'
 import {
@@ -484,10 +485,14 @@ export class PlotsModel extends ModelWithPersistence {
     for (const revision of selectedRevisions) {
       const image = this.comparisonData?.[revision]?.[path]
       const error = this.errors.getImageErrors(path, revision)
+      const fetched = this.fetchedRevs.has(revision)
+      const url = collectImageUrl(image, fetched)
+      const loading = !fetched && !url
       pathRevisions.revisions[revision] = {
         error,
+        loading,
         revision,
-        url: image?.url
+        url
       }
     }
     acc.push(pathRevisions)

--- a/extension/src/plots/webview/contract.ts
+++ b/extension/src/plots/webview/contract.ts
@@ -173,6 +173,7 @@ export type ComparisonPlot = {
   url: string | undefined
   revision: string
   error: string | undefined
+  loading: boolean
 }
 
 export enum PlotsDataKeys {

--- a/extension/src/test/fixtures/expShow/base/customPlots.ts
+++ b/extension/src/test/fixtures/expShow/base/customPlots.ts
@@ -1,9 +1,6 @@
-import { ExperimentWithCheckpoints } from '../../../../experiments/model'
+import type { ExperimentWithCheckpoints } from '../../../../experiments/model'
 import { copyOriginalColors } from '../../../../experiments/model/status/colors'
-import {
-  CHECKPOINTS_PARAM,
-  CustomPlotsOrderValue
-} from '../../../../plots/model/custom'
+import type { CustomPlotsOrderValue } from '../../../../plots/model/custom'
 import {
   CustomPlotsData,
   CustomPlotType,
@@ -24,12 +21,12 @@ export const customPlotsOrderFixture: CustomPlotsOrderValue[] = [
   },
   {
     metric: 'summary.json:loss',
-    param: CHECKPOINTS_PARAM,
+    param: 'epoch',
     type: CustomPlotType.CHECKPOINT
   },
   {
     metric: 'summary.json:accuracy',
-    param: CHECKPOINTS_PARAM,
+    param: 'epoch',
     type: CustomPlotType.CHECKPOINT
   }
 ]
@@ -267,7 +264,7 @@ const data: CustomPlotsData = {
     {
       id: 'custom-summary.json:loss-epoch',
       metric: 'summary.json:loss',
-      param: CHECKPOINTS_PARAM,
+      param: 'epoch',
       values: [
         { group: 'exp-e7a67', iteration: 3, y: 2.0205044746398926 },
         { group: 'exp-e7a67', iteration: 2, y: 2.0205044746398926 },
@@ -288,7 +285,7 @@ const data: CustomPlotsData = {
     {
       id: 'custom-summary.json:accuracy-epoch',
       metric: 'summary.json:accuracy',
-      param: CHECKPOINTS_PARAM,
+      param: 'epoch',
       values: [
         { group: 'exp-e7a67', iteration: 3, y: 0.3724166750907898 },
         { group: 'exp-e7a67', iteration: 2, y: 0.3724166750907898 },

--- a/extension/src/test/fixtures/plotsDiff/index.ts
+++ b/extension/src/test/fixtures/plotsDiff/index.ts
@@ -700,7 +700,8 @@ export const getComparisonWebviewMessage = (
       revisionsAcc[revision] = {
         url: `${url}?${MOCK_IMAGE_MTIME}`,
         revision,
-        error: undefined
+        error: undefined,
+        loading: false
       }
     }
 

--- a/webview/src/plots/components/App.test.tsx
+++ b/webview/src/plots/components/App.test.tsx
@@ -248,7 +248,12 @@ describe('App', () => {
           {
             path: 'training/plots/images/misclassified.jpg',
             revisions: {
-              ad2b5ec: { error: undefined, revision: 'ad2b5ec', url: undefined }
+              ad2b5ec: {
+                error: undefined,
+                loading: true,
+                revision: 'ad2b5ec',
+                url: undefined
+              }
             }
           }
         ],

--- a/webview/src/plots/components/comparisonTable/ComparisonTable.test.tsx
+++ b/webview/src/plots/components/comparisonTable/ComparisonTable.test.tsx
@@ -274,6 +274,7 @@ describe('ComparisonTable', () => {
           ...revisions,
           [revisionWithNoData]: {
             error: undefined,
+            loading: false,
             revision: revisionWithNoData,
             url: undefined
           }
@@ -306,6 +307,7 @@ describe('ComparisonTable', () => {
           ...revisions,
           [revisionWithNoData]: {
             error: 'this is an error',
+            loading: false,
             revision: revisionWithNoData,
             url: undefined
           }

--- a/webview/src/plots/components/comparisonTable/ComparisonTableCell.tsx
+++ b/webview/src/plots/components/comparisonTable/ComparisonTableCell.tsx
@@ -10,7 +10,7 @@ import { ErrorTooltip } from '../../../shared/components/errorTooltip/ErrorToolt
 
 type ComparisonTableCellProps = {
   path: string
-  plot?: ComparisonPlot & { fetched: boolean }
+  plot: ComparisonPlot
 }
 
 const MissingPlotTableCell: React.FC<{ plot: ComparisonPlot }> = ({ plot }) => (
@@ -41,9 +41,8 @@ export const ComparisonTableCell: React.FC<ComparisonTableCellProps> = ({
   path,
   plot
 }) => {
-  const fetched = plot?.fetched
-  const loading = !fetched && !plot?.url
-  const missing = fetched && !plot?.url
+  const loading = plot.loading
+  const missing = !loading && !plot.url
 
   if (loading) {
     return (

--- a/webview/src/plots/components/comparisonTable/ComparisonTableRow.tsx
+++ b/webview/src/plots/components/comparisonTable/ComparisonTableRow.tsx
@@ -15,7 +15,7 @@ import Tooltip, {
 
 export interface ComparisonTableRowProps {
   path: string
-  plots: (ComparisonPlot & { fetched: boolean })[]
+  plots: ComparisonPlot[]
   nbColumns: number
   pinnedColumn: string
 }

--- a/webview/src/plots/components/comparisonTable/ComparisonTableRows.tsx
+++ b/webview/src/plots/components/comparisonTable/ComparisonTableRows.tsx
@@ -46,7 +46,6 @@ export const ComparisionTableRows: React.FC<ComparisonTableRowsProps> = ({
           path={path}
           plots={columns.map(column => ({
             ...revs[column.revision],
-            fetched: column.fetched,
             revision: column.revision
           }))}
           nbColumns={columns.length}

--- a/webview/src/stories/ComparisonTable.stories.tsx
+++ b/webview/src/stories/ComparisonTable.stories.tsx
@@ -87,6 +87,7 @@ const removeImages = (
           revision === 'main'
             ? `FileNotFoundError: ${path} not found.`
             : undefined,
+        loading: false,
         revision,
         url: undefined
       }


### PR DESCRIPTION
# 5/9 `main` <- #3477 <- #3520 <- #3522 <- #3532 <- this <- #3545 <- #3546 <- #3547 <- #3548

We "shouldn't" ever get into this situation but I have seen some weirdness whilst testing the new logic. Seemed like a good idea to make sure the error can't happen.

Also took the opportunity to centralise more collection logic in the extension.