### PR TITLE
Move error formatting logic out to clients

### DIFF
--- a/extension/src/plots/model/index.ts
+++ b/extension/src/plots/model/index.ts
@@ -515,12 +515,12 @@ export class PlotsModel extends ModelWithPersistence {
 
     for (const revision of selectedRevisions) {
       const image = this.comparisonData?.[revision]?.[path]
-      const error = this.errors.getImageErrors(path, revision)
+      const errors = this.errors.getImageErrors(path, revision)
       const fetched = this.fetchedRevs.has(revision)
       const url = collectImageUrl(image, fetched)
       const loading = !fetched && !url
       pathRevisions.revisions[revision] = {
-        error,
+        errors,
         loading,
         revision,
         url

--- a/extension/src/plots/paths/collect.test.ts
+++ b/extension/src/plots/paths/collect.test.ts
@@ -3,6 +3,7 @@ import { VisualizationSpec } from 'react-vega'
 import isEqual from 'lodash.isequal'
 import {
   collectEncodingElements,
+  collectPathErrorsTable,
   collectPaths,
   collectTemplateOrder,
   EncodingType,
@@ -592,5 +593,34 @@ describe('collectEncodingElements', () => {
         value: Shape[1]
       }
     ])
+  })
+})
+
+describe('collectPathErrorsTable', () => {
+  it('should construct a markdown table with the error if they relate to the select revision and provided path', () => {
+    const rev = 'a-really-long-branch-name'
+    const path = 'wat'
+    const markdownTable = collectPathErrorsTable([
+      {
+        msg: `${path} not found.`,
+        rev: EXPERIMENT_WORKSPACE_ID
+      },
+      {
+        msg: 'catastrophic error',
+        rev
+      },
+      {
+        msg: 'UNEXPECTEDERRRRROR',
+        rev
+      }
+    ])
+    expect(markdownTable).toStrictEqual(
+      'Errors\n' +
+        '|||\n' +
+        '|--|--|\n' +
+        '| a-really... | UNEXPECTEDERRRRROR |\n' +
+        '| a-really... | catastrophic error |\n' +
+        '| workspace | wat not found. |'
+    )
   })
 })

--- a/extension/src/plots/paths/collect.ts
+++ b/extension/src/plots/paths/collect.ts
@@ -5,7 +5,12 @@ import {
   TemplatePlot,
   TemplatePlotGroup
 } from '../webview/contract'
-import { PlotError, PlotsData, PlotsOutput } from '../../cli/dvc/contract'
+import {
+  EXPERIMENT_WORKSPACE_ID,
+  PlotError,
+  PlotsData,
+  PlotsOutput
+} from '../../cli/dvc/contract'
 import { getParent, getPath, getPathArray } from '../../fileSystem/util'
 import { splitMatchedOrdered, definedAndNonEmpty } from '../../util/array'
 import { isMultiViewPlot } from '../vega/util'
@@ -18,6 +23,7 @@ import {
 } from '../multiSource/constants'
 import { MultiSourceEncoding } from '../multiSource/collect'
 import { CLIRevisionIdToLabel } from '../model/collect'
+import { truncate } from '../../util/string'
 
 export enum PathType {
   COMPARISON = 'comparison',
@@ -464,4 +470,29 @@ export const collectEncodingElements = (
   }
 
   return acc
+}
+
+const formatError = (acc: string[]): string | undefined => {
+  if (acc.length === 0) {
+    return
+  }
+
+  acc.sort()
+  acc.unshift('Errors\n|||\n|--|--|')
+
+  return acc.join('\n')
+}
+
+export const collectPathErrorsTable = (
+  errors: { rev: string; msg: string }[]
+): string | undefined => {
+  const acc = new Set<string>()
+  for (const error of errors) {
+    const { msg, rev } = error
+
+    const row = `| ${truncate(rev, EXPERIMENT_WORKSPACE_ID.length)} | ${msg} |`
+
+    acc.add(row)
+  }
+  return formatError([...acc])
 }

