### PR TITLE
Show duplicate revisions when experiment finishes running in the workspace

### DIFF
--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -21,6 +21,10 @@ import {
   pickFiltersToRemove
 } from './model/filterBy/quickPick'
 import { Color } from './model/status/colors'
+import {
+  FetchedExperiment,
+  hasFinishedWorkspaceExperiment
+} from './model/status/collect'
 import { UNSELECTED } from './model/status'
 import { starredSort } from './model/sortBy/constants'
 import { pickSortsToRemove, pickSortToAdd } from './model/sortBy/quickPick'
@@ -238,6 +242,17 @@ export class Experiments extends BaseRepository<TableData> {
     const status = this.experiments.toggleStatus(id)
     this.notifyChanged()
     return status
+  }
+
+  public checkForFinishedWorkspaceExperiment(
+    fetchedExperiments: FetchedExperiment[]
+  ) {
+    if (!hasFinishedWorkspaceExperiment(fetchedExperiments)) {
+      return
+    }
+
+    this.experiments.unselectWorkspace()
+    this.notifyChanged()
   }
 
   public getSorts() {
@@ -460,10 +475,6 @@ export class Experiments extends BaseRepository<TableData> {
 
   public getRevisions() {
     return this.experiments.getRevisions()
-  }
-
-  public getSelectedExperiments() {
-    return this.experiments.getSelectedExperiments()
   }
 
   public async modifyExperimentParamsAndRun(

--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -23,11 +23,7 @@ import {
   isRunningInQueue,
   RunningExperiment
 } from '../webview/contract'
-import {
-  definedAndNonEmpty,
-  reorderListSubset,
-  reorderObjectList
-} from '../../util/array'
+import { definedAndNonEmpty, reorderListSubset } from '../../util/array'
 import {
   ExperimentsOutput,
   EXPERIMENT_WORKSPACE_ID
@@ -141,14 +137,18 @@ export class ExperimentsModel extends ModelWithPersistence {
 
     const current = this.coloredStatus[id]
     if (current) {
-      this.unassignColor(current)
       this.coloredStatus[id] = UNSELECTED
+      this.unassignColor(current)
     } else if (this.availableColors.length > 0) {
       this.coloredStatus[id] = this.availableColors.shift() as Color
     }
 
     this.persistStatus()
     return this.coloredStatus[id]
+  }
+
+  public unselectWorkspace() {
+    this.coloredStatus[EXPERIMENT_WORKSPACE_ID] = UNSELECTED
   }
 
   public hasRunningExperiment() {
@@ -245,10 +245,6 @@ export class ExperimentsModel extends ModelWithPersistence {
 
   public getSelectedRevisions() {
     return this.getSelectedFromList(() => this.getCombinedList())
-  }
-
-  public getSelectedExperiments() {
-    return this.getSelectedFromList(() => this.getExperimentsAndQueued())
   }
 
   public setSelected(selectedExperiments: Experiment[]) {
@@ -474,6 +470,10 @@ export class ExperimentsModel extends ModelWithPersistence {
   }
 
   private unassignColor(color: Color) {
+    if (new Set(Object.values(this.coloredStatus)).has(color)) {
+      return
+    }
+
     this.availableColors.unshift(color)
     this.availableColors = reorderListSubset(
       this.availableColors,
@@ -536,10 +536,10 @@ export class ExperimentsModel extends ModelWithPersistence {
       }
     }
 
-    return reorderObjectList<SelectedExperimentWithColor>(
-      copyOriginalColors(),
-      acc,
-      'displayColor'
-    )
+    return copyOriginalColors()
+      .flatMap(orderedItem =>
+        acc.filter(item => item.displayColor === orderedItem)
+      )
+      .filter(Boolean)
   }
 }

--- a/extension/src/experiments/model/status/collect.test.ts
+++ b/extension/src/experiments/model/status/collect.test.ts
@@ -246,7 +246,7 @@ describe('collectColoredStatus', () => {
     expect(availableColors).toStrictEqual(colors.slice(1))
   })
 
-  it("should reassign the workspace's color when an experiment finishes running in the workspace", () => {
+  it("should duplicate the workspace's color when an experiment finishes running in the workspace", () => {
     const colors = copyOriginalColors()
     const { availableColors, coloredStatus } = collectColoredStatus(
       [
@@ -269,7 +269,7 @@ describe('collectColoredStatus', () => {
     )
     expect(coloredStatus).toStrictEqual({
       'exp-1': colors[0],
-      workspace: UNSELECTED
+      workspace: colors[0]
     })
 
     expect(availableColors).toStrictEqual(colors.slice(1))

--- a/extension/src/experiments/model/status/collect.ts
+++ b/extension/src/experiments/model/status/collect.ts
@@ -77,7 +77,7 @@ const removeUnselectedExperimentRunningInWorkspace = (
   }
 }
 
-const reassignFinishedWorkspaceExperiment = (
+const duplicateFinishedWorkspaceExperiment = (
   coloredStatus: ColoredStatus,
   finishedRunning: { [id: string]: string }
 ): void => {
@@ -87,7 +87,6 @@ const reassignFinishedWorkspaceExperiment = (
     }
 
     coloredStatus[id] = coloredStatus.workspace
-    coloredStatus.workspace = UNSELECTED
   }
 }
 
@@ -143,7 +142,7 @@ export const collectColoredStatus = (
     removeUnselectedExperimentRunningInWorkspace(coloredStatus, experiment)
   }
 
-  reassignFinishedWorkspaceExperiment(coloredStatus, finishedRunning)
+  duplicateFinishedWorkspaceExperiment(coloredStatus, finishedRunning)
 
   return { availableColors, coloredStatus }
 }
@@ -309,4 +308,29 @@ export const collectFinishedRunningExperiments = (
     acc[previouslyRunningId] = previouslyRunningId
   }
   return acc
+}
+
+export type FetchedExperiment = { id?: string; displayColor: Color }
+
+export const hasFinishedWorkspaceExperiment = (
+  fetchedExperiments: FetchedExperiment[]
+): boolean => {
+  let workspace: FetchedExperiment | undefined
+  const nonWorkspace: FetchedExperiment[] = []
+
+  for (const revision of fetchedExperiments) {
+    if (revision.id === EXPERIMENT_WORKSPACE_ID) {
+      workspace = revision
+      continue
+    }
+    nonWorkspace.push(revision)
+  }
+
+  if (!workspace) {
+    return false
+  }
+
+  return nonWorkspace.some(
+    ({ displayColor }) => displayColor === workspace?.displayColor
+  )
 }

--- a/extension/src/plots/model/index.ts
+++ b/extension/src/plots/model/index.ts
@@ -196,16 +196,17 @@ export class PlotsModel extends ModelWithPersistence {
   }
 
   public getSelectedRevisionDetails() {
-    return this.experiments.getSelectedRevisions().map(exp => {
+    const selectedRevisions: Revision[] = []
+    for (const experiment of this.experiments.getSelectedRevisions()) {
       const { commit, displayName, label, displayColor, logicalGroupName, id } =
-        exp
+        experiment
       const revision: Revision = {
         displayColor,
         errors: this.errors.getRevisionErrors(label),
         fetched: this.fetchedRevs.has(label),
         firstThreeColumns: getRevisionFirstThreeColumns(
           this.experiments.getFirstThreeColumnOrder(),
-          exp
+          experiment
         ),
         group: logicalGroupName,
         id,
@@ -215,8 +216,10 @@ export class PlotsModel extends ModelWithPersistence {
       if (commit) {
         revision.commit = displayName
       }
-      return revision
-    })
+      selectedRevisions.push(revision)
+    }
+
+    return selectedRevisions
   }
 
   public getTemplatePlots(

--- a/extension/src/plots/webview/messages.ts
+++ b/extension/src/plots/webview/messages.ts
@@ -57,9 +57,10 @@ export class WebviewMessages {
     this.updateData = updateData
   }
 
-  public sendWebviewMessage() {
+  public async sendWebviewMessage() {
     const selectedRevisions = this.plots.getSelectedRevisionDetails()
-    void this.getWebview()?.show({
+
+    await this.getWebview()?.show({
       cliError: this.errors.getCliError()?.error || null,
       comparison: this.getComparisonPlots(),
       custom: this.getCustomPlots(),
@@ -69,6 +70,10 @@ export class WebviewMessages {
       selectedRevisions,
       template: this.getTemplatePlots(selectedRevisions)
     })
+
+    this.experiments.checkForFinishedWorkspaceExperiment(
+      selectedRevisions.filter(({ fetched }) => fetched)
+    )
   }
 
   public handleMessageFromWebview(message: MessageFromWebview) {

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sort-keys-fix/sort-keys-fix */
 import { join, resolve } from 'path'
 import { after, afterEach, beforeEach, describe, it, suite } from 'mocha'
 import { expect } from 'chai'
@@ -71,7 +72,10 @@ import {
   RegisteredCommands
 } from '../../../commands/external'
 import { ConfigKey } from '../../../vscode/config'
-import { EXPERIMENT_WORKSPACE_ID } from '../../../cli/dvc/contract'
+import {
+  EXPERIMENT_WORKSPACE_ID,
+  ExperimentStatus
+} from '../../../cli/dvc/contract'
 import * as Time from '../../../util/time'
 import { AvailableCommands } from '../../../commands/internal'
 import { Setup } from '../../../setup'
@@ -1838,7 +1842,7 @@ suite('Experiments Test Suite', () => {
         secondFilterDefinition
       ])
       const selected = testRepository
-        .getSelectedExperiments()
+        .getSelectedRevisions()
         .map(({ displayColor, id }) => ({ displayColor, id }))
       expect(
         selected,
@@ -1851,6 +1855,10 @@ suite('Experiments Test Suite', () => {
         {
           displayColor: colors[1],
           id: 'test-branch'
+        },
+        {
+          displayColor: colors[2],
+          id: EXPERIMENT_WORKSPACE_ID
         },
         {
           displayColor: colors[5],
@@ -2021,6 +2029,128 @@ suite('Experiments Test Suite', () => {
       expect(mockCheckSignalFile).to.be.called
       expect(mockDelay).to.be.called
       expect(mockUpdateExperimentsData).to.be.calledOnce
+    })
+  })
+
+  describe('checkForFinishedWorkspaceExperiment', () => {
+    it('should unselect the workspace record if it has the same color as an experiment', async () => {
+      const colors = copyOriginalColors()
+      const [color] = colors
+      const commit = 'df3f8647a47e403c9c4aa6562cad0b74afbe900b'
+      const expCommit = 'c0f48cf6c3eb589d48979df82c6bbe78c1ee5d61'
+      const expName = 'fizzy-dilemma'
+      const params = { 'params.yaml': { data: { lr: 1 } } }
+
+      const getSelectedIdsWithColor = (
+        experiments: Experiments
+      ): { id: string; displayColor: string }[] =>
+        experiments
+          .getSelectedRevisions()
+          .map(({ id, displayColor }) => ({ id, displayColor }))
+
+      const selectedWorkspace = {
+        id: EXPERIMENT_WORKSPACE_ID,
+        displayColor: color
+      }
+      const selectedExperiment = {
+        id: expName,
+        displayColor: color
+      }
+      const bothSelected = [selectedWorkspace, selectedExperiment]
+
+      const data = {
+        workspace: {
+          baseline: {
+            data: {
+              executor: EXPERIMENT_WORKSPACE_ID,
+              params,
+              status: ExperimentStatus.RUNNING
+            }
+          }
+        },
+        [commit]: {
+          baseline: {
+            data: {}
+          }
+        }
+      }
+
+      const { experiments, experimentsModel } = buildExperiments(
+        disposable,
+        data
+      )
+
+      await experiments.isReady()
+
+      expect(
+        experimentsModel.hasRunningExperiment(),
+        'should have a running experiment'
+      ).to.be.true
+
+      expect(
+        getSelectedIdsWithColor(experiments),
+        'should automatically select the running experiment'
+      ).to.deep.equal([selectedWorkspace])
+
+      const experimentsChanged = new Promise(resolve =>
+        experiments.onDidChangeExperiments(() => resolve(undefined))
+      )
+
+      await experiments.setState({
+        workspace: {
+          baseline: {
+            data: {
+              executor: null,
+              params
+            }
+          }
+        },
+        [commit]: {
+          ...data[commit],
+          [expCommit]: {
+            data: {
+              name: expName,
+              params,
+              status: ExperimentStatus.SUCCESS,
+              timestamp: '2020-11-21T19:58:22'
+            }
+          }
+        }
+      })
+
+      await experimentsChanged
+
+      expect(
+        getSelectedIdsWithColor(experiments),
+        "should apply the workspace's color to a newly created experiment"
+      ).to.deep.equal(bothSelected)
+
+      experiments.checkForFinishedWorkspaceExperiment([selectedWorkspace])
+
+      expect(
+        getSelectedIdsWithColor(experiments),
+        "should not remove the workspace's color if the experiment's data has not been fetched"
+      ).to.deep.equal(bothSelected)
+
+      experiments.checkForFinishedWorkspaceExperiment([
+        selectedExperiment,
+        selectedWorkspace
+      ])
+
+      expect(
+        getSelectedIdsWithColor(experiments),
+        "should remove the workspace's color once the experiment's data has been shown to be fetched"
+      ).to.deep.equal([selectedExperiment])
+
+      experiments.toggleExperimentStatus(EXPERIMENT_WORKSPACE_ID)
+
+      expect(
+        getSelectedIdsWithColor(experiments),
+        'should not duplicate the color when toggling another experiment'
+      ).to.deep.equal([
+        selectedExperiment,
+        { id: EXPERIMENT_WORKSPACE_ID, displayColor: colors[1] }
+      ])
     })
   })
 })


### PR DESCRIPTION
# 2/2 `main` <- #3639 <- this

This PR replaces a small piece of functionality that was purged in #3624. Instead of overwriting the revision/data, we send duplicate revisions whenever an experiment finishes so that the experiment does not appear to vanish and reappear.

### Demo

https://user-images.githubusercontent.com/37993418/229999686-238e5f69-9145-44df-974d-5ff5cfc74232.mov

### Prior behaviour

https://user-images.githubusercontent.com/37993418/230000027-af71bd83-dc5a-4a8b-83c1-f812b6e243f8.mov

Note: this is a temporary patch as the [new data](https://github.com/iterative/dvc/pull/9170#issuecomment-1469423657) will fix the problem properly.