### PR TITLE
Add a space after the checkbox action in the table

### DIFF
--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -559,7 +559,7 @@ $bullet-size: calc(var(--design-unit) * 4px);
         height: 100%;
 
         &:first-child {
-          margin-right: 2px;
+          margin-right: 20px;
         }
 
         .indicatorIcon {


### PR DESCRIPTION
Might help with #3430 (but won't solve completely)

<img width="1632" alt="Screenshot 2023-04-04 at 6 36 37 PM" src="https://user-images.githubusercontent.com/3683420/229937869-87e6270b-e33c-495a-bef3-e710a7d69eb9.png">
