### PR TITLE
Remove checkpoints from plots

### DIFF
--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -419,10 +419,6 @@ export class Experiments extends BaseRepository<TableData> {
     return this.experiments.getWorkspaceAndCommits()
   }
 
-  public getCheckpoints(id: string) {
-    return this.experiments.getCheckpointsWithType(id)
-  }
-
   public getCommitExperiments(commit: Experiment) {
     return this.experiments.getExperimentsByCommitForTree(commit)
   }
@@ -441,6 +437,10 @@ export class Experiments extends BaseRepository<TableData> {
 
   public getCommitRevisions() {
     return this.experiments.getCommitRevisions()
+  }
+
+  public getExperimentRevisions() {
+    return this.experiments.getExperimentRevisions()
   }
 
   public getFinishedExperiments() {
@@ -591,7 +591,7 @@ export class Experiments extends BaseRepository<TableData> {
     }
 
     const experiment = await pickExperiment(
-      this.experiments.getAllRecords(),
+      this.experiments.getCombinedList(),
       this.getFirstThreeColumnOrder(),
       Title.SELECT_BASE_EXPERIMENT
     )

--- a/extension/src/experiments/model/index.test.ts
+++ b/extension/src/experiments/model/index.test.ts
@@ -33,11 +33,7 @@ beforeEach(() => {
 describe('ExperimentsModel', () => {
   const runningExperiment = 'exp-12345'
 
-  const buildTestExperiment = (
-    testParam: number,
-    checkpoint_tip?: string,
-    name?: string
-  ) => {
+  const buildTestExperiment = (testParam: number, name?: string) => {
     const data = {
       params: {
         'params.yaml': {
@@ -45,16 +41,12 @@ describe('ExperimentsModel', () => {
         }
       }
     } as {
-      checkpoint_tip?: string
       name?: string
       params: {
         'params.yaml': {
           data: { test: number }
         }
       }
-    }
-    if (checkpoint_tip) {
-      data.checkpoint_tip = checkpoint_tip
     }
     if (name) {
       data.name = name
@@ -201,7 +193,7 @@ describe('ExperimentsModel', () => {
       ''
     )
 
-    const experiments = model.getAllRecords()
+    const experiments = model.getCombinedList()
 
     const changed: string[] = []
     for (const { deps, sha } of experiments) {
@@ -241,13 +233,13 @@ describe('ExperimentsModel', () => {
     experimentsModel.transformAndSet(
       {
         testBranch: {
-          baseline: buildTestExperiment(2, undefined, 'testBranch'),
-          exp1: buildTestExperiment(0, 'tip'),
-          exp2: buildTestExperiment(0, 'tip'),
-          exp3: buildTestExperiment(0, 'tip'),
-          exp4: buildTestExperiment(0, 'tip'),
-          exp5: buildTestExperiment(0, 'tip'),
-          tip: buildTestExperiment(0, 'tip', runningExperiment)
+          baseline: buildTestExperiment(2, 'testBranch'),
+          exp1: buildTestExperiment(0),
+          exp2: buildTestExperiment(0),
+          exp3: buildTestExperiment(0),
+          exp4: buildTestExperiment(0),
+          exp5: buildTestExperiment(0),
+          tip: buildTestExperiment(0, runningExperiment)
         },
         [EXPERIMENT_WORKSPACE_ID]: {
           baseline: buildTestExperiment(3)

--- a/extension/src/plots/paths/collect.test.ts
+++ b/extension/src/plots/paths/collect.test.ts
@@ -14,17 +14,21 @@ import plotsDiffFixture from '../../test/fixtures/plotsDiff/output'
 import { Shape, StrokeDash } from '../multiSource/constants'
 import { EXPERIMENT_WORKSPACE_ID } from '../../cli/dvc/contract'
 import { CLIRevisionIdToLabel } from '../model/collect'
+import { getCLIIdToLabel } from '../../test/fixtures/plotsDiff/util'
+import { REVISIONS } from '../../test/fixtures/plotsDiff'
 
 describe('collectPaths', () => {
   const revisions = [
     EXPERIMENT_WORKSPACE_ID,
-    '53c3851',
+    'main',
     '4fb124a',
     '42b8736',
     '1ba7bcd'
   ]
   it('should return the expected data from the test fixture', () => {
-    expect(collectPaths([], plotsDiffFixture, revisions, {})).toStrictEqual([
+    expect(
+      collectPaths([], plotsDiffFixture, REVISIONS, getCLIIdToLabel())
+    ).toStrictEqual([
       {
         hasChildren: false,
         parentPath: 'plots',

--- a/extension/src/plots/paths/model.test.ts
+++ b/extension/src/plots/paths/model.test.ts
@@ -6,6 +6,8 @@ import { buildMockMemento } from '../../test/util'
 import { PlotsType, TemplatePlotGroup } from '../webview/contract'
 import { EXPERIMENT_WORKSPACE_ID } from '../../cli/dvc/contract'
 import { ErrorsModel } from '../errors/model'
+import { getCLIIdToLabel } from '../../test/fixtures/plotsDiff/util'
+import { REVISIONS } from '../../test/fixtures/plotsDiff'
 
 describe('PathsModel', () => {
   const mockDvcRoot = 'test'
@@ -13,13 +15,6 @@ describe('PathsModel', () => {
   const logsAcc = join('logs', 'acc.tsv')
   const logsLoss = join('logs', 'loss.tsv')
   const plotsAcc = join('plots', 'acc.png')
-  const revisions = [
-    EXPERIMENT_WORKSPACE_ID,
-    '53c3851',
-    '4fb124a',
-    '42b8736',
-    '1ba7bcd'
-  ]
 
   const buildMockErrorsModel = () =>
     ({
@@ -38,14 +33,14 @@ describe('PathsModel', () => {
       buildMockErrorsModel(),
       buildMockMemento()
     )
-    model.transformAndSet(plotsDiffFixture, revisions, {})
-    model.setSelectedRevisions(revisions)
+    model.transformAndSet(plotsDiffFixture, REVISIONS, getCLIIdToLabel())
+    model.setSelectedRevisions(REVISIONS)
     expect(model.getTerminalNodes()).toStrictEqual([
       {
         hasChildren: false,
         parentPath: 'plots',
         path: plotsAcc,
-        revisions: new Set(revisions),
+        revisions: new Set(REVISIONS),
         selected: true,
         type: comparisonType
       },
@@ -53,7 +48,7 @@ describe('PathsModel', () => {
         hasChildren: false,
         parentPath: 'plots',
         path: join('plots', 'heatmap.png'),
-        revisions: new Set(revisions),
+        revisions: new Set(REVISIONS),
         selected: true,
         type: comparisonType
       },
@@ -61,7 +56,7 @@ describe('PathsModel', () => {
         hasChildren: false,
         parentPath: 'plots',
         path: join('plots', 'loss.png'),
-        revisions: new Set(revisions),
+        revisions: new Set(REVISIONS),
         selected: true,
         type: comparisonType
       },
@@ -69,7 +64,7 @@ describe('PathsModel', () => {
         hasChildren: false,
         parentPath: 'logs',
         path: logsLoss,
-        revisions: new Set(revisions),
+        revisions: new Set(REVISIONS),
         selected: true,
         type: singleType
       },
@@ -77,7 +72,7 @@ describe('PathsModel', () => {
         hasChildren: false,
         parentPath: 'logs',
         path: logsAcc,
-        revisions: new Set(revisions),
+        revisions: new Set(REVISIONS),
         selected: true,
         type: singleType
       },
@@ -85,7 +80,7 @@ describe('PathsModel', () => {
         hasChildren: false,
         parentPath: undefined,
         path: 'predictions.json',
-        revisions: new Set(revisions),
+        revisions: new Set(REVISIONS),
         selected: true,
         type: multiType
       }
@@ -149,7 +144,7 @@ describe('PathsModel', () => {
       buildMockErrorsModel(),
       buildMockMemento()
     )
-    model.transformAndSet(plotsDiffFixture, revisions, {})
+    model.transformAndSet(plotsDiffFixture, REVISIONS, {})
     model.setSelectedRevisions([EXPERIMENT_WORKSPACE_ID])
 
     expect(model.getTemplateOrder()).toStrictEqual(originalTemplateOrder)
@@ -171,7 +166,7 @@ describe('PathsModel', () => {
       buildMockErrorsModel(),
       buildMockMemento()
     )
-    model.transformAndSet(plotsDiffFixture, revisions, {})
+    model.transformAndSet(plotsDiffFixture, REVISIONS, {})
     model.setSelectedRevisions([EXPERIMENT_WORKSPACE_ID])
 
     expect(model.getTemplateOrder()).toStrictEqual(originalTemplateOrder)
@@ -201,7 +196,7 @@ describe('PathsModel', () => {
       buildMockErrorsModel(),
       buildMockMemento()
     )
-    model.transformAndSet(plotsDiffFixture, revisions, {})
+    model.transformAndSet(plotsDiffFixture, REVISIONS, {})
     model.setSelectedRevisions([EXPERIMENT_WORKSPACE_ID])
 
     expect(model.getTemplateOrder()).toStrictEqual(originalTemplateOrder)
@@ -236,7 +231,7 @@ describe('PathsModel', () => {
 
     model.transformAndSet(
       { data: { ...plotsDiffFixture.data, ...previousPlotFixture.data } },
-      [...revisions, commitBeforePlots],
+      [...REVISIONS, commitBeforePlots],
       {}
     )
 
@@ -278,7 +273,7 @@ describe('PathsModel', () => {
     )
     model.transformAndSet(
       { data: { ...plotsDiffFixture.data, ...previousPlotFixture.data } },
-      [...revisions, commitBeforePlots],
+      [...REVISIONS, commitBeforePlots],
       {}
     )
     model.setSelectedRevisions([EXPERIMENT_WORKSPACE_ID])
@@ -306,7 +301,7 @@ describe('PathsModel', () => {
       buildMockMemento()
     )
 
-    model.transformAndSet(plotsDiffFixture, revisions, {})
+    model.transformAndSet(plotsDiffFixture, REVISIONS, {})
     model.setSelectedRevisions([EXPERIMENT_WORKSPACE_ID])
 
     expect(model.getTemplateOrder()).toStrictEqual(originalTemplateOrder)
@@ -326,7 +321,7 @@ describe('PathsModel', () => {
       buildMockErrorsModel(),
       buildMockMemento()
     )
-    model.transformAndSet(plotsDiffFixture, revisions, {})
+    model.transformAndSet(plotsDiffFixture, REVISIONS, {})
     model.setSelectedRevisions([EXPERIMENT_WORKSPACE_ID])
 
     model.setTemplateOrder([logsLossGroup, logsAccGroup, multiViewGroup])
@@ -342,7 +337,7 @@ describe('PathsModel', () => {
       buildMockErrorsModel(),
       buildMockMemento()
     )
-    model.transformAndSet(plotsDiffFixture, revisions, {})
+    model.transformAndSet(plotsDiffFixture, REVISIONS, {})
     model.setSelectedRevisions([EXPERIMENT_WORKSPACE_ID])
 
     expect(model.getComparisonPaths()).toStrictEqual([
@@ -368,7 +363,7 @@ describe('PathsModel', () => {
       buildMockErrorsModel(),
       buildMockMemento()
     )
-    model.transformAndSet(plotsDiffFixture, revisions, {})
+    model.transformAndSet(plotsDiffFixture, REVISIONS, getCLIIdToLabel())
     model.setSelectedRevisions([EXPERIMENT_WORKSPACE_ID])
 
     const rootChildren = model.getChildren(undefined, {
@@ -383,7 +378,7 @@ describe('PathsModel', () => {
         hasChildren: true,
         parentPath: undefined,
         path: 'logs',
-        revisions: new Set(revisions),
+        revisions: new Set(REVISIONS),
         status: 2,
         tooltip: undefined
       },
@@ -392,7 +387,7 @@ describe('PathsModel', () => {
         hasChildren: true,
         parentPath: undefined,
         path: 'plots',
-        revisions: new Set(revisions),
+        revisions: new Set(REVISIONS),
         status: 2,
         tooltip: undefined
       },
@@ -401,7 +396,7 @@ describe('PathsModel', () => {
         hasChildren: false,
         parentPath: undefined,
         path: 'predictions.json',
-        revisions: new Set(revisions),
+        revisions: new Set(REVISIONS),
         status: 2,
         tooltip: undefined,
         type: new Set([PathType.TEMPLATE_MULTI])
@@ -415,7 +410,7 @@ describe('PathsModel', () => {
         hasChildren: false,
         parentPath: 'logs',
         path: logsAcc,
-        revisions: new Set(revisions),
+        revisions: new Set(REVISIONS),
         status: 2,
         tooltip: undefined,
         type: new Set([PathType.TEMPLATE_SINGLE])
@@ -425,7 +420,7 @@ describe('PathsModel', () => {
         hasChildren: false,
         parentPath: 'logs',
         path: logsLoss,
-        revisions: new Set(revisions),
+        revisions: new Set(REVISIONS),
         status: 2,
         tooltip: undefined,
         type: new Set([PathType.TEMPLATE_SINGLE])
@@ -446,7 +441,7 @@ describe('PathsModel', () => {
         hasChildren: true,
         parentPath: 'logs',
         path: logsAcc,
-        revisions: new Set(revisions),
+        revisions: new Set(REVISIONS),
         status: 2,
         tooltip: undefined,
         type: new Set([PathType.TEMPLATE_SINGLE])
@@ -456,7 +451,7 @@ describe('PathsModel', () => {
         hasChildren: true,
         parentPath: 'logs',
         path: logsLoss,
-        revisions: new Set(revisions),
+        revisions: new Set(REVISIONS),
         status: 2,
         tooltip: undefined,
         type: new Set([PathType.TEMPLATE_SINGLE])

--- a/extension/src/plots/webview/messages.ts
+++ b/extension/src/plots/webview/messages.ts
@@ -4,9 +4,9 @@ import {
   ComparisonRevisionData,
   PlotHeight,
   PlotsData as TPlotsData,
-  Revision,
   PlotsSection,
-  SectionCollapsed
+  SectionCollapsed,
+  Revision
 } from './contract'
 import { Logger } from '../../common/logger'
 import { Experiments } from '../../experiments'
@@ -58,20 +58,16 @@ export class WebviewMessages {
   }
 
   public sendWebviewMessage() {
-    const { overrideComparison, overrideRevisions } =
-      this.plots.getOverrideRevisionDetails()
-
-    const comparison = this.getComparisonPlots(overrideComparison)
-
+    const selectedRevisions = this.plots.getSelectedRevisionDetails()
     void this.getWebview()?.show({
       cliError: this.errors.getCliError()?.error || null,
-      comparison,
+      comparison: this.getComparisonPlots(),
       custom: this.getCustomPlots(),
       hasPlots: !!this.paths.hasPaths(),
       hasUnselectedPlots: this.paths.getHasUnselectedPlots(),
       sectionCollapsed: this.plots.getSectionCollapsed(),
-      selectedRevisions: overrideRevisions,
-      template: this.getTemplatePlots(overrideRevisions)
+      selectedRevisions,
+      template: this.getTemplatePlots(selectedRevisions)
     })
   }
 
@@ -295,8 +291,9 @@ export class WebviewMessages {
   }
 
   private sendTemplatePlots() {
+    const selectedRevisions = this.plots.getSelectedRevisionDetails()
     void this.getWebview()?.show({
-      template: this.getTemplatePlots()
+      template: this.getTemplatePlots(selectedRevisions)
     })
   }
 
@@ -306,9 +303,9 @@ export class WebviewMessages {
     })
   }
 
-  private getTemplatePlots(overrideRevs?: Revision[]) {
+  private getTemplatePlots(selectedRevisions: Revision[]) {
     const paths = this.paths.getTemplateOrder()
-    const plots = this.plots.getTemplatePlots(paths, overrideRevs)
+    const plots = this.plots.getTemplatePlots(paths, selectedRevisions)
 
     if (!plots || isEmpty(plots)) {
       return null
@@ -323,12 +320,9 @@ export class WebviewMessages {
     }
   }
 
-  private getComparisonPlots(overrideRevs?: Revision[]) {
+  private getComparisonPlots() {
     const paths = this.paths.getComparisonPaths()
-    const comparison = this.plots.getComparisonPlots(
-      paths,
-      overrideRevs?.map(({ revision }) => revision)
-    )
+    const comparison = this.plots.getComparisonPlots(paths)
     if (!comparison || isEmpty(comparison)) {
       return null
     }
@@ -338,7 +332,7 @@ export class WebviewMessages {
       plots: comparison.map(({ path, revisions }) => {
         return { path, revisions: this.getRevisionsWithCorrectUrls(revisions) }
       }),
-      revisions: overrideRevs || this.plots.getComparisonRevisions(),
+      revisions: this.plots.getComparisonRevisions(),
       width: this.plots.getNbItemsPerRowOrWidth(PlotsSection.COMPARISON_TABLE)
     }
   }

--- a/extension/src/test/fixtures/plotsDiff/index.ts
+++ b/extension/src/test/fixtures/plotsDiff/index.ts
@@ -30,9 +30,9 @@ const basicVega = {
       revisions: [
         EXPERIMENT_WORKSPACE_ID,
         '53c3851',
-        '42b8736',
-        '1ba7bcd',
-        '4fb124a'
+        'test-branch',
+        'exp-83425',
+        'exp-e7a67'
       ],
       datapoints: {
         [EXPERIMENT_WORKSPACE_ID]: [
@@ -129,7 +129,7 @@ const basicVega = {
             timestamp: '1641966351758'
           }
         ],
-        '42b8736': [
+        'test-branch': [
           {
             loss: '1.6454246044158936',
             step: '0',
@@ -176,7 +176,7 @@ const basicVega = {
             timestamp: '1642041912764'
           }
         ],
-        '1ba7bcd': [
+        'exp-83425': [
           {
             loss: '2.273470401763916',
             step: '0',
@@ -224,7 +224,7 @@ const basicVega = {
             timestamp: '1642041648829'
           }
         ],
-        '4fb124a': [
+        'exp-e7a67': [
           {
             loss: '2.0380799770355225',
             step: '0',
@@ -380,17 +380,17 @@ const getImageData = (baseUrl: string, joinFunc = join) => ({
     },
     {
       type: PlotsType.IMAGE,
-      revisions: ['4fb124a'],
+      revisions: ['exp-e7a67'],
       url: joinFunc(baseUrl, '4fb124a_plots_acc.png')
     },
     {
       type: PlotsType.IMAGE,
-      revisions: ['42b8736'],
+      revisions: ['test-branch'],
       url: joinFunc(baseUrl, '42b8736_plots_acc.png')
     },
     {
       type: PlotsType.IMAGE,
-      revisions: ['1ba7bcd'],
+      revisions: ['exp-83425'],
       url: joinFunc(baseUrl, '1ba7bcd_plots_acc.png')
     }
   ],
@@ -407,17 +407,17 @@ const getImageData = (baseUrl: string, joinFunc = join) => ({
     },
     {
       type: PlotsType.IMAGE,
-      revisions: ['4fb124a'],
+      revisions: ['exp-e7a67'],
       url: joinFunc(baseUrl, '4fb124a_plots_heatmap.png')
     },
     {
       type: PlotsType.IMAGE,
-      revisions: ['42b8736'],
+      revisions: ['test-branch'],
       url: joinFunc(baseUrl, '42b8736_plots_heatmap.png')
     },
     {
       type: PlotsType.IMAGE,
-      revisions: ['1ba7bcd'],
+      revisions: ['exp-83425'],
       url: joinFunc(baseUrl, '1ba7bcd_plots_heatmap.png')
     }
   ],
@@ -434,17 +434,17 @@ const getImageData = (baseUrl: string, joinFunc = join) => ({
     },
     {
       type: PlotsType.IMAGE,
-      revisions: ['4fb124a'],
+      revisions: ['exp-e7a67'],
       url: joinFunc(baseUrl, '4fb124a_plots_loss.png')
     },
     {
       type: PlotsType.IMAGE,
-      revisions: ['42b8736'],
+      revisions: ['test-branch'],
       url: joinFunc(baseUrl, '42b8736_plots_loss.png')
     },
     {
       type: PlotsType.IMAGE,
-      revisions: ['1ba7bcd'],
+      revisions: ['exp-83425'],
       url: joinFunc(baseUrl, '1ba7bcd_plots_loss.png')
     }
   ]
@@ -464,7 +464,7 @@ export const getMultiSourceOutput = (): PlotsOutput => ({
   ...require('./multiSource').default
 })
 
-const expectedRevisions = [
+export const REVISIONS = [
   EXPERIMENT_WORKSPACE_ID,
   'main',
   '4fb124a',
@@ -490,7 +490,7 @@ const extendedSpecs = (plotsOutput: TemplatePlots): TemplatePlotSection[] => {
             ...originalPlot.content,
             data: {
               values:
-                expectedRevisions.flatMap(revision =>
+                REVISIONS.flatMap(revision =>
                   originalPlot.datapoints?.[getCLICommitId(revision)].map(
                     values => ({
                       ...values,
@@ -504,14 +504,14 @@ const extendedSpecs = (plotsOutput: TemplatePlots): TemplatePlotSection[] => {
           DEFAULT_PLOT_HEIGHT,
           {
             color: {
-              domain: expectedRevisions,
+              domain: REVISIONS,
               range: copyOriginalColors().slice(0, 5)
             }
           }
         ) as VisualizationSpec,
         id: path,
         multiView: isMultiViewPlot(originalPlot.content as TopLevelSpec),
-        revisions: expectedRevisions,
+        revisions: REVISIONS,
         type: PlotsType.VEGA
       }
       if (plot.multiView) {
@@ -535,7 +535,7 @@ export const findAndFormatCreated = (revisionId: string): string =>
   )
 
 export const getRevisions = (): Revision[] => {
-  const [workspace, main, _4fb124a, _42b8735, _1ba7bcd] = copyOriginalColors()
+  const [workspace, main, _4fb124a, _42b8736, _1ba7bcd] = copyOriginalColors()
   return [
     {
       id: EXPERIMENT_WORKSPACE_ID,
@@ -634,7 +634,7 @@ export const getRevisions = (): Revision[] => {
       ],
       id: 'test-branch',
       revision: '42b8736',
-      displayColor: _42b8735,
+      displayColor: _42b8736,
       group: '[test-branch]'
     },
     {

--- a/extension/src/test/fixtures/plotsDiff/util.ts
+++ b/extension/src/test/fixtures/plotsDiff/util.ts
@@ -1,13 +1,26 @@
+import { EXPERIMENT_WORKSPACE_ID } from '../../../cli/dvc/contract'
+
+export const getCLIIdToLabel = (): { [rev: string]: string } => ({
+  [EXPERIMENT_WORKSPACE_ID]: EXPERIMENT_WORKSPACE_ID,
+  '53c3851': 'main',
+  'exp-e7a67': '4fb124a',
+  'test-branch': '42b8736',
+  'exp-83425': '1ba7bcd'
+})
+
 export const replaceCommitCLIId = (revision: string): string => {
-  if (revision === '53c3851') {
-    return 'main'
-  }
-  return revision
+  const mapping = getCLIIdToLabel()
+
+  return mapping[revision] || revision
 }
 
 export const getCLICommitId = (revision: string): string => {
-  if (revision === 'main') {
-    return '53c3851'
+  const mapping: { [rev: string]: string } = {
+    main: '53c3851',
+    '4fb124a': 'exp-e7a67',
+    '42b8736': 'test-branch',
+    '1ba7bcd': 'exp-83425'
   }
-  return revision
+
+  return mapping[revision] || revision
 }

--- a/extension/src/test/fixtures/plotsDiff/vega.ts
+++ b/extension/src/test/fixtures/plotsDiff/vega.ts
@@ -9,9 +9,9 @@ const data = {
       revisions: [
         EXPERIMENT_WORKSPACE_ID,
         '53c3851',
-        '42b8736',
-        '1ba7bcd',
-        '4fb124a'
+        'test-branch',
+        'exp-83425',
+        'exp-e7a67'
       ],
       datapoints: {
         workspace: [
@@ -108,7 +108,7 @@ const data = {
             timestamp: '1641966351759'
           }
         ],
-        '42b8736': [
+        'test-branch': [
           {
             acc: '0.5613',
             step: '0',
@@ -155,7 +155,7 @@ const data = {
             timestamp: '1642041912765'
           }
         ],
-        '1ba7bcd': [
+        'exp-83425': [
           {
             acc: '0.1694',
             step: '0',
@@ -202,7 +202,7 @@ const data = {
             timestamp: '1642041648863'
           }
         ],
-        '4fb124a': [
+        'exp-e7a67': [
           {
             acc: '0.5394',
             step: '0',
@@ -333,9 +333,9 @@ const data = {
       revisions: [
         EXPERIMENT_WORKSPACE_ID,
         '53c3851',
-        '42b8736',
-        '1ba7bcd',
-        '4fb124a'
+        'test-branch',
+        'exp-83425',
+        'exp-e7a67'
       ],
       datapoints: {
         workspace: [
@@ -20342,7 +20342,7 @@ const data = {
           { actual: 5, predicted: 0 },
           { actual: 6, predicted: 0 }
         ],
-        '42b8736': [
+        'test-branch': [
           { actual: 7, predicted: 7 },
           { actual: 2, predicted: 2 },
           { actual: 1, predicted: 1 },
@@ -30344,7 +30344,7 @@ const data = {
           { actual: 5, predicted: 8 },
           { actual: 6, predicted: 6 }
         ],
-        '1ba7bcd': [
+        'exp-83425': [
           { actual: 7, predicted: 7 },
           { actual: 2, predicted: 2 },
           { actual: 1, predicted: 1 },
@@ -40346,7 +40346,7 @@ const data = {
           { actual: 5, predicted: 5 },
           { actual: 6, predicted: 6 }
         ],
-        '4fb124a': [
+        'exp-e7a67': [
           { actual: 7, predicted: 7 },
           { actual: 2, predicted: 2 },
           { actual: 1, predicted: 1 },

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -64,7 +64,6 @@ import * as VscodeContext from '../../../vscode/context'
 import { Title } from '../../../vscode/title'
 import { EXP_RWLOCK_FILE, ExperimentFlag } from '../../../cli/dvc/constants'
 import { DvcExecutor } from '../../../cli/dvc/executor'
-import { shortenForLabel } from '../../../util/string'
 import { GitExecutor } from '../../../cli/git/executor'
 import { WorkspacePlots } from '../../../plots/workspace'
 import {
@@ -688,8 +687,7 @@ suite('Experiments Test Suite', () => {
       const { experiments } = buildExperiments(disposable)
       await experiments.isReady()
 
-      const testCheckpointId = 'd1343a87c6ee4a2e82d19525964d2fb2cb6756c9'
-      const testCheckpointLabel = shortenForLabel(testCheckpointId)
+      const mockExperiment = 'exp-e7a67'
       const mockBranch = 'it-is-a-branch-shared-to-the-remote'
       const inputEvent = getInputBoxEvent(mockBranch)
 
@@ -697,7 +695,7 @@ suite('Experiments Test Suite', () => {
         DvcExecutor.prototype,
         'experimentBranch'
       ).resolves(
-        `Git branch '${mockBranch}' has been created from experiment '${testCheckpointId}'.        
+        `Git branch '${mockBranch}' has been created from experiment '${mockExperiment}'.        
        To switch to the new branch run:
              git checkout ${mockBranch}`
       )
@@ -705,7 +703,7 @@ suite('Experiments Test Suite', () => {
         DvcExecutor.prototype,
         'experimentApply'
       ).resolves(
-        `Changes for experiment '${testCheckpointId}' have been applied to your current workspace.`
+        `Changes for experiment '${mockExperiment}' have been applied to your current workspace.`
       )
       const mockPush = stub(DvcExecutor.prototype, 'push').resolves(
         '10 files updated.'
@@ -724,7 +722,7 @@ suite('Experiments Test Suite', () => {
       const mockMessageReceived = getMessageReceivedEmitter(webview)
 
       mockMessageReceived.fire({
-        payload: testCheckpointId,
+        payload: mockExperiment,
         type: MessageFromWebviewType.SHARE_EXPERIMENT_AS_BRANCH
       })
 
@@ -732,12 +730,12 @@ suite('Experiments Test Suite', () => {
       await branchPushedToRemote
       expect(mockExperimentBranch).to.be.calledWithExactly(
         dvcDemoPath,
-        testCheckpointLabel,
+        mockExperiment,
         mockBranch
       )
       expect(mockExperimentApply).to.be.calledWithExactly(
         dvcDemoPath,
-        testCheckpointLabel
+        mockExperiment
       )
       expect(mockPush).to.be.calledWithExactly(dvcDemoPath)
       expect(mockGitPush).to.be.calledWithExactly(dvcDemoPath, mockBranch)
@@ -747,8 +745,7 @@ suite('Experiments Test Suite', () => {
       const { experiments } = buildExperiments(disposable)
       await experiments.isReady()
 
-      const testCheckpointId = 'd1343a87c6ee4a2e82d19525964d2fb2cb6756c9'
-      const testCheckpointLabel = shortenForLabel(testCheckpointId)
+      const mockExperiment = 'exp-e7a67'
       const mockCommitMessage =
         'this is the very best version that I could come up with'
       const inputEvent = getInputBoxEvent(mockCommitMessage)
@@ -757,7 +754,7 @@ suite('Experiments Test Suite', () => {
         DvcExecutor.prototype,
         'experimentApply'
       ).resolves(
-        `Changes for experiment '${testCheckpointId}' have been applied to your current workspace.`
+        `Changes for experiment '${mockExperiment}' have been applied to your current workspace.`
       )
       const mockStageAndCommit = stub(
         GitExecutor.prototype,
@@ -781,7 +778,7 @@ suite('Experiments Test Suite', () => {
       const mockMessageReceived = getMessageReceivedEmitter(webview)
 
       mockMessageReceived.fire({
-        payload: testCheckpointId,
+        payload: mockExperiment,
         type: MessageFromWebviewType.SHARE_EXPERIMENT_AS_COMMIT
       })
 
@@ -793,7 +790,7 @@ suite('Experiments Test Suite', () => {
       )
       expect(mockExperimentApply).to.be.calledWithExactly(
         dvcDemoPath,
-        testCheckpointLabel
+        mockExperiment
       )
       expect(mockPush).to.be.calledWithExactly(dvcDemoPath)
       expect(mockGitPush).to.be.calledWithExactly(dvcDemoPath)
@@ -945,7 +942,7 @@ suite('Experiments Test Suite', () => {
       const queuedExperiment = '90aea7f2482117a55dfcadcdb901aaa6610fbbc9'
 
       const isExperimentSelected = (expId: string): boolean =>
-        !!experimentsModel.getAllRecords().find(({ id }) => id === expId)
+        !!experimentsModel.getCombinedList().find(({ id }) => id === expId)
           ?.selected
 
       expect(isExperimentSelected(experimentToToggle), 'experiment is selected')
@@ -1141,7 +1138,7 @@ suite('Experiments Test Suite', () => {
       const areExperimentsStarred = (expIds: string[]): boolean =>
         expIds
           .map(expId =>
-            experimentsModel.getAllRecords().find(({ id }) => id === expId)
+            experimentsModel.getCombinedList().find(({ id }) => id === expId)
           )
           .every(exp => exp?.starred)
 
@@ -1240,11 +1237,7 @@ suite('Experiments Test Suite', () => {
 
       const webview = await experiments.showWebview()
       const mockMessageReceived = getMessageReceivedEmitter(webview)
-      const mockExperimentIds = [
-        'exp-e7a67',
-        'd1343a87c6ee4a2e82d19525964d2fb2cb6756c9',
-        'test-branch'
-      ]
+      const mockExperimentIds = ['exp-e7a67', 'test-branch']
 
       stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 

--- a/extension/src/test/suite/experiments/model/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/tree.test.ts
@@ -351,11 +351,6 @@ suite('Experiments Tree Test Suite', () => {
         },
         {
           dvcRoot: dvcDemoPath,
-          id: 'checkpoint-excluded',
-          type: ExperimentType.CHECKPOINT
-        },
-        {
-          dvcRoot: dvcDemoPath,
           id: 'workspace-excluded',
           type: ExperimentType.WORKSPACE
         }
@@ -382,7 +377,7 @@ suite('Experiments Tree Test Suite', () => {
 
       await experiments.isReady()
 
-      const mockExperiment = 'd1343a87c6ee4a2e82d19525964d2fb2cb6756c9'
+      const mockExperiment = 'exp-e7a67'
 
       const mockExperimentApply = stub(
         DvcExecutor.prototype,
@@ -402,7 +397,7 @@ suite('Experiments Tree Test Suite', () => {
 
       expect(mockExperimentApply).to.be.calledWithExactly(
         dvcDemoPath,
-        mockExperiment.slice(0, 7)
+        mockExperiment
       )
     })
 
@@ -421,7 +416,7 @@ suite('Experiments Tree Test Suite', () => {
         RegisteredCliCommands.EXPERIMENT_VIEW_BRANCH,
         {
           dvcRoot: dvcDemoPath,
-          id: 'd1343a87c6ee4a2e82d19525964d2fb2cb6756c9'
+          id: 'exp-e7a67'
         }
       )
 
@@ -433,7 +428,7 @@ suite('Experiments Tree Test Suite', () => {
       const { experiments } = buildExperiments(disposable)
       await experiments.isReady()
 
-      const mockExperiment = 'e821416'
+      const mockExperiment = 'exp-e7a67'
       const mockBranch = 'it-is-a-branch'
 
       const mockExperimentBranch = stub(
@@ -451,7 +446,7 @@ suite('Experiments Tree Test Suite', () => {
         RegisteredCliCommands.EXPERIMENT_VIEW_BRANCH,
         {
           dvcRoot: dvcDemoPath,
-          id: 'e821416bfafb4bc28b3e0a8ddb322505b0ad2361'
+          id: mockExperiment
         }
       )
 

--- a/extension/src/test/suite/plots/data/index.test.ts
+++ b/extension/src/test/suite/plots/data/index.test.ts
@@ -86,26 +86,6 @@ suite('Plots Data Test Suite', () => {
       expect(mockPlotsDiff).to.be.calledWithExactly(dvcDemoPath, 'a7739b5')
     })
 
-    it('should call plots diff when an experiment is running and there are missing revisions (checkpoints)', async () => {
-      const { data, mockPlotsDiff } = buildPlotsData([
-        '53c3851',
-        '4fb124a',
-        '42b8736',
-        '1ba7bcd'
-      ])
-
-      await data.update()
-
-      expect(mockPlotsDiff).to.be.calledOnce
-      expect(mockPlotsDiff).to.be.calledWithExactly(
-        dvcDemoPath,
-        '53c3851',
-        '4fb124a',
-        '42b8736',
-        '1ba7bcd'
-      )
-    })
-
     it('should collect files and watch them for updates', async () => {
       const mockNow = getMockNow()
       const parentDirectory = 'training'

--- a/extension/src/test/suite/plots/index.test.ts
+++ b/extension/src/test/suite/plots/index.test.ts
@@ -77,9 +77,9 @@ suite('Plots Test Suite', () => {
       expect(mockPlotsDiff).to.be.calledWithExactly(
         dvcDemoPath,
         EXPERIMENT_WORKSPACE_ID,
-        '4fb124a',
-        '42b8736',
-        '1ba7bcd',
+        'exp-e7a67',
+        'test-branch',
+        'exp-83425',
         '53c3851'
       )
       mockPlotsDiff.resetHistory()
@@ -141,10 +141,10 @@ suite('Plots Test Suite', () => {
       expect(mockPlotsDiff).to.be.calledWithExactly(
         dvcDemoPath,
         EXPERIMENT_WORKSPACE_ID,
-        'experim',
-        '4fb124a',
-        '42b8736',
-        '1ba7bcd',
+        'exp-e1new',
+        'exp-e7a67',
+        'test-branch',
+        'exp-83425',
         '53c3851'
       )
     })
@@ -637,9 +637,9 @@ suite('Plots Test Suite', () => {
       expect(mockPlotsDiff).to.be.calledWithExactly(
         dvcDemoPath,
         EXPERIMENT_WORKSPACE_ID,
-        '4fb124a',
-        '42b8736',
-        '1ba7bcd',
+        'exp-e7a67',
+        'test-branch',
+        'exp-83425',
         '53c3851'
       )
       expect(
@@ -701,21 +701,22 @@ suite('Plots Test Suite', () => {
         }
       }
 
+      const brokenExp = 'exp-e7a67'
       const brokenRev = '4fb124a'
 
       const reFetchedOutput = {
         data: {
           [accPngPath]: accPng.filter(
-            ({ revisions }) => !isEqual(revisions, [brokenRev])
+            ({ revisions }) => !isEqual(revisions, [brokenExp])
           ),
           [lossTsvPath]: lossTsv.map((plot, i) => {
             const datapoints = { ...lossTsv[i].datapoints }
-            delete datapoints[brokenRev]
+            delete datapoints[brokenExp]
 
             return {
               ...plot,
               datapoints,
-              revisions: lossTsv[i].revisions?.filter(rev => rev !== brokenRev)
+              revisions: lossTsv[i].revisions?.filter(rev => rev !== brokenExp)
             }
           })
         }

--- a/extension/src/test/suite/plots/paths/tree.test.ts
+++ b/extension/src/test/suite/plots/paths/tree.test.ts
@@ -150,9 +150,9 @@ suite('Plots Paths Tree Test Suite', () => {
       expect(mockPlotsDiff).to.be.calledWithExactly(
         dvcDemoPath,
         EXPERIMENT_WORKSPACE_ID,
-        '4fb124a',
-        '42b8736',
-        '1ba7bcd',
+        'exp-e7a67',
+        'test-branch',
+        'exp-83425',
         '53c3851'
       )
     }).timeout(WEBVIEW_TEST_TIMEOUT)


### PR DESCRIPTION
Related to #3619

This removes patches from the plots code from checkpoint experiments running in the workspace. In order to do this I have started calling the CLI with experiment names instead of short shas. Ideally, the name would replace the short sha as the `revision: string` in the `Revision` type but that is a much bigger job for another day (started working on that and had to reverse out).