### PR TITLE
Display error thrown by Plots Diff in Plots tree

### DIFF
--- a/extension/src/experiments/columns/tree.test.ts
+++ b/extension/src/experiments/columns/tree.test.ts
@@ -439,7 +439,7 @@ describe('ExperimentsColumnsTree', () => {
     it('should return the correct tree item for a repository root', () => {
       let mockedItem = {}
       mockedTreeItem.mockImplementationOnce(function (uri, collapsibleState) {
-        expect(collapsibleState).toStrictEqual(1)
+        expect(collapsibleState).toStrictEqual(2)
         mockedItem = { collapsibleState, uri }
         return mockedItem
       })
@@ -498,6 +498,7 @@ describe('ExperimentsColumnsTree', () => {
       },
       description: '3/4',
       iconPath: mockedSelectedCheckbox,
+      tooltip: undefined,
       uri: filename
     })
   })
@@ -538,6 +539,7 @@ describe('ExperimentsColumnsTree', () => {
         title: 'toggle'
       },
       iconPath: mockedEmptyCheckbox,
+      tooltip: undefined,
       uri: filename
     })
   })

--- a/extension/src/experiments/columns/tree.ts
+++ b/extension/src/experiments/columns/tree.ts
@@ -8,6 +8,7 @@ import { ResourceLocator } from '../../resourceLocator'
 import { RegisteredCommands } from '../../commands/external'
 import { EventName } from '../../telemetry/constants'
 import { InternalCommands } from '../../commands/internal'
+import { getRootItem, isRoot } from '../../tree'
 
 export class ExperimentsColumnsTree extends BasePathSelectionTree<WorkspaceExperiments> {
   constructor(
@@ -31,11 +32,16 @@ export class ExperimentsColumnsTree extends BasePathSelectionTree<WorkspaceExper
     )
   }
 
