### PR TITLE
Move e2e tests to stable

### DIFF
--- a/extension/src/test/e2e/wdio.conf.ts
+++ b/extension/src/test/e2e/wdio.conf.ts
@@ -47,7 +47,7 @@ export const config: Options.Testrunner = {
   capabilities: [
     {
       browserName: 'vscode',
-      browserVersion: 'insiders',
+      browserVersion: 'stable',
       'wdio:vscodeOptions': {
         extensionPath,
         userSettings: {


### PR DESCRIPTION
E2e tests are failing again and moving to stable fixes the issue, but not sure why. [Details in slack thread](https://iterativeai.slack.com/archives/C01RB7BTG4C/p1680534627025879).