### PR TITLE
Add cli error indicator into plots webview

### DIFF
--- a/extension/src/plots/index.ts
+++ b/extension/src/plots/index.ts
@@ -60,6 +60,7 @@ export class Plots extends BaseRepository<TPlotsData> {
     this.webviewMessages = this.createWebviewMessageHandler(
       this.paths,
       this.plots,
+      this.errors,
       experiments
     )
 
@@ -162,11 +163,13 @@ export class Plots extends BaseRepository<TPlotsData> {
   private createWebviewMessageHandler(
     paths: PathsModel,
     plots: PlotsModel,
+    errors: ErrorsModel,
     experiments: Experiments
   ) {
     const webviewMessages = new WebviewMessages(
       paths,
       plots,
+      errors,
       experiments,
       () => this.getWebview(),
       () => this.selectPlots(),

--- a/extension/src/plots/webview/contract.ts
+++ b/extension/src/plots/webview/contract.ts
@@ -156,6 +156,7 @@ export type ComparisonPlot = {
 
 export enum PlotsDataKeys {
   COMPARISON = 'comparison',
+  CLI_ERROR = 'cliError',
   CUSTOM = 'custom',
   HAS_UNSELECTED_PLOTS = 'hasUnselectedPlots',
   HAS_PLOTS = 'hasPlots',
@@ -168,6 +169,7 @@ export type PlotsData =
   | {
       [PlotsDataKeys.COMPARISON]?: PlotsComparisonData | null
       [PlotsDataKeys.CUSTOM]?: CustomPlotsData | null
+      [PlotsDataKeys.CLI_ERROR]?: string | null
       [PlotsDataKeys.HAS_PLOTS]?: boolean
       [PlotsDataKeys.HAS_UNSELECTED_PLOTS]?: boolean
       [PlotsDataKeys.SELECTED_REVISIONS]?: Revision[]

--- a/extension/src/plots/webview/messages.ts
+++ b/extension/src/plots/webview/messages.ts
@@ -27,10 +27,12 @@ import { Title } from '../../vscode/title'
 import { reorderObjectList } from '../../util/array'
 import { CustomPlotsOrderValue } from '../model/custom'
 import { getCustomPlotId } from '../model/collect'
+import { ErrorsModel } from '../errors/model'
 
 export class WebviewMessages {
   private readonly paths: PathsModel
   private readonly plots: PlotsModel
+  private readonly errors: ErrorsModel
   private readonly experiments: Experiments
 
   private readonly getWebview: () => BaseWebview<TPlotsData> | undefined
@@ -40,6 +42,7 @@ export class WebviewMessages {
   constructor(
     paths: PathsModel,
     plots: PlotsModel,
+    errors: ErrorsModel,
     experiments: Experiments,
     getWebview: () => BaseWebview<TPlotsData> | undefined,
     selectPlots: () => Promise<void>,
@@ -47,6 +50,7 @@ export class WebviewMessages {
   ) {
     this.paths = paths
     this.plots = plots
+    this.errors = errors
     this.experiments = experiments
     this.getWebview = getWebview
     this.selectPlots = selectPlots
@@ -60,6 +64,7 @@ export class WebviewMessages {
     const comparison = this.getComparisonPlots(overrideComparison)
 
     void this.getWebview()?.show({
+      cliError: this.errors.getCliError()?.error || null,
       comparison,
       custom: this.getCustomPlots(),
       hasPlots: !!this.paths.hasPaths(),

--- a/extension/src/test/suite/plots/index.test.ts
+++ b/extension/src/test/suite/plots/index.test.ts
@@ -670,6 +670,7 @@ suite('Plots Test Suite', () => {
       expect(templateData).to.deep.equal(templatePlotsFixture)
 
       const expectedPlotsData: TPlotsData = {
+        cliError: null,
         comparison: comparisonPlotsFixture,
         custom: customPlotsFixture,
         hasPlots: true,

--- a/extension/src/webview/contract.ts
+++ b/extension/src/webview/contract.ts
@@ -32,7 +32,6 @@ export enum MessageFromWebviewType {
   REORDER_PLOTS_COMPARISON_ROWS = 'reorder-plots-comparison-rows',
   REORDER_PLOTS_CUSTOM = 'reorder-plots-custom',
   REORDER_PLOTS_TEMPLATES = 'reorder-plots-templates',
-  REFRESH_REVISION = 'refresh-revision',
   REFRESH_REVISIONS = 'refresh-revisions',
   RESIZE_COLUMN = 'resize-column',
   RESIZE_PLOTS = 'resize-plots',

--- a/webview/src/plots/components/App.tsx
+++ b/webview/src/plots/components/App.tsx
@@ -26,6 +26,7 @@ import {
 } from './templatePlots/templatePlotsSlice'
 import {
   initialize,
+  updateCliError,
   updateHasPlots,
   updateHasUnselectedPlots,
   updateSelectedRevisions
@@ -54,6 +55,9 @@ export const feedStore = (
     dispatch(initialize())
     for (const key of Object.keys(data.data)) {
       switch (key) {
+        case PlotsDataKeys.CLI_ERROR:
+          dispatch(updateCliError(data.data[key]))
+          continue
         case PlotsDataKeys.CUSTOM:
           dispatch(updateCustomPlots(data.data[key] as CustomPlotsData))
           continue

--- a/webview/src/plots/components/ErrorIcon.tsx
+++ b/webview/src/plots/components/ErrorIcon.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import styles from './styles.module.scss'
+import { ErrorTooltip } from '../../shared/components/tooltip/ErrorTooltip'
+import { Error } from '../../shared/components/icons'
+
+export const ErrorIcon: React.FC<{ error: string; size: number }> = ({
+  error: msg,
+  size
+}) => (
+  <ErrorTooltip error={msg}>
+    <div>
+      <Error
+        className={styles.errorIcon}
+        data-testid="error-icon"
+        height={size}
+        width={size}
+      />
+    </div>
+  </ErrorTooltip>
+)

--- a/webview/src/plots/components/GetStarted.tsx
+++ b/webview/src/plots/components/GetStarted.tsx
@@ -1,18 +1,24 @@
 import React from 'react'
 import { MessageFromWebviewType } from 'dvc/src/webview/contract'
+import { ErrorIcon } from './ErrorIcon'
+import { refreshRevisions } from './messages'
 import { sendMessage } from '../../shared/vscode'
 import { StartButton } from '../../shared/components/button/StartButton'
+import { RefreshButton } from '../../shared/components/button/RefreshButton'
 
 export type AddPlotsProps = {
   hasUnselectedPlots: boolean
   hasNoCustomPlots: boolean
+  cliError: string | undefined
 }
 
 export const AddPlots: React.FC<AddPlotsProps> = ({
+  cliError,
   hasUnselectedPlots,
   hasNoCustomPlots
 }: AddPlotsProps) => (
   <div>
+    {cliError && <ErrorIcon error={cliError} size={96} />}
     <p>No Plots to Display</p>
     <div>
       <StartButton
@@ -23,7 +29,7 @@ export const AddPlots: React.FC<AddPlotsProps> = ({
         }
         text="Add Experiments"
       />
-      {hasUnselectedPlots && (
+      {hasUnselectedPlots && !cliError && (
         <StartButton
           isNested={hasUnselectedPlots}
           appearance="secondary"
@@ -45,6 +51,13 @@ export const AddPlots: React.FC<AddPlotsProps> = ({
             })
           }
           text="Add Custom Plot"
+        />
+      )}
+      {cliError && (
+        <RefreshButton
+          onClick={refreshRevisions}
+          isNested={true}
+          appearance="secondary"
         />
       )}
     </div>

--- a/webview/src/plots/components/Plots.tsx
+++ b/webview/src/plots/components/Plots.tsx
@@ -16,9 +16,8 @@ import { PlotsState } from '../store'
 
 const PlotsContent = () => {
   const dispatch = useDispatch()
-  const { hasData, hasPlots, hasUnselectedPlots, zoomedInPlot } = useSelector(
-    (state: PlotsState) => state.webview
-  )
+  const { hasData, hasPlots, hasUnselectedPlots, zoomedInPlot, cliError } =
+    useSelector((state: PlotsState) => state.webview)
   const hasComparisonData = useSelector(
     (state: PlotsState) => state.comparison.hasData
   )
@@ -71,9 +70,10 @@ const PlotsContent = () => {
             <AddPlots
               hasUnselectedPlots={hasUnselectedPlots}
               hasNoCustomPlots={hasNoCustomPlots}
+              cliError={cliError}
             />
           }
-          showEmpty={!hasPlots}
+          showEmpty={!hasPlots && !cliError}
           welcome={<Welcome />}
           isFullScreen={hasNoCustomPlots}
         />

--- a/webview/src/plots/components/comparisonTable/ComparisonTableCell.tsx
+++ b/webview/src/plots/components/comparisonTable/ComparisonTableCell.tsx
@@ -3,8 +3,7 @@ import { ComparisonPlot } from 'dvc/src/plots/webview/contract'
 import styles from './styles.module.scss'
 import { RefreshButton } from '../../../shared/components/button/RefreshButton'
 import { refreshRevisions, zoomPlot } from '../messages'
-import { Error } from '../../../shared/components/icons'
-import { ErrorTooltip } from '../../../shared/components/tooltip/ErrorTooltip'
+import { ErrorIcon } from '../ErrorIcon'
 
 type ComparisonTableCellProps = {
   path: string
@@ -15,11 +14,9 @@ const MissingPlotTableCell: React.FC<{ plot: ComparisonPlot }> = ({ plot }) => (
   <div className={styles.noImageContent}>
     {plot.errors?.length ? (
       <>
-        <ErrorTooltip error={plot.errors.join('\n')}>
-          <div>
-            <Error height={48} width={48} className={styles.errorIcon} />
-          </div>
-        </ErrorTooltip>
+        <div className={styles.errorIcon}>
+          <ErrorIcon error={plot.errors.join('\n')} size={48} />
+        </div>
         <RefreshButton onClick={refreshRevisions} />
       </>
     ) : (

--- a/webview/src/plots/components/comparisonTable/styles.module.scss
+++ b/webview/src/plots/components/comparisonTable/styles.module.scss
@@ -219,7 +219,6 @@ $gap: 4px;
 }
 
 .errorIcon {
-  color: $error-color;
   margin: 6px;
 }
 

--- a/webview/src/plots/components/styles.module.scss
+++ b/webview/src/plots/components/styles.module.scss
@@ -220,6 +220,10 @@ $gap: 20px;
   }
 }
 
+.errorIcon {
+  color: $error-color;
+}
+
 .zoomablePlot {
   display: block;
   width: 100%;

--- a/webview/src/plots/components/webviewSlice.ts
+++ b/webview/src/plots/components/webviewSlice.ts
@@ -9,6 +9,7 @@ type ZoomedInPlotState = {
   refresh?: boolean
 }
 export interface WebviewState {
+  cliError: string | undefined
   hasData: boolean
   hasPlots: boolean
   hasUnselectedPlots: boolean
@@ -18,6 +19,7 @@ export interface WebviewState {
 }
 
 export const webviewInitialState: WebviewState = {
+  cliError: undefined,
   hasData: false,
   hasPlots: false,
   hasUnselectedPlots: false,
@@ -61,6 +63,19 @@ export const webviewSlice = createSlice({
         Object.assign(state.zoomedInPlot, action.payload)
       }
     },
+    updateCliError: (
+      state: { cliError: string | undefined },
+      action: PayloadAction<string | undefined | null>
+    ) => {
+      if (action.payload === undefined) {
+        return
+      }
+      if (action.payload === null) {
+        state.cliError = undefined
+        return
+      }
+      state.cliError = action.payload
+    },
     updateHasPlots: (
       state: { hasPlots: boolean },
       action: PayloadAction<boolean>
@@ -84,6 +99,7 @@ export const webviewSlice = createSlice({
 
 export const {
   initialize,
+  updateCliError,
   updateHasPlots,
   updateHasUnselectedPlots,
   updateSelectedRevisions,

--- a/webview/src/stories/Plots.stories.tsx
+++ b/webview/src/stories/Plots.stories.tsx
@@ -37,7 +37,7 @@ const smallCustomPlotsFixture = {
 }
 
 const manyCustomPlots = (length: number) =>
-  Array.from({ length }, () => customPlotsFixture.plots[2]).map((plot, i) => {
+  Array.from({ length }, () => customPlotsFixture.plots[1]).map((plot, i) => {
     const id = plot.id + i.toString()
     return {
       ...plot,
@@ -66,6 +66,7 @@ const MockedState: React.FC<{ data: PlotsData; children: React.ReactNode }> = ({
 export default {
   args: {
     data: {
+      cliError: null,
       comparison: comparisonPlotsFixture,
       custom: customPlotsFixture,
       hasPlots: true,
@@ -140,6 +141,17 @@ WithoutPlots.args = {
 export const WithoutPlotsSelected = Template.bind({})
 WithoutPlotsSelected.args = {
   data: {
+    hasPlots: true,
+    hasUnselectedPlots: true,
+    sectionCollapsed: DEFAULT_SECTION_COLLAPSED,
+    selectedRevisions: plotsRevisionsFixture
+  }
+}
+
+export const WithCliError = Template.bind({})
+WithCliError.args = {
+  data: {
+    cliError: 'some big bad error',
     hasPlots: true,
     hasUnselectedPlots: true,
     sectionCollapsed: DEFAULT_SECTION_COLLAPSED,


### PR DESCRIPTION
Closes #1649 & #3222

This PR adds an indicator to the plots webview whenever the CLI throws a error calling plots diff.

### Demo


https://user-images.githubusercontent.com/37993418/229773822-65234277-3ac5-4f76-bb00-4612c32da244.mov


Note: I had to rig `plots diff` to throw an error whenever a certain combination of revisions were used to call the CLI. Big thanks to copilot for coming up with the error

<img width="1728" alt="Screenshot 2023-04-04 at 9 08 46 pm" src="https://user-images.githubusercontent.com/37993418/229773961-45986350-f355-4fc9-818b-4e02dc105fed.png">

