### PR TITLE
fix(table): DnD landing zone covers the whole cell in the table

### DIFF
--- a/webview/src/experiments/components/table/header/TableHeaderCellContents.tsx
+++ b/webview/src/experiments/components/table/header/TableHeaderCellContents.tsx
@@ -63,7 +63,7 @@ export const ColumnDragHandle: React.FC<{
         onDrop={onDrop}
         onDragLeave={onDragLeave}
       >
-        <span>
+        <span className={header.isPlaceholder ? '' : styles.cellDraggable}>
           {header.isPlaceholder
             ? null
             : flexRender(header.column.columnDef.header, header.getContext())}

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -382,8 +382,12 @@ table.withExpColumnShadow tr > *:first-child {
     display: block;
 
     span[draggable='true'] {
-      display: block;
       cursor: grab;
+    }
+
+    .cellDraggable {
+      display: block;
+      padding: 0.31rem $cell-padding;
     }
   }
 
@@ -566,9 +570,6 @@ td {
 
 .placeholderHeaderCell {
   background-color: $header-bg-color;
-  .cellContents {
-    padding: 0.31rem $cell-padding;
-  }
 
   &::before {
     @extend %cellBorderLeft;
@@ -841,6 +842,7 @@ td {
   overflow-x: hidden;
   text-overflow: ellipsis;
   text-align: left;
+  pointer-events: none;
 }
 
 thead {


### PR DESCRIPTION
Fixes #3008 (to hopefully close it finally :) )

(not very visible on the demo, but DnD doesn't break now at the edges of the cell like it was before)


https://user-images.githubusercontent.com/3659196/231602982-8e031a7d-5549-47dd-9376-d42015ede06d.mov

