### PR TITLE
Fix auto-selection of running experiments

### DIFF
--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -21,10 +21,6 @@ import {
   pickFiltersToRemove
 } from './model/filterBy/quickPick'
 import { Color } from './model/status/colors'
-import {
-  FetchedExperiment,
-  hasFinishedWorkspaceExperiment
-} from './model/status/collect'
 import { UNSELECTED } from './model/status'
 import { starredSort } from './model/sortBy/constants'
 import { pickSortsToRemove, pickSortToAdd } from './model/sortBy/quickPick'
@@ -36,7 +32,7 @@ import { DecorationProvider } from './model/decorationProvider'
 import { starredFilter } from './model/filterBy/constants'
 import { ResourceLocator } from '../resourceLocator'
 import { AvailableCommands, InternalCommands } from '../commands/internal'
-import { EXPERIMENT_WORKSPACE_ID, ExpShowOutput } from '../cli/dvc/contract'
+import { ExpShowOutput } from '../cli/dvc/contract'
 import { ViewKey } from '../webview/constants'
 import { BaseRepository } from '../webview/repository'
 import { Title } from '../vscode/title'
@@ -217,15 +213,6 @@ export class Experiments extends BaseRepository<TableData> {
   public toggleExperimentStatus(
     id: string
   ): Color | typeof UNSELECTED | undefined {
-    if (
-      this.experiments.isRunningInWorkspace(id) &&
-      !this.experiments.isSelected(id)
-    ) {
-      return this.experiments.isSelected(EXPERIMENT_WORKSPACE_ID)
-        ? undefined
-        : this.toggleExperimentStatus(EXPERIMENT_WORKSPACE_ID)
-    }
-
     const selected = this.experiments.isSelected(id)
     if (!selected && !this.experiments.canSelect()) {
       return
@@ -234,17 +221,6 @@ export class Experiments extends BaseRepository<TableData> {
     const status = this.experiments.toggleStatus(id)
     this.notifyChanged()
     return status
-  }
-
-  public checkForFinishedWorkspaceExperiment(
-    fetchedExperiments: FetchedExperiment[]
-  ) {
-    if (!hasFinishedWorkspaceExperiment(fetchedExperiments)) {
-      return
-    }
-
-    this.experiments.unselectWorkspace()
-    this.notifyChanged()
   }
 
   public getSorts() {
@@ -436,14 +412,6 @@ export class Experiments extends BaseRepository<TableData> {
     }
 
     return this.experiments.getSelectedRevisions()
-  }
-
-  public setRevisionCollected(revisions: string[]) {
-    this.experiments.setRevisionCollected(revisions)
-  }
-
-  public getFinishedExperiments() {
-    return this.experiments.getFinishedExperiments()
   }
 
   public getExperiments() {

--- a/extension/src/experiments/model/status/collect.test.ts
+++ b/extension/src/experiments/model/status/collect.test.ts
@@ -1,15 +1,8 @@
 import { UNSELECTED } from '.'
-import {
-  collectColoredStatus,
-  collectFinishedRunningExperiments
-} from './collect'
+import { collectColoredStatus } from './collect'
 import { copyOriginalColors } from './colors'
 import { Experiment } from '../../webview/contract'
-import {
-  ExperimentStatus,
-  EXPERIMENT_WORKSPACE_ID,
-  Executor
-} from '../../../cli/dvc/contract'
+import { ExperimentStatus } from '../../../cli/dvc/contract'
 
 describe('collectColoredStatus', () => {
   const buildMockExperiments = (n: number, prefix = 'exp') => {
@@ -31,8 +24,7 @@ describe('collectColoredStatus', () => {
       new Map(),
       {},
       copyOriginalColors(),
-      new Set(),
-      {}
+      new Set()
     )
 
     expect(availableColors).toStrictEqual(colors)
@@ -53,8 +45,7 @@ describe('collectColoredStatus', () => {
       new Map(),
       {},
       copyOriginalColors(),
-      new Set(),
-      {}
+      new Set()
     )
 
     expect(availableColors).toStrictEqual(colors)
@@ -80,8 +71,7 @@ describe('collectColoredStatus', () => {
         exp7: colors[6]
       },
       [],
-      new Set(['exp8']),
-      {}
+      new Set(['exp8'])
     )
 
     expect(availableColors).toStrictEqual([])
@@ -114,8 +104,7 @@ describe('collectColoredStatus', () => {
         exp8: UNSELECTED
       },
       copyOriginalColors().slice(3),
-      new Set(['exp1']),
-      {}
+      new Set(['exp1'])
     )
 
     expect(coloredStatus).toStrictEqual({ exp1: colors[0] })
@@ -137,8 +126,7 @@ describe('collectColoredStatus', () => {
         exp9: colors[1]
       },
       unassignedColors,
-      new Set(),
-      {}
+      new Set()
     )
 
     expect(coloredStatus).toStrictEqual({
@@ -166,8 +154,7 @@ describe('collectColoredStatus', () => {
       new Map(),
       { exp9: colors[0] },
       unassignColors,
-      new Set(),
-      {}
+      new Set()
     )
 
     expect(availableColors).toStrictEqual(unassignColors)
@@ -200,8 +187,7 @@ describe('collectColoredStatus', () => {
         exp9: colors[5]
       },
       copyOriginalColors().slice(6),
-      new Set(['exp1', 'exp2', 'exp3']),
-      {}
+      new Set(['exp1', 'exp2', 'exp3'])
     )
 
     expect(availableColors).toStrictEqual([])
@@ -215,197 +201,6 @@ describe('collectColoredStatus', () => {
       exp7: colors[3],
       exp8: colors[4],
       exp9: colors[5]
-    })
-  })
-
-  it('should remove the unselected status of experiments running in the workspace (for getMostRecentExperiment)', () => {
-    const colors = copyOriginalColors()
-    const { availableColors, coloredStatus } = collectColoredStatus(
-      [
-        {
-          executor: Executor.WORKSPACE,
-          id: 'exp-1',
-          status: ExperimentStatus.RUNNING
-        },
-        {
-          executor: Executor.WORKSPACE,
-          id: 'exp-2',
-          status: ExperimentStatus.RUNNING
-        }
-      ] as Experiment[],
-      new Map(),
-      {
-        'exp-1': UNSELECTED,
-        'exp-2': colors[0]
-      },
-      colors.slice(1),
-      new Set(),
-      {}
-    )
-    expect(coloredStatus['exp-1']).toBeUndefined()
-    expect(coloredStatus['exp-2']).toStrictEqual(colors[0])
-    expect(availableColors).toStrictEqual(colors.slice(1))
-  })
-
-  it("should duplicate the workspace's color when an experiment finishes running in the workspace", () => {
-    const colors = copyOriginalColors()
-    const { availableColors, coloredStatus } = collectColoredStatus(
-      [
-        {
-          executor: null,
-          id: 'exp-1',
-          status: ExperimentStatus.SUCCESS
-        },
-        {
-          id: EXPERIMENT_WORKSPACE_ID
-        }
-      ] as Experiment[],
-      new Map(),
-      {
-        workspace: colors[0]
-      },
-      colors.slice(1),
-      new Set(),
-      { 'exp-1': EXPERIMENT_WORKSPACE_ID }
-    )
-    expect(coloredStatus).toStrictEqual({
-      'exp-1': colors[0],
-      workspace: colors[0]
-    })
-
-    expect(availableColors).toStrictEqual(colors.slice(1))
-  })
-
-  it('should not overwrite an experiments color if it has one and finishes running in the workspace', () => {
-    const colors = copyOriginalColors()
-    const { availableColors, coloredStatus } = collectColoredStatus(
-      [
-        {
-          executor: null,
-          id: 'exp-1',
-          status: ExperimentStatus.SUCCESS
-        },
-        {
-          id: EXPERIMENT_WORKSPACE_ID
-        }
-      ] as Experiment[],
-      new Map(),
-      {
-        'exp-1': colors[2],
-        workspace: colors[0]
-      },
-      colors.slice(1),
-      new Set(),
-      { 'exp-1': EXPERIMENT_WORKSPACE_ID }
-    )
-    expect(coloredStatus).toStrictEqual({
-      'exp-1': colors[2],
-      workspace: colors[0]
-    })
-
-    expect(availableColors).toStrictEqual(colors.slice(1))
-  })
-})
-
-describe('collectFinishedRunningExperiments', () => {
-  it('should return an empty object when an experiment is still running', () => {
-    const finishedRunning = collectFinishedRunningExperiments(
-      {},
-      [{ Created: '2022-12-02T07:48:24', id: 'exp-1234' }] as Experiment[],
-      [{ executor: Executor.WORKSPACE, id: 'exp-1234' }],
-      [{ executor: Executor.WORKSPACE, id: 'exp-1234' }],
-      {}
-    )
-    expect(finishedRunning).toStrictEqual({})
-  })
-
-  it('should return the most recently created and unseen (without a status) experiment if there is no longer an experiment running in the workspace', () => {
-    const latestCreatedId = 'exp-123'
-    const finishedRunning = collectFinishedRunningExperiments(
-      {},
-      [
-        { Created: '2022-12-02T10:48:24', id: 'exp-456' },
-        { Created: '2022-10-02T07:48:24', id: 'exp-789' },
-        { Created: '2022-12-02T07:48:25', id: latestCreatedId },
-        { Created: null, id: 'exp-null' }
-      ] as Experiment[],
-      [{ executor: Executor.WORKSPACE, id: EXPERIMENT_WORKSPACE_ID }],
-      [],
-      { 'exp-456': UNSELECTED }
-    )
-    expect(finishedRunning).toStrictEqual({
-      [latestCreatedId]: EXPERIMENT_WORKSPACE_ID
-    })
-  })
-
-  it('should return the most recently created experiment if there is no longer a checkpoint experiment running in the workspace', () => {
-    const latestCreatedId = 'exp-123'
-    const finishedRunning = collectFinishedRunningExperiments(
-      {},
-      [
-        { Created: '2022-12-02T07:48:24', id: 'exp-456' },
-        { Created: '2022-10-02T07:48:24', id: 'exp-789' },
-        { Created: '2022-12-02T07:48:25', id: latestCreatedId },
-        { Created: null, id: 'exp-null' }
-      ] as Experiment[],
-      [{ executor: Executor.WORKSPACE, id: latestCreatedId }],
-      [],
-      {}
-    )
-    expect(finishedRunning).toStrictEqual({
-      [latestCreatedId]: EXPERIMENT_WORKSPACE_ID
-    })
-  })
-
-  it('should not return an experiment if all of the experiments can be found in the status object', () => {
-    const previouslyCreatedId = 'exp-123'
-    const finishedRunning = collectFinishedRunningExperiments(
-      {},
-      [
-        { Created: '2022-12-02T07:48:25', id: previouslyCreatedId }
-      ] as Experiment[],
-      [{ executor: Executor.WORKSPACE, id: previouslyCreatedId }],
-      [],
-      { [previouslyCreatedId]: UNSELECTED }
-    )
-    expect(finishedRunning).toStrictEqual({})
-  })
-
-  it('should return the most recently created experiment if there is no longer an experiment running in the queue', () => {
-    const latestCreatedId = 'exp-123'
-    const finishedRunning = collectFinishedRunningExperiments(
-      {},
-      [
-        { Created: '2022-12-02T07:48:24', id: 'exp-456' },
-        { Created: '2022-10-02T07:48:24', id: 'exp-789' },
-        { Created: '2022-12-02T07:48:25', id: latestCreatedId },
-        { Created: null, id: 'exp-null' }
-      ] as Experiment[],
-      [{ executor: Executor.DVC_TASK, id: latestCreatedId }],
-      [],
-      {}
-    )
-    expect(finishedRunning).toStrictEqual({
-      [latestCreatedId]: latestCreatedId
-    })
-  })
-
-  it('should remove the id that was run in the workspace if a new one is found', () => {
-    const latestCreatedId = 'exp-123'
-    const finishedRunning = collectFinishedRunningExperiments(
-      { 'exp-previous': EXPERIMENT_WORKSPACE_ID },
-      [
-        { Created: '2022-12-02T07:48:24', id: 'exp-456' },
-        { Created: '2022-10-02T07:48:24', id: 'exp-789' },
-        { Created: '2022-12-02T07:48:25', id: latestCreatedId },
-        { Created: null, id: 'exp-null' }
-      ] as Experiment[],
-      [{ executor: Executor.WORKSPACE, id: latestCreatedId }],
-      [],
-      {}
-    )
-    expect(finishedRunning).toStrictEqual({
-      [latestCreatedId]: EXPERIMENT_WORKSPACE_ID
     })
   })
 })

--- a/extension/src/experiments/model/status/collect.ts
+++ b/extension/src/experiments/model/status/collect.ts
@@ -1,15 +1,10 @@
 import { canSelect, ColoredStatus, UNSELECTED } from '.'
 import { Color, copyOriginalColors } from './colors'
 import { hasKey } from '../../../util/object'
-import {
-  Experiment,
-  isQueued,
-  isRunning,
-  RunningExperiment
-} from '../../webview/contract'
+import { Experiment, isQueued, RunningExperiment } from '../../webview/contract'
 import { definedAndNonEmpty, reorderListSubset } from '../../../util/array'
 import { flattenMapValues } from '../../../util/map'
-import { EXPERIMENT_WORKSPACE_ID } from '../../../cli/dvc/contract'
+import { Executor, EXPERIMENT_WORKSPACE_ID } from '../../../cli/dvc/contract'
 
 const canAssign = (
   coloredStatus: ColoredStatus,
@@ -63,33 +58,6 @@ const collectStartedRunningColors = (
   }
 }
 
-const removeUnselectedExperimentRunningInWorkspace = (
-  coloredStatus: ColoredStatus,
-  { status, executor, id }: Experiment
-): void => {
-  if (
-    isRunning(status) &&
-    executor === EXPERIMENT_WORKSPACE_ID &&
-    id !== EXPERIMENT_WORKSPACE_ID &&
-    !coloredStatus[id]
-  ) {
-    delete coloredStatus[id]
-  }
-}
-
-const duplicateFinishedWorkspaceExperiment = (
-  coloredStatus: ColoredStatus,
-  finishedRunning: { [id: string]: string }
-): void => {
-  for (const [id, previousId] of Object.entries(finishedRunning)) {
-    if (previousId !== EXPERIMENT_WORKSPACE_ID || coloredStatus[id]) {
-      continue
-    }
-
-    coloredStatus[id] = coloredStatus.workspace
-  }
-}
-
 export const unassignColors = (
   experiments: Experiment[],
   current: ColoredStatus,
@@ -114,8 +82,7 @@ export const collectColoredStatus = (
   experimentsByCommit: Map<string, Experiment[]>,
   previousStatus: ColoredStatus,
   unassignedColors: Color[],
-  startedRunning: Set<string>,
-  finishedRunning: { [id: string]: string }
+  startedRunning: Set<string>
 ): { coloredStatus: ColoredStatus; availableColors: Color[] } => {
   const flatExperimentsByCommit = flattenMapValues(experimentsByCommit)
   const availableColors = unassignColors(
@@ -139,10 +106,7 @@ export const collectColoredStatus = (
 
   for (const experiment of [...experiments, ...flatExperimentsByCommit]) {
     collectStatus(coloredStatus, experiment)
-    removeUnselectedExperimentRunningInWorkspace(coloredStatus, experiment)
   }
-
-  duplicateFinishedWorkspaceExperiment(coloredStatus, finishedRunning)
 
   return { availableColors, coloredStatus }
 }
@@ -217,120 +181,15 @@ export const collectStartedRunningExperiments = (
   const acc = new Set<string>()
 
   for (const { id: runningId, executor } of nowRunning) {
-    if (previouslyRunning.some(({ id }) => id === runningId)) {
-      continue
-    }
-    acc.add(
-      executor === EXPERIMENT_WORKSPACE_ID ? EXPERIMENT_WORKSPACE_ID : runningId
-    )
-  }
-
-  return acc
-}
-
-const getMostRecentExperiment = (
-  experiments: Experiment[],
-  coloredStatus: ColoredStatus
-): Experiment | undefined =>
-  experiments
-    .filter(({ id }) => coloredStatus[id] === undefined)
-    .sort(({ Created: aCreated }, { Created: bCreated }) => {
-      if (!aCreated) {
-        return 1
-      }
-      if (!bCreated) {
-        return -1
-      }
-      return bCreated.localeCompare(aCreated)
-    })
-    .slice(0, 1)[0]
-
-const collectFinishedWorkspaceExperiment = (
-  acc: { [id: string]: string },
-  mostRecentExperiment: Experiment | undefined
-): void => {
-  const newId = mostRecentExperiment?.id
-
-  if (!newId) {
-    return
-  }
-
-  for (const [id, previousId] of Object.entries(acc)) {
-    if (previousId === EXPERIMENT_WORKSPACE_ID) {
-      delete acc[id]
-    }
-  }
-  acc[newId] = EXPERIMENT_WORKSPACE_ID
-}
-
-const isStillRunning = (
-  stillExecutingInWorkspace: boolean,
-  previouslyRunningId: string,
-  previouslyRunningExecutor: string,
-  stillRunning: RunningExperiment[]
-): boolean =>
-  (stillExecutingInWorkspace &&
-    previouslyRunningExecutor === EXPERIMENT_WORKSPACE_ID) ||
-  stillRunning.some(({ id }) => id === previouslyRunningId)
-
-export const collectFinishedRunningExperiments = (
-  acc: { [id: string]: string },
-  experiments: Experiment[],
-  previouslyRunning: RunningExperiment[],
-  stillRunning: RunningExperiment[],
-  coloredStatus: ColoredStatus
-): { [id: string]: string } => {
-  const stillExecutingInWorkspace = stillRunning.some(
-    ({ executor }) => executor === EXPERIMENT_WORKSPACE_ID
-  )
-  for (const {
-    id: previouslyRunningId,
-    executor: previouslyRunningExecutor
-  } of previouslyRunning) {
     if (
-      isStillRunning(
-        stillExecutingInWorkspace,
-        previouslyRunningId,
-        previouslyRunningExecutor,
-        stillRunning
-      )
+      runningId === EXPERIMENT_WORKSPACE_ID ||
+      executor === Executor.DVC_TASK ||
+      previouslyRunning.some(({ id }) => id === runningId)
     ) {
       continue
     }
-
-    if (previouslyRunningExecutor === EXPERIMENT_WORKSPACE_ID) {
-      collectFinishedWorkspaceExperiment(
-        acc,
-        getMostRecentExperiment(experiments, coloredStatus)
-      )
-      continue
-    }
-    acc[previouslyRunningId] = previouslyRunningId
+    acc.add(runningId)
   }
+
   return acc
-}
-
-export type FetchedExperiment = { id?: string; displayColor: Color }
-
-export const hasFinishedWorkspaceExperiment = (
-  fetchedExperiments: FetchedExperiment[]
-): boolean => {
-  let workspace: FetchedExperiment | undefined
-  const nonWorkspace: FetchedExperiment[] = []
-
-  for (const revision of fetchedExperiments) {
-    if (revision.id === EXPERIMENT_WORKSPACE_ID) {
-      workspace = revision
-      continue
-    }
-    nonWorkspace.push(revision)
-  }
-
-  if (!workspace) {
-    return false
-  }
-
-  return nonWorkspace.some(
-    ({ displayColor }) => displayColor === workspace?.displayColor
-  )
 }

--- a/extension/src/plots/model/index.ts
+++ b/extension/src/plots/model/index.ts
@@ -112,8 +112,6 @@ export class PlotsModel extends ModelWithPersistence {
 
     this.fetchedRevs = new Set(revs)
 
-    this.experiments.setRevisionCollected(revs)
-
     this.deferred.resolve()
   }
 

--- a/extension/src/plots/webview/messages.ts
+++ b/extension/src/plots/webview/messages.ts
@@ -70,10 +70,6 @@ export class WebviewMessages {
       selectedRevisions,
       template: this.getTemplatePlots(selectedRevisions)
     })
-
-    this.experiments.checkForFinishedWorkspaceExperiment(
-      selectedRevisions.filter(({ fetched }) => fetched)
-    )
   }
 
   public handleMessageFromWebview(message: MessageFromWebview) {

--- a/extension/src/test/fixtures/expShow/base/rows.ts
+++ b/extension/src/test/fixtures/expShow/base/rows.ts
@@ -41,7 +41,7 @@ const data: Commit[] = [
         'c3961d777cfbd7727f9fde4851896006'
       )
     },
-    displayColor: colorsList[0],
+    displayColor: undefined,
     executor: Executor.WORKSPACE,
     id: EXPERIMENT_WORKSPACE_ID,
     label: EXPERIMENT_WORKSPACE_ID,
@@ -68,7 +68,7 @@ const data: Commit[] = [
       }
     },
     status: ExperimentStatus.RUNNING,
-    selected: true,
+    selected: false,
     starred: false
   },
   {
@@ -150,7 +150,7 @@ const data: Commit[] = [
             'c3961d777cfbd7727f9fde4851896006'
           )
         },
-        displayColor: colorsList[1],
+        displayColor: undefined,
         description: '[exp-e7a67]',
         executor: Executor.DVC_TASK,
         id: 'exp-e7a67',
@@ -179,7 +179,7 @@ const data: Commit[] = [
           }
         },
         status: ExperimentStatus.RUNNING,
-        selected: true,
+        selected: false,
         sha: '4fb124aebddb2adf1545030907687fa9a4c80e70',
         starred: false,
         Created: '2020-12-29T15:31:52'
@@ -266,7 +266,7 @@ const data: Commit[] = [
             'c3961d777cfbd7727f9fde4851896006'
           )
         },
-        displayColor: undefined,
+        displayColor: colorsList[0],
         description: '[exp-83425]',
         executor: Executor.WORKSPACE,
         id: 'exp-83425',
@@ -294,7 +294,7 @@ const data: Commit[] = [
             test: true
           }
         },
-        selected: false,
+        selected: true,
         starred: false,
         status: ExperimentStatus.RUNNING,
         Created: '2020-12-29T15:27:02'

--- a/extension/src/test/suite/plots/util.ts
+++ b/extension/src/test/suite/plots/util.ts
@@ -100,6 +100,7 @@ export const buildPlots = async (
     data,
     errorsModel,
     experiments,
+    experimentsModel,
     messageSpy,
     mockGetModifiedTime,
     mockPlotsDiff,


### PR DESCRIPTION
# 2/2 `main` <- #3665 <- this

This PR fixes the auto selection of running experiments. The new behaviour is as follows:

1. Experiments running in the workspace are automatically selected (not the workspace record).
2. Experiments running in the queue are not automatically selected.
3. Experiments running in the queue can no longer be selected through any other means (as calling plots diff with those revisions will cause an error).

This results in a good reduction in complexity. Once the prerequisites for #3436 land we can revisit.

### Demos

https://user-images.githubusercontent.com/37993418/232690382-b887d30c-bb7d-4b72-a59d-cf1b6bc7f16f.mov


https://user-images.githubusercontent.com/37993418/232690522-2e992e1b-8a9c-4868-ada1-3e0bd07b19bd.mov


