### PR TITLE
Avoid CSS element selection in table styles

### DIFF
--- a/webview/src/experiments/components/table/Cell.tsx
+++ b/webview/src/experiments/components/table/Cell.tsx
@@ -55,7 +55,7 @@ export const FirstCell: React.FC<
   const { toggleExperiment } = rowActionsProps
 
   return (
-    <td className={styles.experimentCell}>
+    <td className={cx(styles.td, styles.experimentCell)}>
       <div className={styles.innerCell} style={{ width: getSize() }}>
         <CellRowActions status={status} {...rowActionsProps} />
         <RowExpansionButton row={row} />
@@ -92,7 +92,7 @@ export const CellWrapper: React.FC<
 > = ({ cell, cellId, changes }) => {
   return (
     <td
-      className={cx({
+      className={cx(styles.td, {
         [styles.workspaceChangeText]: changes?.includes(cell.column.id),
         [styles.depChangeText]: cellHasChanges(cell.getValue() as CellValue)
       })}

--- a/webview/src/experiments/components/table/Cell.tsx
+++ b/webview/src/experiments/components/table/Cell.tsx
@@ -55,7 +55,7 @@ export const FirstCell: React.FC<
   const { toggleExperiment } = rowActionsProps
 
   return (
-    <td className={cx(styles.td, styles.experimentCell)}>
+    <td className={cx(styles.experimentsTd, styles.experimentCell)}>
       <div className={styles.innerCell} style={{ width: getSize() }}>
         <CellRowActions status={status} {...rowActionsProps} />
         <RowExpansionButton row={row} />
@@ -92,7 +92,7 @@ export const CellWrapper: React.FC<
 > = ({ cell, cellId, changes }) => {
   return (
     <td
-      className={cx(styles.td, {
+      className={cx(styles.experimentsTd, {
         [styles.workspaceChangeText]: changes?.includes(cell.column.id),
         [styles.depChangeText]: cellHasChanges(cell.getValue() as CellValue)
       })}

--- a/webview/src/experiments/components/table/Row.tsx
+++ b/webview/src/experiments/components/table/Row.tsx
@@ -44,7 +44,7 @@ const getRowClassNames = (
 ) => {
   return cx(
     className,
-    styles.tr,
+    styles.experimentsTr,
     styles.bodyRow,
     getExperimentTypeClass(original),
     cond(

--- a/webview/src/experiments/components/table/Table.tsx
+++ b/webview/src/experiments/components/table/Table.tsx
@@ -78,7 +78,7 @@ export const Table: React.FC<TableProps> = ({
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
       <table
         className={cx(
-          styles.table,
+          styles.experimentsTable,
           expColumnNeedsShadow && styles.withExpColumnShadow
         )}
         ref={tableRef}

--- a/webview/src/experiments/components/table/Table.tsx
+++ b/webview/src/experiments/components/table/Table.tsx
@@ -77,7 +77,10 @@ export const Table: React.FC<TableProps> = ({
     >
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
       <table
-        className={cx(expColumnNeedsShadow && styles.withExpColumnShadow)}
+        className={cx(
+          styles.table,
+          expColumnNeedsShadow && styles.withExpColumnShadow
+        )}
         ref={tableRef}
         onKeyUp={e => {
           if (e.key === 'Escape') {

--- a/webview/src/experiments/components/table/TableBody.tsx
+++ b/webview/src/experiments/components/table/TableBody.tsx
@@ -78,12 +78,12 @@ export const TableBody: React.FC<
     <>
       {row.index === 2 && row.depth === 0 && (
         <tbody>
-          <tr className={cx(styles.tr, styles.previousCommitsRow)}>
-            <td className={styles.td}>
+          <tr className={cx(styles.experimentsTr, styles.previousCommitsRow)}>
+            <td className={styles.experimentsTd}>
               {isBranchesView ? 'Other Branches' : 'Previous Commits'}
             </td>
             <td
-              className={styles.td}
+              className={styles.experimentsTd}
               colSpan={row.getAllCells().length - 1}
             ></td>
           </tr>

--- a/webview/src/experiments/components/table/TableBody.tsx
+++ b/webview/src/experiments/components/table/TableBody.tsx
@@ -78,9 +78,14 @@ export const TableBody: React.FC<
     <>
       {row.index === 2 && row.depth === 0 && (
         <tbody>
-          <tr className={styles.previousCommitsRow}>
-            <td>{isBranchesView ? 'Other Branches' : 'Previous Commits'}</td>
-            <td colSpan={row.getAllCells().length - 1}></td>
+          <tr className={cx(styles.tr, styles.previousCommitsRow)}>
+            <td className={styles.td}>
+              {isBranchesView ? 'Other Branches' : 'Previous Commits'}
+            </td>
+            <td
+              className={styles.td}
+              colSpan={row.getAllCells().length - 1}
+            ></td>
           </tr>
         </tbody>
       )}

--- a/webview/src/experiments/components/table/header/MergeHeaderGroups.tsx
+++ b/webview/src/experiments/components/table/header/MergeHeaderGroups.tsx
@@ -28,7 +28,7 @@ export const MergedHeaderGroups: React.FC<{
   onlyOneLine
 }) => {
   return (
-    <tr className={cx(styles.tr, styles.headRow)}>
+    <tr className={cx(styles.experimentsTr, styles.headRow)}>
       {headerGroup.headers.map((header: Header<Experiment, unknown>) => (
         <TableHeader
           setExpColumnNeedsShadow={setExpColumnNeedsShadow}

--- a/webview/src/experiments/components/table/header/MergeHeaderGroups.tsx
+++ b/webview/src/experiments/components/table/header/MergeHeaderGroups.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import cx from 'classnames'
 import { Experiment } from 'dvc/src/experiments/webview/contract'
 import { HeaderGroup, Header } from '@tanstack/react-table'
 import { TableHeader } from './TableHeader'
@@ -27,7 +28,7 @@ export const MergedHeaderGroups: React.FC<{
   onlyOneLine
 }) => {
   return (
-    <tr className={styles.headRow}>
+    <tr className={cx(styles.tr, styles.headRow)}>
       {headerGroup.headers.map((header: Header<Experiment, unknown>) => (
         <TableHeader
           setExpColumnNeedsShadow={setExpColumnNeedsShadow}

--- a/webview/src/experiments/components/table/header/TableHead.tsx
+++ b/webview/src/experiments/components/table/header/TableHead.tsx
@@ -13,6 +13,8 @@ import {
   isExperimentColumn
 } from '../../../util/columns'
 import { DragFunction } from '../../../../shared/components/dragDrop/Draggable'
+import styles from '../styles.module.scss'
+
 interface TableHeadProps {
   instance: Table<Experiment>
   root: HTMLElement | null
@@ -117,7 +119,7 @@ export const TableHead = ({
   }
 
   return (
-    <thead ref={wrapper}>
+    <thead className={styles.thead} ref={wrapper}>
       {headerGroups.map(headerGroup => (
         <MergedHeaderGroups
           key={headerGroup.id}

--- a/webview/src/experiments/components/table/header/TableHead.tsx
+++ b/webview/src/experiments/components/table/header/TableHead.tsx
@@ -119,7 +119,7 @@ export const TableHead = ({
   }
 
   return (
-    <thead className={styles.thead} ref={wrapper}>
+    <thead className={styles.experimentsThead} ref={wrapper}>
       {headerGroups.map(headerGroup => (
         <MergedHeaderGroups
           key={headerGroup.id}

--- a/webview/src/experiments/components/table/header/TableHeaderCell.tsx
+++ b/webview/src/experiments/components/table/header/TableHeaderCell.tsx
@@ -40,7 +40,7 @@ const getHeaderPropsArgs = (
   const columnWithGroup = header.column.columnDef as ColumnWithGroup
   return {
     className: cx(
-      styles.th,
+      styles.experimentsTh,
       header.isPlaceholder ? styles.placeholderHeaderCell : styles.headerCell,
       {
         [styles.paramHeaderCell]: columnWithGroup.group === ColumnType.PARAMS,

--- a/webview/src/experiments/components/table/header/TableHeaderCell.tsx
+++ b/webview/src/experiments/components/table/header/TableHeaderCell.tsx
@@ -40,6 +40,7 @@ const getHeaderPropsArgs = (
   const columnWithGroup = header.column.columnDef as ColumnWithGroup
   return {
     className: cx(
+      styles.th,
       header.isPlaceholder ? styles.placeholderHeaderCell : styles.headerCell,
       {
         [styles.paramHeaderCell]: columnWithGroup.group === ColumnType.PARAMS,

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -113,18 +113,18 @@ $badge-size: 0.85rem;
   flex-flow: column nowrap;
 }
 
-.table {
+.experimentsTable {
   display: inline-block;
   border-collapse: collapse;
 }
 
-.tr {
+.experimentsTr {
   position: relative;
   width: fit-content;
 }
 
-.td,
-.th {
+.experimentsTd,
+.experimentsTh {
   white-space: nowrap;
   min-width: 0;
   position: relative;
@@ -146,7 +146,7 @@ $badge-size: 0.85rem;
   }
 }
 
-.table.withExpColumnShadow .tr > *:first-child {
+.table.withExpColumnShadow .experimentsTr > *:first-child {
   &::after {
     box-shadow: 3px 0px 3px $shadow;
   }
@@ -209,7 +209,7 @@ $badge-size: 0.85rem;
   text-align: left;
 }
 
-.thead {
+.experimentsThead {
   background-color: $bg-color;
   transition: 0.25s all;
   box-shadow: none;
@@ -218,7 +218,7 @@ $badge-size: 0.85rem;
   z-index: 5;
 }
 
-.th {
+.experimentsTh {
   height: auto;
   background-color: $header-bg-color;
   font-size: 0.7rem;
@@ -413,8 +413,8 @@ $badge-size: 0.85rem;
   border-bottom: $row-border;
 
   &:hover {
-    .td:not(.experimentCell):hover::before,
-    .td:hover + .td::before {
+    .experimentsTd:not(.experimentCell):hover::before,
+    .experimentsTd:hover + .experimentsTd::before {
       background-color: $border-color;
     }
   }
@@ -429,7 +429,7 @@ $badge-size: 0.85rem;
   &.withShadow {
     box-shadow: 0 5px 8px -2px $shadow;
 
-    .tr {
+    .experimentsTr {
       border-bottom: none;
     }
   }
@@ -459,8 +459,8 @@ $badge-size: 0.85rem;
       pointer-events: none;
     }
 
-    .td:not(.experimentCell):hover::before,
-    .td:hover + .td::before {
+    .experimentsTd:not(.experimentCell):hover::before,
+    .experimentsTd:hover + .experimentsTd::before {
       background-color: $row-border-selected-color;
     }
   }
@@ -469,14 +469,14 @@ $badge-size: 0.85rem;
 .previousCommitsRow {
   border-bottom: $row-border;
 
-  .td {
+  .experimentsTd {
     font-size: 0.6rem;
     padding-left: 16px;
   }
 }
 
 .rowGroup:last-child {
-  & > .tr:last-child {
+  & > .experimentTr:last-child {
     border-color: $row-bg-color;
 
     &.rowSelected {
@@ -485,7 +485,7 @@ $badge-size: 0.85rem;
   }
 
   .experimentGroup {
-    &:last-child .tr:last-child {
+    &:last-child .experimentsTr:last-child {
       border-color: $row-bg-color;
 
       &.rowSelected {
@@ -495,7 +495,7 @@ $badge-size: 0.85rem;
   }
 }
 
-.td {
+.experimentsTd {
   height: auto;
   font-size: 0.8rem;
   line-height: 2rem;

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -113,18 +113,18 @@ $badge-size: 0.85rem;
   flex-flow: column nowrap;
 }
 
-table {
+.table {
   display: inline-block;
   border-collapse: collapse;
 }
 
-tr {
+.tr {
   position: relative;
   width: fit-content;
 }
 
-td,
-th {
+.td,
+.th {
   white-space: nowrap;
   min-width: 0;
   position: relative;
@@ -146,7 +146,7 @@ th {
   }
 }
 
-table.withExpColumnShadow tr > *:first-child {
+.table.withExpColumnShadow .tr > *:first-child {
   &::after {
     box-shadow: 3px 0px 3px $shadow;
   }
@@ -197,10 +197,6 @@ table.withExpColumnShadow tr > *:first-child {
   @extend %cellContentsBase;
 }
 
-ul {
-  padding-left: 1rem;
-}
-
 // table head styles
 
 .tableIndicators {
@@ -213,7 +209,7 @@ ul {
   text-align: left;
 }
 
-thead {
+.thead {
   background-color: $bg-color;
   transition: 0.25s all;
   box-shadow: none;
@@ -222,7 +218,7 @@ thead {
   z-index: 5;
 }
 
-th {
+.th {
   height: auto;
   background-color: $header-bg-color;
   font-size: 0.7rem;
@@ -417,8 +413,8 @@ th {
   border-bottom: $row-border;
 
   &:hover {
-    td:not(.experimentCell):hover::before,
-    td:hover + td::before {
+    .td:not(.experimentCell):hover::before,
+    .td:hover + .td::before {
       background-color: $border-color;
     }
   }
@@ -433,7 +429,7 @@ th {
   &.withShadow {
     box-shadow: 0 5px 8px -2px $shadow;
 
-    tr {
+    .tr {
       border-bottom: none;
     }
   }
@@ -463,19 +459,9 @@ th {
       pointer-events: none;
     }
 
-    td:not(.experimentCell):hover::before,
-    td:hover + td::before {
+    .td:not(.experimentCell):hover::before,
+    .td:hover + .td::before {
       background-color: $row-border-selected-color;
-    }
-  }
-}
-
-.nestedRow {
-  .experimentCell .innerCell {
-    padding-left: calc($nested-row-padding + $edge-padding);
-
-    .rowActions {
-      left: calc(($cell-padding + $nested-row-padding) * -1);
     }
   }
 }
@@ -483,14 +469,14 @@ th {
 .previousCommitsRow {
   border-bottom: $row-border;
 
-  td {
+  .td {
     font-size: 0.6rem;
     padding-left: 16px;
   }
 }
 
 .rowGroup:last-child {
-  & > tr:last-child {
+  & > .tr:last-child {
     border-color: $row-bg-color;
 
     &.rowSelected {
@@ -499,7 +485,7 @@ th {
   }
 
   .experimentGroup {
-    &:last-child tr:last-child {
+    &:last-child .tr:last-child {
       border-color: $row-bg-color;
 
       &.rowSelected {
@@ -509,7 +495,7 @@ th {
   }
 }
 
-td {
+.td {
   height: auto;
   font-size: 0.8rem;
   line-height: 2rem;
@@ -572,6 +558,10 @@ td {
     display: flex;
     flex-flow: row nowrap;
     justify-content: flex-start;
+
+    .nestedRow & {
+      padding-left: calc($nested-row-padding + $edge-padding);
+    }
   }
 }
 
@@ -584,6 +574,10 @@ td {
 
   &:first-child {
     margin-right: 20px;
+  }
+
+  .nestedRow & {
+    left: calc(($cell-padding + $nested-row-padding) * -1);
   }
 
   .indicatorIcon {


### PR DESCRIPTION
# 4/4 `main` <= #3667 <= #3674 <= #3681 <= this

Doing this fixes issues we have with storybook making component styles global ([see slack thread](https://iterativeai.slack.com/archives/C01RB7BTG4C/p1681749458147849)) and is a good practice in general (avoids accidental element selection and keeps specificity more equal across selectors). 

Part of #3597 