### PR TITLE
Fix experiment id for commits (shown in plots)

### DIFF
--- a/extension/src/experiments/model/collect.ts
+++ b/extension/src/experiments/model/collect.ts
@@ -171,11 +171,11 @@ const collectExpState = (
   commitData: { [sha: string]: CommitData }
 ): Experiment | undefined => {
   const { rev, name } = expState
-  const id = name || rev
   const label =
     rev === EXPERIMENT_WORKSPACE_ID
       ? EXPERIMENT_WORKSPACE_ID
       : name || shortenForLabel(rev)
+  const id = name || label
 
   const experiment: Experiment = { id, label }
 

--- a/extension/src/test/fixtures/expShow/survival/rows.ts
+++ b/extension/src/test/fixtures/expShow/survival/rows.ts
@@ -316,7 +316,7 @@ const data: Commit[] = [
     starred: false
   },
   {
-    id: 'a49e03966a1f9f1299ec222ebc4bed8625d2c54d',
+    id: 'a49e039',
     label: 'a49e039',
     sha: 'a49e03966a1f9f1299ec222ebc4bed8625d2c54d',
     Created: '2021-07-16T19:50:39',
@@ -473,7 +473,7 @@ const data: Commit[] = [
     starred: false
   },
   {
-    id: '4f7b50c3d171a11b6cfcd04416a16fc80b61018d',
+    id: '4f7b50c',
     label: '4f7b50c',
     sha: '4f7b50c3d171a11b6cfcd04416a16fc80b61018d',
     Created: '2021-07-16T19:48:45',


### PR DESCRIPTION
# 2/2 `main` <- #3665 <- this

This PR fixes commits' experiment id. Previously the sha was taken as the ID leading to the full sha being shown in the plots webview.

### Screenshot

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/37993418/233244301-34b27825-bd6f-4d72-84bd-c45fcd56544e.png">
