### PR TITLE
Account for data key being optional in plots diff output

### DIFF
--- a/extension/src/cli/dvc/contract.ts
+++ b/extension/src/cli/dvc/contract.ts
@@ -106,9 +106,13 @@ export type PlotError = {
   source?: string
 } & ErrorContents
 
-export interface PlotsOutput {
-  data: { [path: string]: Plot[] }
+export type RawPlotsOutput = {
+  data?: { [path: string]: Plot[] }
   errors?: PlotError[]
+}
+
+export type PlotsOutput = RawPlotsOutput & {
+  data: { [path: string]: Plot[] }
 }
 
 export type PlotsOutputOrError = PlotsOutput | DvcError

--- a/extension/src/cli/dvc/reader.test.ts
+++ b/extension/src/cli/dvc/reader.test.ts
@@ -180,7 +180,30 @@ describe('CliReader', () => {
       mockedCreateProcess.mockReturnValueOnce(getMockedProcess(''))
 
       const plots = await dvcReader.plotsDiff(cwd, 'HEAD')
-      expect(plots).toStrictEqual({})
+      expect(plots).toStrictEqual({ data: {} })
+    })
+
+    it('should remove an empty errors array from the output', async () => {
+      const cwd = __dirname
+
+      mockedCreateProcess.mockReturnValueOnce(
+        getMockedProcess(JSON.stringify({ errors: [] }))
+      )
+
+      const plots = await dvcReader.plotsDiff(cwd, 'main')
+      expect(plots).toStrictEqual({ data: {} })
+    })
+
+    it('should not remove an errors array with entries from the output', async () => {
+      const cwd = __dirname
+      const errors = [{ msg: 'something went wrong' }]
+
+      mockedCreateProcess.mockReturnValueOnce(
+        getMockedProcess(JSON.stringify({ errors }))
+      )
+
+      const plots = await dvcReader.plotsDiff(cwd, 'main')
+      expect(plots).toStrictEqual({ data: {}, errors })
     })
 
     it('should match the expected output', async () => {


### PR DESCRIPTION
# 8/9 `main` <- https://github.com/iterative/vscode-dvc/pull/3477 <- https://github.com/iterative/vscode-dvc/pull/3520 <- https://github.com/iterative/vscode-dvc/pull/3522 <- https://github.com/iterative/vscode-dvc/pull/3532 <- #3544 <- https://github.com/iterative/vscode-dvc/pull/3545 <- https://github.com/iterative/vscode-dvc/pull/3546 <- this <- #3548

This PR makes sure that we account for the data key being optional in `plots diff`. We do this at the boundary of the system instead of checking for the presence of the key all through the collection code.