### PR TITLE
Remove experiment checkpoints from tree

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1156,12 +1156,12 @@
         {
           "command": "dvc.views.experiments.applyExperiment",
           "group": "inline@1",
-          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(checkpoint|experiment)$/ && !dvc.experiment.running"
+          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem == experiment && !dvc.experiment.running"
         },
         {
           "command": "dvc.views.experiments.branchExperiment",
           "group": "inline@2",
-          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(checkpoint|experiment)$/ && !dvc.experiment.running"
+          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem == experiment && !dvc.experiment.running"
         },
         {
           "command": "dvc.views.experimentsTree.removeExperiment",
@@ -1176,12 +1176,12 @@
         {
           "command": "dvc.views.experiments.shareExperimentAsCommit",
           "group": "1_share@1",
-          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(checkpoint|experiment)$/ && !dvc.experiment.running"
+          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem == experiment && !dvc.experiment.running"
         },
         {
           "command": "dvc.views.experiments.shareExperimentAsBranch",
           "group": "1_share@2",
-          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(checkpoint|experiment)$/ && !dvc.experiment.running"
+          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem == experiment && !dvc.experiment.running"
         },
         {
           "command": "dvc.views.experiments.runExperiment",

--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -407,12 +407,7 @@ export class ExperimentsModel extends ModelWithPersistence {
   }
 
   public getExperimentCount() {
-    return sum([
-      this.getFlattenedCheckpoints().length,
-      this.getExperimentsAndQueued().length,
-      this.commits.length,
-      1
-    ])
+    return sum([this.getExperimentsAndQueued().length, this.commits.length, 1])
   }
 
   public getFilteredCounts(hasCheckpoints: boolean) {
@@ -432,7 +427,7 @@ export class ExperimentsModel extends ModelWithPersistence {
   public getExperimentsByCommitForTree(commit: Experiment) {
     return this.getExperimentsByCommit(commit)?.map(experiment => ({
       ...experiment,
-      hasChildren: definedAndNonEmpty(this.checkpointsByTip.get(experiment.id)),
+      hasChildren: false,
       type: isQueued(experiment.status)
         ? ExperimentType.QUEUED
         : ExperimentType.EXPERIMENT

--- a/extension/src/experiments/model/tree.test.ts
+++ b/extension/src/experiments/model/tree.test.ts
@@ -34,7 +34,6 @@ const mockedGetMarkdownString = jest.mocked(getMarkdownString)
 
 const {
   mockedExperiments,
-  mockedGetCheckpoints,
   mockedGetCommitExperiments,
   mockedGetDvcRoots,
   mockedGetFirstThreeColumnOrder,
@@ -133,7 +132,7 @@ describe('ExperimentsTree', () => {
       const experiments = [
         {
           displayColor: '#b180d7',
-          hasChildren: true,
+          hasChildren: false,
           id: 'exp-12345',
           label: '90aea7f',
           selected: true,
@@ -189,7 +188,7 @@ describe('ExperimentsTree', () => {
 
       expect(children).toStrictEqual([
         {
-          collapsibleState: 1,
+          collapsibleState: 0,
           command: {
             arguments: [{ dvcRoot: 'repo', id: 'exp-12345' }],
             command: RegisteredCommands.EXPERIMENT_TOGGLE,
@@ -267,78 +266,6 @@ describe('ExperimentsTree', () => {
       ])
     })
 
-    it('should return an array of checkpoint items when a non root element is provided', async () => {
-      mockedThemeIcon.mockImplementation(function (id) {
-        return { id }
-      })
-
-      const experimentsTree = new ExperimentsTree(
-        mockedExperiments,
-        mockedResourceLocator
-      )
-
-      const checkpoints = [
-        {
-          id: 'aaaaaaaaaaaaaaaaa',
-          label: 'aaaaaaa',
-          tooltip: undefined,
-          type: ExperimentType.CHECKPOINT
-        },
-        {
-          id: 'bbbbbbbbbbbbbbbbb',
-          label: 'bbbbbbb',
-          tooltip: undefined,
-          type: ExperimentType.CHECKPOINT
-        }
-      ]
-      mockedGetCheckpoints.mockReturnValueOnce(checkpoints)
-      mockedGetFirstThreeColumnOrder.mockReturnValue([])
-
-      const children = await experimentsTree.getChildren({
-        collapsibleState: 1,
-        description: undefined,
-        dvcRoot: 'repo',
-        iconPath: new ThemeIcon('loading~spin'),
-        id: 'ebbd66f',
-        label: 'ebbd66f',
-        tooltip: undefined,
-        type: ExperimentType.EXPERIMENT
-      })
-
-      expect(children).toStrictEqual([
-        {
-          collapsibleState: 0,
-          command: {
-            arguments: [{ dvcRoot: 'repo', id: 'aaaaaaaaaaaaaaaaa' }],
-            command: 'dvc.views.experiments.toggleStatus',
-            title: 'toggle'
-          },
-          description: undefined,
-          dvcRoot: 'repo',
-          iconPath: new ThemeIcon('circle-filled'),
-          id: 'aaaaaaaaaaaaaaaaa',
-          label: 'aaaaaaa',
-          tooltip: undefined,
-          type: ExperimentType.CHECKPOINT
-        },
-        {
-          collapsibleState: 0,
-          command: {
-            arguments: [{ dvcRoot: 'repo', id: 'bbbbbbbbbbbbbbbbb' }],
-            command: 'dvc.views.experiments.toggleStatus',
-            title: 'toggle'
-          },
-          description: undefined,
-          dvcRoot: 'repo',
-          iconPath: new ThemeIcon('circle-filled'),
-          id: 'bbbbbbbbbbbbbbbbb',
-          label: 'bbbbbbb',
-          tooltip: undefined,
-          type: ExperimentType.CHECKPOINT
-        }
-      ])
-    })
-
     it("should return the commit's experiments when the element is a commit", async () => {
       const experimentsTree = new ExperimentsTree(
         mockedExperiments,
@@ -404,7 +331,7 @@ describe('ExperimentsTree', () => {
             'data/data.xml': { changes: false, value: '22a1a29' }
           },
           displayColor: undefined,
-          hasChildren: true,
+          hasChildren: false,
           id: 'exp-123',
           label: 'a123',
           params: {
@@ -474,7 +401,7 @@ describe('ExperimentsTree', () => {
 
       expect(children).toStrictEqual([
         {
-          collapsibleState: 1,
+          collapsibleState: 0,
           command: {
             arguments: [{ dvcRoot: 'repo', id: 'exp-123' }],
             command: RegisteredCommands.EXPERIMENT_TOGGLE,
@@ -649,38 +576,6 @@ describe('ExperimentsTree', () => {
       expect(treeItem).toStrictEqual({
         ...mockedItem,
         iconPath: { id: 'loading~spin' }
-      })
-    })
-
-    it("should return a tree item for an experiment's checkpoint", () => {
-      let mockedItem = {}
-      mockedTreeItem.mockImplementationOnce(function (label, collapsibleState) {
-        expect(collapsibleState).toStrictEqual(0)
-        mockedItem = { collapsibleState, label }
-        return mockedItem
-      })
-      mockedThemeIcon.mockImplementationOnce(function (id) {
-        return { id }
-      })
-
-      const experimentsTree = new ExperimentsTree(
-        mockedExperiments,
-        mockedResourceLocator
-      )
-
-      const treeItem = experimentsTree.getTreeItem({
-        collapsibleState: 0,
-        description: undefined,
-        dvcRoot: 'demo',
-        iconPath: new ThemeIcon('circle-filled'),
-        id: 'f0778b3',
-        label: 'f0778b3',
-        tooltip: undefined,
-        type: ExperimentType.EXPERIMENT
-      })
-      expect(treeItem).toStrictEqual({
-        ...mockedItem,
-        iconPath: { id: 'circle-filled' }
       })
     })
 

--- a/extension/src/test/util/jest/index.ts
+++ b/extension/src/test/util/jest/index.ts
@@ -33,7 +33,6 @@ export const buildMockedExperiments = () => {
   const mockedGetChildColumns = jest.fn()
   const mockedGetDvcRoots = jest.fn()
   const mockedGetWorkspaceAndCommits = jest.fn()
-  const mockedGetCheckpoints = jest.fn()
   const mockedGetFilters = jest.fn()
   const mockedGetFilter = jest.fn()
   const mockedGetSorts = jest.fn()
@@ -46,7 +45,6 @@ export const buildMockedExperiments = () => {
     getDvcRoots: mockedGetDvcRoots,
     getRepository: () =>
       ({
-        getCheckpoints: mockedGetCheckpoints,
         getChildColumns: mockedGetChildColumns,
         getCommitExperiments: mockedGetCommitExperiments,
         getFilter: mockedGetFilter,
@@ -64,7 +62,6 @@ export const buildMockedExperiments = () => {
     mockedColumnsOrderOrStatusChanged,
     mockedExperiments,
     mockedExperimentsChanged,
-    mockedGetCheckpoints,
     mockedGetChildColumns,
     mockedGetCommitExperiments,
     mockedGetDvcRoots,


### PR DESCRIPTION
# 2/5 `main` <- #3585 <- this <- #3588 <- #3589 <- #3590

This PR removes checkpoints from the experiments tree.

### Screenshot

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/37993418/228717471-8ed7c6ca-e813-411c-843d-0e9645d1aa99.png">
