### PR TITLE
Remove vega-util truncation for ribbon tooltip

### DIFF
--- a/extension/src/test/fixtures/plotsDiff/index.ts
+++ b/extension/src/test/fixtures/plotsDiff/index.ts
@@ -572,7 +572,7 @@ export const getRevisions = (): Revision[] => {
           value: 2.048856019973755
         },
         {
-          path: 'summary.json:accuracy',
+          path: 'summary.json:accuracy:something:something_more:way--way-way-longer',
           type: ColumnType.METRICS,
           value: 0.3484833240509033
         }

--- a/extension/src/test/fixtures/plotsDiff/index.ts
+++ b/extension/src/test/fixtures/plotsDiff/index.ts
@@ -572,7 +572,7 @@ export const getRevisions = (): Revision[] => {
           value: 2.048856019973755
         },
         {
-          path: 'summary.json:accuracy:something:something_more:way--way-way-longer',
+          path: 'summary.json:accuracy',
           type: ColumnType.METRICS,
           value: 0.3484833240509033
         }

--- a/webview/src/plots/components/ribbon/RibbonBlockTooltip.tsx
+++ b/webview/src/plots/components/ribbon/RibbonBlockTooltip.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from 'react'
 import cn from 'classnames'
-import { truncate } from 'vega-util'
 import { Revision } from 'dvc/src/plots/webview/contract'
 import { formatNumber } from 'dvc/src/util/number'
 import styles from './styles.module.scss'
@@ -22,7 +21,7 @@ export const RibbonBlockTooltip: React.FC<{
           {firstThreeColumns.map(({ path, value, type }) => (
             <tr key={path}>
               <td className={cn(styles[`${type}Key`])}>
-                {truncate(path, 45, 'left')}
+                <span className={styles.tooltipPathWrapper}>{path}</span>
               </td>
               <td>
                 {typeof value === 'number' ? formatNumber(value) : value}

--- a/webview/src/plots/components/ribbon/styles.module.scss
+++ b/webview/src/plots/components/ribbon/styles.module.scss
@@ -160,3 +160,12 @@
 .buttonWrapper {
   list-style: none;
 }
+
+.tooltipPathWrapper {
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  direction: rtl;
+  display: block;
+  white-space: nowrap;
+}


### PR DESCRIPTION
Saw this while reviewing. 

https://user-images.githubusercontent.com/3683420/228282398-0b347793-bce9-400e-bad0-f3bd217b03ab.mov

A max width of `300px` truncated after 41 characters, which is pretty close to the 45 characters previously set in Javascript.

