### PR TITLE
Add 20px to min width of experiments column

### DIFF
--- a/webview/src/experiments/components/Experiments.tsx
+++ b/webview/src/experiments/components/Experiments.tsx
@@ -67,8 +67,8 @@ const getDefaultColumnWithIndicatorsPlaceHolder = () =>
     },
     header: ExperimentHeader,
     id: EXPERIMENT_COLUMN_ID,
-    minSize: 215,
-    size: 215
+    minSize: 235,
+    size: 235
   })
 
 const getColumns = (columns: Column[]) => {


### PR DESCRIPTION
Takes into account the 20px added to the column contents in https://github.com/iterative/vscode-dvc/pull/3635.

## Min width

### Before 

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/37993418/230346127-1c40b9ee-bfea-4d8d-a834-a9eac4ed4cae.png">


### After

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/37993418/230345982-f112c5a4-66c0-4f3f-96ac-7acda55de7d9.png">

This is a take-it-or-leave-it change. Just something that I noticed. Feel free to close.
