### PR TITLE
Fix removal of existing commit errors

### DIFF
--- a/extension/src/plots/errors/collect.test.ts
+++ b/extension/src/plots/errors/collect.test.ts
@@ -26,6 +26,66 @@ describe('collectErrors', () => {
     expect(errors).toStrictEqual([])
   })
 
+  it('should correctly handle the cliIdToLabel mapping for removing existing errors', () => {
+    const errors = collectErrors(
+      { data: {} },
+      [EXPERIMENT_WORKSPACE_ID, 'ff2489c'],
+      [
+        {
+          msg: 'unexpected error',
+          name: 'fun::plot',
+          rev: EXPERIMENT_WORKSPACE_ID,
+          source: 'metrics.json',
+          type: 'unexpected'
+        },
+        {
+          msg: 'unexpected error',
+          name: 'fun::plot',
+          rev: 'main',
+          source: 'metrics.json',
+          type: 'unexpected'
+        }
+      ],
+      { [EXPERIMENT_WORKSPACE_ID]: EXPERIMENT_WORKSPACE_ID, ff2489c: 'main' }
+    )
+
+    expect(errors).toStrictEqual([])
+  })
+
+  it('should correctly handle the cliIdToLabel mapping for replacing errors', () => {
+    const newError = {
+      msg: 'new error',
+      name: 'fun::plot',
+      rev: 'ff2489c',
+      source: 'metrics.json',
+      type: 'unexpected'
+    }
+
+    const errors = collectErrors(
+      { data: {}, errors: [newError] },
+      [EXPERIMENT_WORKSPACE_ID, 'ff2489c'],
+      [
+        {
+          msg: 'unexpected error',
+          name: 'fun::plot',
+          rev: EXPERIMENT_WORKSPACE_ID,
+          source: 'metrics.json',
+          type: 'unexpected'
+        },
+        {
+          msg: 'unexpected error',
+          name: 'fun::plot',
+          rev: 'main',
+          source: 'metrics.json',
+          type: 'unexpected'
+        }
+      ],
+      { [EXPERIMENT_WORKSPACE_ID]: EXPERIMENT_WORKSPACE_ID, ff2489c: 'main' }
+    )
+
+    expect(errors).toStrictEqual([{ ...newError, rev: 'main' }])
+  })
+
   it('should collect new errors', () => {
     const newError = {
       msg: 'Blue screen of death',

--- a/extension/src/plots/errors/collect.ts
+++ b/extension/src/plots/errors/collect.ts
@@ -11,9 +11,11 @@ export const collectErrors = (
   errors: PlotError[],
   cliIdToLabel: { [id: string]: string }
 ) => {
-  const existingErrors = errors.filter(
-    ({ rev }) => !revs.includes(cliIdToLabel[rev] || rev)
+  const fetchedRevs = new Set(
+    revs.map((rev: string) => cliIdToLabel[rev] || rev)
   )
+
+  const existingErrors = errors.filter(({ rev }) => !fetchedRevs.has(rev))
   const newErrors = data?.errors || []
 
   return [


### PR DESCRIPTION
# 6/9 `main` <- #3477 <- #3520 <- #3522 <- #3532 <- #3544 <- this <- #3546 <- #3547 <- #3548

This PR fixes an issue where errors for commits were not successfully dismissed on update.