### PR TITLE
Prevent plotting of running experiments

### DIFF
--- a/extension/src/experiments/commands/register.ts
+++ b/extension/src/experiments/commands/register.ts
@@ -257,7 +257,7 @@ const registerExperimentQuickPickCommands = (
   internalCommands.registerExternalCommand(
     RegisteredCommands.EXPERIMENT_SELECT,
     (context: Context) =>
-      experiments.selectExperiments(getDvcRootFromContext(context))
+      experiments.selectExperimentsToPlot(getDvcRootFromContext(context))
   )
 
   internalCommands.registerExternalCommand(

--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -142,12 +142,12 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
     return this.getRepository(dvcRoot).removeSorts()
   }
 
-  public async selectExperiments(overrideRoot?: string) {
+  public async selectExperimentsToPlot(overrideRoot?: string) {
     const dvcRoot = await this.getDvcRoot(overrideRoot)
     if (!dvcRoot) {
       return
     }
-    return this.getRepository(dvcRoot).selectExperiments()
+    return this.getRepository(dvcRoot).selectExperimentsToPlot()
   }
 
   public async selectColumns(overrideRoot?: string) {

--- a/extension/src/plots/webview/messages.ts
+++ b/extension/src/plots/webview/messages.ts
@@ -220,7 +220,7 @@ export class WebviewMessages {
   }
 
   private selectExperimentsFromWebview() {
-    void this.experiments.selectExperiments()
+    void this.experiments.selectExperimentsToPlot()
     sendTelemetryEvent(
       EventName.VIEWS_PLOTS_SELECT_EXPERIMENTS,
       undefined,

--- a/extension/src/test/fixtures/expShow/base/rows.ts
+++ b/extension/src/test/fixtures/expShow/base/rows.ts
@@ -150,7 +150,7 @@ const data: Commit[] = [
             'c3961d777cfbd7727f9fde4851896006'
           )
         },
-        displayColor: colorsList[1],
+        displayColor: undefined,
         description: '[exp-e7a67]',
         executor: Executor.DVC_TASK,
         id: 'exp-e7a67',
@@ -179,7 +179,7 @@ const data: Commit[] = [
           }
         },
         status: ExperimentStatus.RUNNING,
-        selected: true,
+        selected: false,
         sha: '4fb124aebddb2adf1545030907687fa9a4c80e70',
         starred: false,
         Created: '2020-12-29T15:31:52'

--- a/extension/src/test/suite/experiments/model/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/tree.test.ts
@@ -38,6 +38,8 @@ import { EXPERIMENT_WORKSPACE_ID } from '../../../../cli/dvc/contract'
 import { DvcReader } from '../../../../cli/dvc/reader'
 import { copyOriginalColors } from '../../../../experiments/model/status/colors'
 import { Revision } from '../../../../plots/webview/contract'
+import { BaseWebview } from '../../../../webview'
+import { Experiment } from '../../../../experiments/webview/contract'
 
 suite('Experiments Tree Test Suite', () => {
   const disposable = getTimeSafeDisposer()
@@ -61,17 +63,21 @@ suite('Experiments Tree Test Suite', () => {
     it('should be able to toggle whether an experiment is shown in the plots webview with dvc.views.experiments.toggleStatus', async () => {
       const mockNow = getMockNow()
 
-      const { plots, messageSpy, plotsModel, experiments } = await buildPlots(
-        disposable
-      )
+      const { plots, messageSpy, plotsModel, experimentsModel } =
+        await buildPlots(disposable)
+      messageSpy.restore()
+      const mockShow = stub(BaseWebview.prototype, 'show')
+
+      experimentsModel.setSelected([
+        { id: EXPERIMENT_WORKSPACE_ID },
+        { id: 'main' },
+        { id: 'test-branch' },
+        { id: 'exp-f13bca' }
+      ] as Experiment[])
 
       const expectedRevisions: { displayColor: string; id: string }[] = []
 
       const [{ id }] = plotsModel.getSelectedRevisionDetails()
-      const mockCheckForFinishedWorkspaceExperiment = stub(
-        experiments,
-        'checkForFinishedWorkspaceExperiment'
-      )
 
       for (const {
         id,
@@ -86,7 +92,7 @@ suite('Experiments Tree Test Suite', () => {
 
       let updateCall = 1
       while (expectedRevisions.length > 0) {
-        const { selectedRevisions } = getFirstArgOfLastCall(messageSpy)
+        const { selectedRevisions } = mockShow.lastCall.firstArg
 
         expect(
           (selectedRevisions as Revision[]).map(({ displayColor, id }) => ({
@@ -95,16 +101,19 @@ suite('Experiments Tree Test Suite', () => {
           })),
           'a message is sent with colors for the currently selected experiments'
         ).to.deep.equal(expectedRevisions)
-        messageSpy.resetHistory()
+        mockShow.resetHistory()
+        mockShow.resetBehavior()
 
         const { id } = expectedRevisions.pop() as { id: string }
 
-        bypassProcessManagerDebounce(mockNow, updateCall)
         const messageSent = new Promise(resolve =>
-          mockCheckForFinishedWorkspaceExperiment.callsFake(() =>
+          mockShow.callsFake(() => {
             resolve(undefined)
-          )
+            return Promise.resolve(true)
+          })
         )
+
+        bypassProcessManagerDebounce(mockNow, updateCall)
         const unSelected = await commands.executeCommand(
           RegisteredCommands.EXPERIMENT_TOGGLE,
           {
@@ -116,16 +125,22 @@ suite('Experiments Tree Test Suite', () => {
 
         expect(unSelected).to.equal(UNSELECTED)
         await messageSent
-        mockCheckForFinishedWorkspaceExperiment.resetBehavior()
       }
 
       expect(
-        messageSpy,
+        mockShow,
         "when there are no experiments selected we don't send any template plots"
       ).to.be.calledWithMatch({
         template: null
       })
-      messageSpy.resetHistory()
+      mockShow.resetHistory()
+
+      const messageSent = new Promise(resolve =>
+        mockShow.callsFake(() => {
+          resolve(undefined)
+          return Promise.resolve(true)
+        })
+      )
 
       bypassProcessManagerDebounce(mockNow, updateCall)
       const selected = await commands.executeCommand(
@@ -135,6 +150,8 @@ suite('Experiments Tree Test Suite', () => {
           id
         }
       )
+
+      await messageSent
 
       expect(selected, 'the experiment is now selected').to.equal(
         copyOriginalColors()[0]

--- a/extension/src/test/suite/plots/index.test.ts
+++ b/extension/src/test/suite/plots/index.test.ts
@@ -496,7 +496,7 @@ suite('Plots Test Suite', () => {
 
       const mockSelectExperiments = stub(
         experiments,
-        'selectExperiments'
+        'selectExperimentsToPlot'
       ).resolves(undefined)
 
       const webview = await plots.showWebview()

--- a/extension/src/test/suite/plots/util.ts
+++ b/extension/src/test/suite/plots/util.ts
@@ -100,6 +100,7 @@ export const buildPlots = async (
     data,
     errorsModel,
     experiments,
+    experimentsModel,
     messageSpy,
     mockGetModifiedTime,
     mockPlotsDiff,


### PR DESCRIPTION
# 2/2 `main` <- #3665 <- this

Replaces #3705

This PR ensures that queued/running experiments cannot be selected for plotting. In the special case that an experiment is running in the workspace and the user tries to select that experiment for plotting the workspace will be selected.