-  protected getBaseTreeItem({
-    label,
-    collapsibleState
-  }: PathSelectionItem & { label: string }) {
-    return new TreeItem(label, collapsibleState)
+  public getTreeItem(element: string | PathSelectionItem): TreeItem {
+    if (isRoot(element)) {
+      return getRootItem(element)
+    }
+
+    const { label, collapsibleState } = element
+
+    const treeItem = new TreeItem(label as string, collapsibleState)
+
+    return this.addTreeItemDetails(element, treeItem)
   }
 
   protected getRepositoryChildren(dvcRoot: string, path: string) {

--- a/extension/src/experiments/model/filterBy/tree.ts
+++ b/extension/src/experiments/model/filterBy/tree.ts
@@ -18,7 +18,7 @@ import {
   joinTruthyItems,
   sortCollectedArray
 } from '../../../util/array'
-import { createTreeView, getRootItem } from '../../../tree'
+import { createTreeView, getRootItem, isRoot } from '../../../tree'
 import { Disposable } from '../../../class/dispose'
 
 export type FilterItem = {
@@ -66,7 +66,7 @@ export class ExperimentsFilterByTree
   }
 
   public getTreeItem(element: string | FilterItem): TreeItem {
-    if (this.isRoot(element)) {
+    if (isRoot(element)) {
       return getRootItem(element)
     }
 
@@ -142,10 +142,6 @@ export class ExperimentsFilterByTree
     return this.experiments
       .getRepository(filter.dvcRoot)
       .removeFilter(filter.id)
-  }
-
-  private isRoot(element: string | FilterItem): element is string {
-    return typeof element === 'string'
   }
 
   private getDvcRoots() {

--- a/extension/src/experiments/model/tree.ts
+++ b/extension/src/experiments/model/tree.ts
@@ -22,7 +22,8 @@ import {
   DecoratableTreeItemScheme,
   getDecoratableTreeItem,
   getErrorTooltip,
-  getRootItem
+  getRootItem,
+  isRoot
 } from '../../tree'
 import { IconName, Resource, ResourceLocator } from '../../resourceLocator'
 import {
@@ -82,7 +83,7 @@ export class ExperimentsTree
   }
 
   public getTreeItem(element: string | ExperimentItem): TreeItem {
-    if (this.isRoot(element)) {
+    if (isRoot(element)) {
       return getRootItem(element)
     }
 
@@ -121,7 +122,7 @@ export class ExperimentsTree
       return this.getRootElements()
     }
 
-    if (this.isRoot(element)) {
+    if (isRoot(element)) {
       return Promise.resolve(this.getWorkspaceAndCommits(element))
     }
 
@@ -232,7 +233,7 @@ export class ExperimentsTree
   }
 
   private setExpanded(element: string | ExperimentItem, expanded: boolean) {
-    if (!this.isRoot(element) && element.description) {
+    if (!isRoot(element) && element.description) {
       this.setExperimentExpanded(element.description, expanded)
     }
   }
@@ -349,10 +350,6 @@ export class ExperimentsTree
       (dvcRoots.length > 1 ? ' per project' : '') +
       ')'
     )
-  }
-
-  private isRoot(element: string | ExperimentItem): element is string {
-    return typeof element === 'string'
   }
 
   private getSelectedExperimentItems() {

--- a/extension/src/path/selection/model.ts
+++ b/extension/src/path/selection/model.ts
@@ -46,7 +46,7 @@ export abstract class PathSelectionModel<
 
   public getTerminalNodeStatuses(parentPath?: string): Status[] {
     return (this.getChildren(parentPath) || []).flatMap(element => {
-      const terminalStatuses = element.hasChildren
+      const terminalStatuses = (element as T).hasChildren
         ? this.getTerminalNodeStatuses(element.path)
         : [this.status[element.path]]
       return [...terminalStatuses]
@@ -144,7 +144,9 @@ export abstract class PathSelectionModel<
 
   abstract getChildren(
     ...args: unknown[]
-  ): (T & { descendantStatuses: Status[]; status: Status })[]
+  ):
+    | (T & { descendantStatuses: Status[]; status: Status })[]
+    | { error: string; path: string }[]
 
   abstract getTerminalNodes(): (T & { selected: boolean })[]
 }

--- a/extension/src/path/selection/tree.ts
+++ b/extension/src/path/selection/tree.ts
@@ -12,34 +12,38 @@ import { WorkspaceExperiments } from '../../experiments/workspace'
 import { WorkspacePlots } from '../../plots/workspace'
 import { Resource, ResourceLocator } from '../../resourceLocator'
 import { RegisteredCommands } from '../../commands/external'
-import { createTreeView } from '../../tree'
+import { createTreeView, isRoot } from '../../tree'
 import { definedAndNonEmpty, sortCollectedArray } from '../../util/array'
 import { sendViewOpenedTelemetryEvent } from '../../telemetry'
 import { ViewOpenedEventName } from '../../telemetry/constants'
 import { Disposable } from '../../class/dispose'
 
+export type ErrorItem = { error: string; path: string }
+
 export type PathSelectionItem = {
+  collapsibleState: TreeItemCollapsibleState
   description: string | undefined
   dvcRoot: string
-  collapsibleState: TreeItemCollapsibleState
+  iconPath: Resource | Uri
   label: string | undefined
   path: string
-  iconPath: Resource | Uri
   tooltip: MarkdownString | undefined
 }
+
+type Item = ErrorItem | PathSelectionItem
 
 export abstract class BasePathSelectionTree<
     T extends WorkspaceExperiments | WorkspacePlots
   >
   extends Disposable
-  implements TreeDataProvider<string | PathSelectionItem>
+  implements TreeDataProvider<string | Item>
 {
   public readonly onDidChangeTreeData: Event<PathSelectionItem | void>
 
   protected readonly workspace: T
   protected readonly resourceLocator: ResourceLocator
 
-  private readonly view: TreeView<string | PathSelectionItem>
+  private readonly view: TreeView<string | Item>
 
   private viewed = false
   private readonly openEventName: ViewOpenedEventName
@@ -61,9 +65,7 @@ export abstract class BasePathSelectionTree<
 
     this.onDidChangeTreeData = changeEvent
 
-    this.view = this.dispose.track(
-      createTreeView<PathSelectionItem>(name, this)
-    )
+    this.view = this.dispose.track(createTreeView<Item>(name, this))
 
     this.toggleCommand = toggleCommand
 
@@ -72,36 +74,9 @@ export abstract class BasePathSelectionTree<
     this.updateDescriptionOnChange()
   }
 
-  public getTreeItem(element: string | PathSelectionItem): TreeItem {
-    if (this.isRoot(element)) {
-      const resourceUri = Uri.file(element)
-      return new TreeItem(resourceUri, TreeItemCollapsibleState.Collapsed)
-    }
-
-    const { dvcRoot, path, description, iconPath, tooltip } = element
-
-    const treeItem = this.getBaseTreeItem(element)
-
-    treeItem.command = {
-      arguments: [{ dvcRoot, path }],
-      command: this.toggleCommand,
-      title: 'toggle'
-    }
-
-    treeItem.iconPath = iconPath
-    if (description) {
-      treeItem.description = description
-    }
-    if (tooltip) {
-      treeItem.tooltip = tooltip
-    }
-
-    return treeItem
-  }
-
   public getChildren(
     element?: string | PathSelectionItem
-  ): Promise<PathSelectionItem[] | string[]> {
+  ): Promise<Item[] | string[]> {
     if (element) {
       return Promise.resolve(this.getChildElements(element))
     }
@@ -109,7 +84,7 @@ export abstract class BasePathSelectionTree<
     return this.getRootElements()
   }
 
-  protected getIconPath(status?: Status) {
+  protected getIconPath(status: Status) {
     if (status === Status.SELECTED) {
       return this.resourceLocator.checkedCheckbox
     }
@@ -155,7 +130,7 @@ export abstract class BasePathSelectionTree<
       ? TreeItemCollapsibleState.Collapsed
       : TreeItemCollapsibleState.None
 
-    return {
+    const pathSelectionItem: PathSelectionItem = {
       collapsibleState,
       description,
       dvcRoot,
@@ -164,6 +139,27 @@ export abstract class BasePathSelectionTree<
       path,
       tooltip
     }
+
+    return pathSelectionItem
+  }
+
+  protected addTreeItemDetails(element: PathSelectionItem, treeItem: TreeItem) {
+    const { dvcRoot, path, description, iconPath, tooltip } = element
+
+    treeItem.command = {
+      arguments: [{ dvcRoot, path }],
+      command: this.toggleCommand,
+      title: 'toggle'
+    }
+
+    treeItem.iconPath = iconPath
+    if (description) {
+      treeItem.description = description
+    }
+
+    treeItem.tooltip = tooltip
+
+    return treeItem
   }
 
   private updateDescriptionOnChange() {
@@ -196,14 +192,12 @@ export abstract class BasePathSelectionTree<
     return sortCollectedArray(dvcRoots, (a, b) => a.localeCompare(b))
   }
 
-  private getChildElements(
-    element: string | PathSelectionItem
-  ): PathSelectionItem[] {
+  private getChildElements(element: string | PathSelectionItem): Item[] {
     if (!element) {
       return []
     }
 
-    if (this.isRoot(element)) {
+    if (isRoot(element)) {
       return this.getRepositoryChildren(element, undefined)
     }
 
@@ -212,16 +206,12 @@ export abstract class BasePathSelectionTree<
     return this.getRepositoryChildren(dvcRoot, path)
   }
 
-  private isRoot(element: string | PathSelectionItem): element is string {
-    return typeof element === 'string'
-  }
-
-  protected abstract getBaseTreeItem(element: PathSelectionItem): TreeItem
+  abstract getTreeItem(element: string | Item): TreeItem
 
   protected abstract getRepositoryChildren(
     dvcRoot: string,
     path: string | undefined
-  ): PathSelectionItem[]
+  ): Item[]
 
   protected abstract getRepositoryStatuses(dvcRoot: string): Status[]
 }

--- a/extension/src/plots/index.ts
+++ b/extension/src/plots/index.ts
@@ -122,6 +122,9 @@ export class Plots extends BaseRepository<TPlotsData> {
   }
 
   public getPathStatuses() {
+    if (this.errors.hasCliError()) {
+      return []
+    }
     return this.paths.getTerminalNodeStatuses(undefined)
   }
 

--- a/extension/src/plots/paths/model.test.ts
+++ b/extension/src/plots/paths/model.test.ts
@@ -22,7 +22,11 @@ describe('PathsModel', () => {
   ]
 
   const buildMockErrorsModel = () =>
-    ({ getPathErrors: () => undefined } as unknown as ErrorsModel)
+    ({
+      getCliError: () => undefined,
+      getPathErrors: () => undefined,
+      hasCliError: () => undefined
+    } as unknown as ErrorsModel)
 
   it('should return the expected paths when given the default output fixture', () => {
     const comparisonType = new Set([PathType.COMPARISON])

--- a/extension/src/repository/model/collect.ts
+++ b/extension/src/repository/model/collect.ts
@@ -242,7 +242,7 @@ export const collectDataStatus = (
 export type PathItem = Resource & {
   isDirectory: boolean
   isTracked: boolean
-  error?: { label: string; msg: string }
+  error?: string
 }
 
 const transformToAbsTree = (

--- a/extension/src/repository/model/error.ts
+++ b/extension/src/repository/model/error.ts
@@ -1,29 +1,21 @@
 import { PathItem } from './collect'
 
-export type ErrorItem = { error: { label: string; msg: string } }
+type ErrorItem = { error: string }
 
 export const pathItemHasError = <T extends PathItem>(
   maybeErrorItem: T
-): maybeErrorItem is T & ErrorItem =>
-  !!(maybeErrorItem?.error?.label && maybeErrorItem?.error?.msg)
-
-export const getLabel = (msg: string): string =>
-  msg.split('\n')[0].replace(/'|"/g, '')
+): maybeErrorItem is T & ErrorItem => !!maybeErrorItem?.error
 
 export const createTreeFromError = (
   dvcRoot: string,
-  msg: string,
-  label: string
+  msg: string
 ): Map<string, PathItem[]> =>
   new Map([
     [
       dvcRoot,
       [
         {
-          error: {
-            label,
-            msg
-          }
+          error: msg
         } as PathItem
       ]
     ]

--- a/extension/src/repository/model/index.test.ts
+++ b/extension/src/repository/model/index.test.ts
@@ -253,9 +253,7 @@ describe('RepositoryModel', () => {
       expect(model.getChildren(dvcDemoPath)).toStrictEqual([])
 
       model.transformAndSet(emptyRepoError)
-      expect(model.getChildren(dvcDemoPath)).toStrictEqual([
-        { error: { label: './dvc.yaml validation failed.', msg } }
-      ])
+      expect(model.getChildren(dvcDemoPath)).toStrictEqual([{ error: msg }])
 
       model.transformAndSet(emptyRepoData)
       expect(model.getChildren(dvcDemoPath)).toStrictEqual([])

--- a/extension/src/repository/model/tree.test.ts
+++ b/extension/src/repository/model/tree.test.ts
@@ -401,10 +401,7 @@ describe('RepositoriesTree', () => {
       )
 
       const treeItem = trackedTreeView.getTreeItem({
-        error: {
-          label,
-          msg
-        }
+        error: msg
       } as PathItem)
 
       expect(mockedTreeItem).toHaveBeenCalledTimes(1)

--- a/extension/src/test/suite/plots/util.ts
+++ b/extension/src/test/suite/plots/util.ts
@@ -25,6 +25,7 @@ import { ExperimentsModel } from '../../../experiments/model'
 import { Experiment } from '../../../experiments/webview/contract'
 import { EXPERIMENT_WORKSPACE_ID, PlotsOutput } from '../../../cli/dvc/contract'
 import { isCheckpointPlot } from '../../../plots/model/custom'
+import { ErrorsModel } from '../../../plots/errors/model'
 
 export const buildPlots = async (
   disposer: Disposer,
@@ -98,10 +99,14 @@ export const buildPlots = async (
   const pathsModel: PathsModel = (plots as any).paths
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const errorsModel: ErrorsModel = (plots as any).errors
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const webviewMessages: WebviewMessages = (plots as any).webviewMessages
 
   return {
     data,
+    errorsModel,
     experiments,
     messageSpy,
     mockGetModifiedTime,

--- a/extension/src/test/suite/repository/index.test.ts
+++ b/extension/src/test/suite/repository/index.test.ts
@@ -406,10 +406,7 @@ suite('Repository Test Suite', () => {
 
       expect(repository.getChildren(dvcDemoPath)).to.deep.equal([
         {
-          error: {
-            label: './dvc.yaml validation failed.',
-            msg
-          }
+          error: msg
         }
       ])
     })

--- a/extension/src/tree/index.ts
+++ b/extension/src/tree/index.ts
@@ -1,5 +1,6 @@
 import {
   MarkdownString,
+  ThemeIcon,
   TreeDataProvider,
   TreeItem,
   TreeItemCollapsibleState,
@@ -8,6 +9,8 @@ import {
   window
 } from 'vscode'
 import { getMarkdownString } from '../vscode/markdownString'
+import { RegisteredCommands } from '../commands/external'
+import { hasKey } from '../util/object'
 
 export enum DecoratableTreeItemScheme {
   EXPERIMENTS = 'dvc.experiments',
@@ -29,8 +32,38 @@ export const getDecoratableTreeItem = (
   return new TreeItem(decoratableUri, collapsibleState)
 }
 
+export type ErrorItem = { error: string }
+
+export const isErrorItem = (
+  maybeErrorItem: unknown
+): maybeErrorItem is ErrorItem => hasKey(maybeErrorItem, 'error')
+
 export const getErrorTooltip = (msg: string): MarkdownString =>
   getMarkdownString(`$(error) ${msg}`)
+
+export const getCliErrorLabel = (msg: string): string =>
+  msg.split('\n')[0].replace(/'|"/g, '')
+
+export const getCliErrorTreeItem = (
+  path: string,
+  msg: string,
+  decoratableTreeItemScheme: DecoratableTreeItemScheme
+) => {
+  const treeItem = getDecoratableTreeItem(path, decoratableTreeItemScheme)
+
+  treeItem.tooltip = getErrorTooltip(msg)
+
+  treeItem.iconPath = new ThemeIcon('blank')
+
+  treeItem.command = {
+    command: RegisteredCommands.EXTENSION_SHOW_OUTPUT,
+    title: 'Show DVC Output'
+  }
+  return treeItem
+}
+
+export const isRoot = (element: unknown): element is string =>
+  typeof element === 'string'
 
 export const createTreeView = <T>(
   name: string,


### PR DESCRIPTION
# 1/2 `main` <- this <- #3570 

Part of #3222

This PR handles `dvc plots` diff throwing an error. The error is displayed in the plots tree. In the normal way that we display "global errors". I will delay the 2nd part of this PR (displaying global errors in the webview) until #3523 is merged.

### Demo

https://user-images.githubusercontent.com/37993418/228108929-1e72a36d-f8e0-4574-9ade-55c9ee64b4a8.mov


Note: `dvc plots diff` will actually no longer throw an error under the above circumstances.