### PR TITLE
Stub dvc config calls in integration tests

### DIFF
--- a/extension/src/test/suite/extension.test.ts
+++ b/extension/src/test/suite/extension.test.ts
@@ -94,6 +94,7 @@ suite('Extension Test Suite', () => {
       const mockExpShow = stub(DvcReader.prototype, 'expShow')
       const mockDataStatus = stub(DvcReader.prototype, 'dataStatus')
       const mockPlotsDiff = stub(DvcReader.prototype, 'plotsDiff')
+      stub(DvcExecutor.prototype, 'config').resolves('')
 
       stub(DvcReader.prototype, 'root').resolves('.')
 

--- a/extension/src/test/suite/setup/util.ts
+++ b/extension/src/test/suite/setup/util.ts
@@ -33,6 +33,7 @@ export const buildSetup = (
     messageSpy,
     resourceLocator,
     internalCommands,
+    dvcExecutor,
     dvcReader,
     gitExecutor,
     gitReader
@@ -78,6 +79,8 @@ export const buildSetup = (
     })
   )
 
+  stub(dvcExecutor, 'config').resolves('')
+
   const setup = disposer.track(
     new Setup(
       config,
@@ -118,6 +121,7 @@ export const buildSetup = (
 export const buildSetupWithWatchers = async (disposer: Disposer) => {
   const mockEmitter = disposer.track(new EventEmitter())
   const mockInternalCommands = {
+    executeCommand: stub(),
     registerExternalCliCommand: stub(),
     registerExternalCommand: stub()
   } as unknown as InternalCommands


### PR DESCRIPTION
# 4/6 `main` <-  #3768 <- #3701 <- #3771 <- this <- #3778 <- #3779

This PR stubs calls made to `dvc config` within the integration test suite.