--- a/extension/src/plots/paths/model.ts
+++ b/extension/src/plots/paths/model.ts
@@ -1,5 +1,6 @@
 import { Memento } from 'vscode'
 import {
+  collectPathErrorsTable,
   collectPaths,
   collectTemplateOrder,
   PathType,
@@ -199,7 +200,13 @@ export class PathsModel extends PathSelectionModel<PlotPath> {
   }
 
   private getTooltip(path: string) {
-    const error = this.errors.getPathErrors(path, this.selectedRevisions)
+    const errors = this.errors.getPathErrors(path, this.selectedRevisions)
+
+    if (!errors?.length) {
+      return
+    }
+
+    const error = collectPathErrorsTable(errors)
     return error ? getErrorTooltip(error) : undefined
   }
 }

--- a/extension/src/plots/webview/contract.ts
+++ b/extension/src/plots/webview/contract.ts
@@ -173,7 +173,7 @@ export interface TemplatePlotsData {
 export type ComparisonPlot = {
   url: string | undefined
   revision: string
-  error: string | undefined
+  errors: string[] | undefined
   loading: boolean
 }
 

--- a/extension/src/test/fixtures/plotsDiff/index.ts
+++ b/extension/src/test/fixtures/plotsDiff/index.ts
@@ -705,7 +705,7 @@ export const getComparisonWebviewMessage = (
       revisionsAcc[revision] = {
         url: `${url}?${MOCK_IMAGE_MTIME}`,
         revision,
-        error: undefined,
+        errors: undefined,
         loading: false
       }
     }

--- a/webview/src/plots/components/App.test.tsx
+++ b/webview/src/plots/components/App.test.tsx
@@ -249,7 +249,7 @@ describe('App', () => {
             path: 'training/plots/images/misclassified.jpg',
             revisions: {
               ad2b5ec: {
-                error: undefined,
+                errors: undefined,
                 loading: true,
                 revision: 'ad2b5ec',
                 url: undefined

--- a/webview/src/plots/components/comparisonTable/ComparisonTable.test.tsx
+++ b/webview/src/plots/components/comparisonTable/ComparisonTable.test.tsx
@@ -273,7 +273,7 @@ describe('ComparisonTable', () => {
         revisions: {
           ...revisions,
           [revisionWithNoData]: {
-            error: undefined,
+            errors: undefined,
             loading: false,
             revision: revisionWithNoData,
             url: undefined
@@ -306,7 +306,7 @@ describe('ComparisonTable', () => {
         revisions: {
           ...revisions,
           [revisionWithNoData]: {
-            error: 'this is an error',
+            errors: ['this is an error'],
             loading: false,
             revision: revisionWithNoData,
             url: undefined

--- a/webview/src/plots/components/comparisonTable/ComparisonTableCell.tsx
+++ b/webview/src/plots/components/comparisonTable/ComparisonTableCell.tsx
@@ -13,9 +13,9 @@ type ComparisonTableCellProps = {
 
 const MissingPlotTableCell: React.FC<{ plot: ComparisonPlot }> = ({ plot }) => (
   <div className={styles.noImageContent}>
-    {plot.error ? (
+    {plot.errors?.length ? (
       <>
-        <ErrorTooltip error={plot.error}>
+        <ErrorTooltip error={plot.errors.join('\n')}>
           <div>
             <Error height={48} width={48} className={styles.errorIcon} />
           </div>

--- a/webview/src/stories/ComparisonTable.stories.tsx
+++ b/webview/src/stories/ComparisonTable.stories.tsx
@@ -83,9 +83,9 @@ const removeImages = (
       revision === EXPERIMENT_WORKSPACE_ID
     ) {
       filteredRevisionData[revision] = {
-        error:
+        errors:
           revision === 'main'
-            ? `FileNotFoundError: ${path} not found.`
+            ? [`FileNotFoundError: ${path} not found.`]
             : undefined,
         loading: false,
         revision,


### PR DESCRIPTION
# 2/2 `main` <- #3576 <- this

This PR is a follow-up to [this comment](https://github.com/iterative/vscode-dvc/pull/3520#discussion_r1144763776) from what feels like 3 years ago.

There should be no change to the user-facing behaviour.

### Demo


https://user-images.githubusercontent.com/37993418/228412061-9b9d291d-80b5-4dcc-b310-47bf7373c35f.mov

