### PR TITLE
Remove code that refreshes a single plot revision (no longer possible)

### DIFF
--- a/extension/src/plots/webview/messages.ts
+++ b/extension/src/plots/webview/messages.ts
@@ -106,10 +106,8 @@ export class WebviewMessages {
         return this.selectExperimentsFromWebview()
       case MessageFromWebviewType.REMOVE_CUSTOM_PLOTS:
         return this.removeCustomPlots()
-      case MessageFromWebviewType.REFRESH_REVISION:
-        return this.attemptToRefreshRevData(message.payload)
       case MessageFromWebviewType.REFRESH_REVISIONS:
-        return this.attemptToRefreshSelectedData(message.payload)
+        return this.refreshData()
       case MessageFromWebviewType.TOGGLE_EXPERIMENT:
         return this.setExperimentStatus(message.payload)
       case MessageFromWebviewType.ZOOM_PLOT:
@@ -326,24 +324,12 @@ export class WebviewMessages {
     )
   }
 
-  private attemptToRefreshRevData(revision: string) {
-    void Toast.infoWithOptions(
-      `Attempting to refresh plots data for ${revision}.`
-    )
-    void this.updateData()
-    sendTelemetryEvent(
-      EventName.VIEWS_PLOTS_MANUAL_REFRESH,
-      { revisions: 1 },
-      undefined
-    )
-  }
-
-  private attemptToRefreshSelectedData(revisions: string[]) {
+  private refreshData() {
     void Toast.infoWithOptions('Attempting to refresh visible plots data.')
     void this.updateData()
     sendTelemetryEvent(
       EventName.VIEWS_PLOTS_MANUAL_REFRESH,
-      { revisions: revisions.length },
+      undefined,
       undefined
     )
   }

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -243,7 +243,7 @@ export interface IEventNamePropertyMapping {
   [EventName.VIEWS_PLOTS_CUSTOM_PLOT_REMOVED]: undefined
   [EventName.VIEWS_PLOTS_CUSTOM_PLOT_ADDED]: undefined
   [EventName.VIEWS_PLOTS_FOCUS_CHANGED]: WebviewFocusChangedProperties
-  [EventName.VIEWS_PLOTS_MANUAL_REFRESH]: { revisions: number }
+  [EventName.VIEWS_PLOTS_MANUAL_REFRESH]: undefined
   [EventName.VIEWS_PLOTS_REVISIONS_REORDERED]: undefined
   [EventName.VIEWS_PLOTS_COMPARISON_ROWS_REORDERED]: undefined
   [EventName.VIEWS_PLOTS_SECTION_RESIZED]: {

--- a/extension/src/test/suite/plots/index.test.ts
+++ b/extension/src/test/suite/plots/index.test.ts
@@ -601,47 +601,7 @@ suite('Plots Test Suite', () => {
       )
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
-    it('should handle a message to manually refresh a revision from the webview', async () => {
-      const { data, plots, mockPlotsDiff } = await buildPlots(
-        disposable,
-        plotsDiffFixture
-      )
-
-      const webview = await plots.showWebview()
-      mockPlotsDiff.resetHistory()
-
-      const mockSendTelemetryEvent = stub(Telemetry, 'sendTelemetryEvent')
-      const mockMessageReceived = getMessageReceivedEmitter(webview)
-
-      const dataUpdateEvent = new Promise(resolve =>
-        data.onDidUpdate(() => resolve(undefined))
-      )
-
-      mockMessageReceived.fire({
-        payload: 'main',
-        type: MessageFromWebviewType.REFRESH_REVISION
-      })
-
-      await dataUpdateEvent
-
-      expect(mockSendTelemetryEvent).to.be.calledOnce
-      expect(mockSendTelemetryEvent).to.be.calledWithExactly(
-        EventName.VIEWS_PLOTS_MANUAL_REFRESH,
-        { revisions: 1 },
-        undefined
-      )
-      expect(mockPlotsDiff).to.be.called
-      expect(mockPlotsDiff).to.be.calledWithExactly(
-        dvcDemoPath,
-        EXPERIMENT_WORKSPACE_ID,
-        '4fb124a',
-        '42b8736',
-        '1ba7bcd',
-        '53c3851'
-      )
-    }).timeout(WEBVIEW_TEST_TIMEOUT)
-
-    it('should handle a message to manually refresh all visible plots from the webview', async () => {
+    it('should handle a message to manually refresh plot revisions from the webview', async () => {
       const { data, plots, mockPlotsDiff, messageSpy } = await buildPlots(
         disposable,
         plotsDiffFixture
@@ -661,13 +621,6 @@ suite('Plots Test Suite', () => {
       )
 
       mockMessageReceived.fire({
-        payload: [
-          '1ba7bcd',
-          '42b8736',
-          '4fb124a',
-          'main',
-          EXPERIMENT_WORKSPACE_ID
-        ],
         type: MessageFromWebviewType.REFRESH_REVISIONS
       })
 
@@ -676,7 +629,7 @@ suite('Plots Test Suite', () => {
       expect(mockSendTelemetryEvent).to.be.calledOnce
       expect(mockSendTelemetryEvent).to.be.calledWithExactly(
         EventName.VIEWS_PLOTS_MANUAL_REFRESH,
-        { revisions: 5 },
+        undefined,
         undefined
       )
       expect(mockPlotsDiff).to.be.called

--- a/extension/src/webview/contract.ts
+++ b/extension/src/webview/contract.ts
@@ -193,8 +193,7 @@ export type MessageFromWebview =
   | { type: MessageFromWebviewType.SELECT_EXPERIMENTS }
   | { type: MessageFromWebviewType.SELECT_PYTHON_INTERPRETER }
   | { type: MessageFromWebviewType.SELECT_PLOTS }
-  | { type: MessageFromWebviewType.REFRESH_REVISION; payload: string }
-  | { type: MessageFromWebviewType.REFRESH_REVISIONS; payload: string[] }
+  | { type: MessageFromWebviewType.REFRESH_REVISIONS }
   | { type: MessageFromWebviewType.SELECT_COLUMNS }
   | { type: MessageFromWebviewType.FOCUS_FILTERS_TREE }
   | { type: MessageFromWebviewType.FOCUS_SORTS_TREE }

--- a/webview/src/plots/components/App.test.tsx
+++ b/webview/src/plots/components/App.test.tsx
@@ -1874,13 +1874,6 @@ describe('App', () => {
 
       expect(mockPostMessage).toHaveBeenCalledTimes(1)
       expect(mockPostMessage).toHaveBeenCalledWith({
-        payload: [
-          EXPERIMENT_WORKSPACE_ID,
-          'main',
-          '4fb124a',
-          '42b8736',
-          '1ba7bcd'
-        ],
         type: MessageFromWebviewType.REFRESH_REVISIONS
       })
     })

--- a/webview/src/plots/components/comparisonTable/ComparisonTable.test.tsx
+++ b/webview/src/plots/components/comparisonTable/ComparisonTable.test.tsx
@@ -334,8 +334,7 @@ describe('ComparisonTable', () => {
       fireEvent.click(button)
       expect(mockPostMessage).toHaveBeenCalledTimes(1)
       expect(mockPostMessage).toHaveBeenCalledWith({
-        payload: revisionWithNoData,
-        type: MessageFromWebviewType.REFRESH_REVISION
+        type: MessageFromWebviewType.REFRESH_REVISIONS
       })
       mockPostMessage.mockReset()
     }

--- a/webview/src/plots/components/comparisonTable/ComparisonTableCell.tsx
+++ b/webview/src/plots/components/comparisonTable/ComparisonTableCell.tsx
@@ -1,10 +1,8 @@
 import React from 'react'
-import { MessageFromWebviewType } from 'dvc/src/webview/contract'
 import { ComparisonPlot } from 'dvc/src/plots/webview/contract'
 import styles from './styles.module.scss'
 import { RefreshButton } from '../../../shared/components/button/RefreshButton'
-import { sendMessage } from '../../../shared/vscode'
-import { zoomPlot } from '../messages'
+import { refreshRevisions, zoomPlot } from '../messages'
 import { Error } from '../../../shared/components/icons'
 import { ErrorTooltip } from '../../../shared/components/tooltip/ErrorTooltip'
 
@@ -22,14 +20,7 @@ const MissingPlotTableCell: React.FC<{ plot: ComparisonPlot }> = ({ plot }) => (
             <Error height={48} width={48} className={styles.errorIcon} />
           </div>
         </ErrorTooltip>
-        <RefreshButton
-          onClick={() =>
-            sendMessage({
-              payload: plot.revision,
-              type: MessageFromWebviewType.REFRESH_REVISION
-            })
-          }
-        />
+        <RefreshButton onClick={refreshRevisions} />
       </>
     ) : (
       <p className={styles.emptyIcon}>-</p>

--- a/webview/src/plots/components/messages.ts
+++ b/webview/src/plots/components/messages.ts
@@ -3,3 +3,21 @@ import { sendMessage } from '../../shared/vscode'
 
 export const zoomPlot = (imagePath?: string) =>
   sendMessage({ payload: imagePath, type: MessageFromWebviewType.ZOOM_PLOT })
+
+export const removeRevision = (revision: string) => {
+  sendMessage({
+    payload: revision,
+    type: MessageFromWebviewType.TOGGLE_EXPERIMENT
+  })
+}
+
+export const refreshRevisions = () =>
+  sendMessage({
+    type: MessageFromWebviewType.REFRESH_REVISIONS
+  })
+
+export const selectRevisions = () => {
+  sendMessage({
+    type: MessageFromWebviewType.SELECT_EXPERIMENTS
+  })
+}

--- a/webview/src/plots/components/ribbon/Ribbon.tsx
+++ b/webview/src/plots/components/ribbon/Ribbon.tsx
@@ -1,15 +1,14 @@
 import cx from 'classnames'
-import { MessageFromWebviewType } from 'dvc/src/webview/contract'
 import React, { useCallback, useEffect, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useInView } from 'react-intersection-observer'
 import styles from './styles.module.scss'
 import { RibbonBlock } from './RibbonBlock'
 import { update } from './ribbonSlice'
-import { sendMessage } from '../../../shared/vscode'
 import { IconButton } from '../../../shared/components/button/IconButton'
 import { PlotsState } from '../../store'
 import { Lines, Refresh } from '../../../shared/components/icons'
+import { refreshRevisions, removeRevision, selectRevisions } from '../messages'
 
 const MAX_NB_EXP = 7
 
@@ -44,25 +43,6 @@ export const Ribbon: React.FC = () => {
       window.removeEventListener('resize', changeRibbonHeight)
     }
   }, [changeRibbonHeight])
-
-  const removeRevision = (revision: string) => {
-    sendMessage({
-      payload: revision,
-      type: MessageFromWebviewType.TOGGLE_EXPERIMENT
-    })
-  }
-
-  const refreshRevisions = () =>
-    sendMessage({
-      payload: revisions.map(({ revision }) => revision),
-      type: MessageFromWebviewType.REFRESH_REVISIONS
-    })
-
-  const selectRevisions = () => {
-    sendMessage({
-      type: MessageFromWebviewType.SELECT_EXPERIMENTS
-    })
-  }
 
   return (
     <ul


### PR DESCRIPTION
Note: starting a new chain as this is number 10 away from `main`. Does not seem like a good use of time to maintain the already approved PR descriptions.

# 1/2 `main` <- this <- #3557

This PR removes the code relating to refreshing a single revision. It is no longer possible to refresh a single revision after #3532.
