### PR TITLE
Give the multiview template extra large sizes for each layer

### DIFF
--- a/extension/src/plots/model/collect.ts
+++ b/extension/src/plots/model/collect.ts
@@ -319,7 +319,10 @@ const fillTemplate = (
   datapoints: unknown[]
 ): TopLevelSpec => {
   return JSON.parse(
-    template.replace('"<DVC_METRIC_DATA>"', JSON.stringify(datapoints))
+    template
+      .replace('"<DVC_METRIC_DATA>"', JSON.stringify(datapoints))
+      .replace('"width":300', '"width":3000')
+      .replace('"height":300', '"height":3000')
   ) as TopLevelSpec
 }
 


### PR DESCRIPTION
Quick prototype for #3757 

https://user-images.githubusercontent.com/3683420/234377937-9a5ab1d9-08ad-4e95-9729-f73fa23d64b3.mov

Because we scale down the plot when its layers have 300x300 dimensions, the hypothesis here is that by giving it a very large size, it will also scale down. The problem with this solution, is that there aren't just plots layers inside of this plot. The legends and labels need to be scaled down by a lot to show the big plots.

This is the same thing that's actually happening when the size is 300, but it's less apparent because 300 is a small value and it's easier to fit in the rest (scaling down to 280 will make the legend and labels still scale down only a little as well. Scaling down from 3000 to 500 is a lot to compensate and for VegaLite to find room for other items. We could go for something smaller than 3000, but it's impossible to find the perfect value (big screens vs small screens).

I'll try making this dynamic next.

