### PR TITLE
Remove experiment checkpoints from table context menu

### DIFF
--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -267,7 +267,7 @@ export class ExperimentsModel extends ModelWithPersistence {
     }
 
     const { availableColors, coloredStatus } = collectSelected(
-      selectedExperiments,
+      selectedExperiments.filter(({ status }) => !isQueued(status)),
       this.getCombinedList(),
       this.coloredStatus,
       this.availableColors

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -1219,11 +1219,9 @@ suite('Experiments Test Suite', () => {
 
       const webview = await experiments.showWebview()
       const mockMessageReceived = getMessageReceivedEmitter(webview)
-      const mockExperimentIds = [
-        'exp-e7a67',
-        'd1343a87c6ee4a2e82d19525964d2fb2cb6756c9',
-        'test-branch'
-      ]
+      const queuedId = '90aea7f2482117a55dfcadcdb901aaa6610fbbc9'
+      const expectedIds = ['exp-e7a67', 'test-branch']
+      const mockExperimentIds = [...expectedIds, queuedId]
 
       stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
@@ -1241,7 +1239,10 @@ suite('Experiments Test Suite', () => {
         .map(({ id }) => id)
         .sort()
       mockExperimentIds.sort()
-      expect(selectExperimentIds).to.deep.equal(mockExperimentIds)
+      expect(
+        selectExperimentIds,
+        'should exclude queued experiments from selection'
+      ).to.deep.equal(expectedIds)
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should be able to handle a message to compare experiments plots', async () => {


### PR DESCRIPTION
# 3/3 #3585 <- #3591 <- #3595 <- this 

This PR does some housekeeping in the experiment table context menu. We no longer need to cater to the condition of checkpoints existing so code can be simplified.

### Demo


https://user-images.githubusercontent.com/37993418/229024379-1936e7ed-c35f-4055-89a5-178e8197c0a3.mov


Note: I also caught and fixed a bug where queued experiments could be selected for plotting through the context menu 😞 