### PR TITLE
Extend timeout of run experiment test (e2e)

### DIFF
--- a/extension/src/test/e2e/extension.test.ts
+++ b/extension/src/test/e2e/extension.test.ts
@@ -91,7 +91,7 @@ describe('Experiments Table Webview', function () {
   })
 
   it('should update with new data for each DVCLive step when an experiment is running', async function () {
-    this.timeout(180000)
+    this.timeout(210000)
     await runModifiedExperiment()
     await webview.focus()
 
@@ -102,7 +102,7 @@ describe('Experiments Table Webview', function () {
 
         return currentRows.length >= initialRows + experimentRow
       },
-      { interval: 5000, timeout: 180000 }
+      { interval: 5000, timeout: 210000 }
     )
 
     const currentRows = await webview.row$$
@@ -121,19 +121,15 @@ describe('Experiments Table Webview', function () {
 
         return step === epochs - 1
       },
-      { interval: 5000, timeout: 180000 }
+      { interval: 5000, timeout: 210000 }
     )
-
-    await webview.unfocus()
-    await waitForDvcToFinish()
-    await webview.focus()
 
     const finalRows = await webview.row$$
 
     expect(finalRows.length).toStrictEqual(initialRows + experimentRow)
     await webview.unfocus()
     await closeAllEditors()
-    await waitForDvcToFinish()
+    await waitForDvcToFinish(90000)
     const workbench = await browser.getWorkbench()
     return workbench.executeCommand('Terminal: Kill All Terminals')
   })

--- a/extension/src/test/e2e/util.ts
+++ b/extension/src/test/e2e/util.ts
@@ -34,9 +34,9 @@ const dvcIsWorking = async (): Promise<boolean> => {
   )
 }
 
-export const waitForDvcToFinish = async (): Promise<void> => {
+export const waitForDvcToFinish = async (timeout = 60000): Promise<void> => {
   await browser.waitUntil(async () => !(await dvcIsWorking()), {
-    timeout: 60000
+    timeout
   })
 }
 


### PR DESCRIPTION
# 2/2 `main` <- #3665 <- this

An attempt to fix the flaky e2e test (works fine locally).