### PR TITLE
Rename exp commands to closer match CLI

### DIFF
--- a/extension/src/cli/dvc/executor.test.ts
+++ b/extension/src/cli/dvc/executor.test.ts
@@ -238,13 +238,13 @@ describe('CliExecutor', () => {
     })
   })
 
-  describe('experimentApply', () => {
+  describe('expApply', () => {
     it('should call createProcess with the correct parameters to apply an existing experiment to the workspace', async () => {
       const cwd = ''
       const stdout = 'Test output that will be passed along'
       mockedCreateProcess.mockReturnValueOnce(getMockedProcess(stdout))
 
-      const output = await dvcExecutor.experimentApply(cwd, 'exp-test')
+      const output = await dvcExecutor.expApply(cwd, 'exp-test')
       expect(output).toStrictEqual(stdout)
 
       expect(mockedCreateProcess).toHaveBeenCalledWith({
@@ -256,7 +256,7 @@ describe('CliExecutor', () => {
     })
   })
 
-  describe('experimentBranch', () => {
+  describe('expBranch', () => {
     it('should call createProcess with the correct parameters to create a new branch from an existing experiment', async () => {
       const cwd = __dirname
       const stdout =
@@ -265,7 +265,7 @@ describe('CliExecutor', () => {
         '\t\tgit checkout some-branch'
       mockedCreateProcess.mockReturnValueOnce(getMockedProcess(stdout))
 
-      const output = await dvcExecutor.experimentBranch(
+      const output = await dvcExecutor.expBranch(
         cwd,
         'exp-0898f',
         'some-branch'
@@ -281,7 +281,7 @@ describe('CliExecutor', () => {
     })
   })
 
-  describe('experimentGarbageCollect', () => {
+  describe('expGarbageCollect', () => {
     it('should call createProcess with the correct parameters to garbage collect experiments', async () => {
       const cwd = __dirname
       const stdout =
@@ -290,7 +290,7 @@ describe('CliExecutor', () => {
         "Removed 45 experiments. To remove unused cache files use 'dvc gc'. "
       mockedCreateProcess.mockReturnValueOnce(getMockedProcess(stdout))
 
-      const output = await dvcExecutor.experimentGarbageCollect(
+      const output = await dvcExecutor.expGarbageCollect(
         cwd,
         GcPreserveFlag.WORKSPACE,
         GcPreserveFlag.QUEUED
@@ -306,13 +306,13 @@ describe('CliExecutor', () => {
     })
   })
 
-  describe('experimentPush', () => {
+  describe('expPush', () => {
     it('should call createProcess with the correct parameters to push an existing experiment to the remote', async () => {
       const cwd = __dirname
       const stdout = ''
       mockedCreateProcess.mockReturnValueOnce(getMockedProcess(stdout))
 
-      const output = await dvcExecutor.experimentPush(cwd, 'toric-sail')
+      const output = await dvcExecutor.expPush(cwd, 'toric-sail')
       expect(output).toStrictEqual(stdout)
 
       expect(mockedCreateProcess).toHaveBeenCalledWith({
@@ -324,13 +324,13 @@ describe('CliExecutor', () => {
     })
   })
 
-  describe('experimentRemove', () => {
+  describe('expRemove', () => {
     it('should call createProcess with the correct parameters to remove an existing experiment from the workspace', async () => {
       const cwd = __dirname
       const stdout = ''
       mockedCreateProcess.mockReturnValueOnce(getMockedProcess(stdout))
 
-      const output = await dvcExecutor.experimentRemove(cwd, 'exp-dfd12')
+      const output = await dvcExecutor.expRemove(cwd, 'exp-dfd12')
       expect(output).toStrictEqual(stdout)
 
       expect(mockedCreateProcess).toHaveBeenCalledWith({
@@ -342,13 +342,13 @@ describe('CliExecutor', () => {
     })
   })
 
-  describe('experimentRemoveQueue', () => {
+  describe('expRemoveQueue', () => {
     it('should call createProcess with the correct parameters to remove all existing queued experiments from the workspace', async () => {
       const cwd = __dirname
       const stdout = ''
       mockedCreateProcess.mockReturnValueOnce(getMockedProcess(stdout))
 
-      const output = await dvcExecutor.experimentRemoveQueue(cwd)
+      const output = await dvcExecutor.expRemoveQueue(cwd)
       expect(output).toStrictEqual(stdout)
 
       expect(mockedCreateProcess).toHaveBeenCalledWith({
@@ -360,13 +360,13 @@ describe('CliExecutor', () => {
     })
   })
 
-  describe('experimentRunQueue', () => {
+  describe('expRunQueue', () => {
     it('should call createProcess with the correct parameters to queue an experiment for later execution', async () => {
       const cwd = __dirname
       const stdout = "Queued experiment 'bbf5c01' for future execution."
       mockedCreateProcess.mockReturnValueOnce(getMockedProcess(stdout))
 
-      const output = await dvcExecutor.experimentRunQueue(cwd)
+      const output = await dvcExecutor.expRunQueue(cwd)
       expect(output).toStrictEqual(stdout)
 
       expect(mockedCreateProcess).toHaveBeenCalledWith({

--- a/extension/src/cli/dvc/executor.ts
+++ b/extension/src/cli/dvc/executor.ts
@@ -20,13 +20,13 @@ export const autoRegisteredCommands = {
   CHECKOUT: 'checkout',
   COMMIT: 'commit',
   CONFIG: 'config',
-  EXPERIMENT_APPLY: 'experimentApply',
-  EXPERIMENT_BRANCH: 'experimentBranch',
-  EXPERIMENT_GARBAGE_COLLECT: 'experimentGarbageCollect',
-  EXPERIMENT_PUSH: 'experimentPush',
-  EXPERIMENT_QUEUE: 'experimentRunQueue',
-  EXPERIMENT_REMOVE: 'experimentRemove',
-  EXPERIMENT_REMOVE_QUEUE: 'experimentRemoveQueue',
+  EXP_APPLY: 'expApply',
+  EXP_BRANCH: 'expBranch',
+  EXP_GARBAGE_COLLECT: 'expGarbageCollect',
+  EXP_PUSH: 'expPush',
+  EXP_QUEUE: 'expRunQueue',
+  EXP_REMOVE: 'expRemove',
+  EXP_REMOVE_QUEUE: 'expRemoveQueue',
   INIT: 'init',
   IS_SCM_COMMAND_RUNNING: 'isScmCommandRunning',
   MOVE: 'move',
@@ -78,7 +78,7 @@ export class DvcExecutor extends DvcCli {
     return this.executeDvcProcess(cwd, Command.CONFIG, ...args)
   }
 
-  public experimentApply(cwd: string, experimentName: string) {
+  public expApply(cwd: string, experimentName: string) {
     return this.executeExperimentProcess(
       cwd,
       ExperimentSubCommand.APPLY,
@@ -86,11 +86,7 @@ export class DvcExecutor extends DvcCli {
     )
   }
 
-  public experimentBranch(
-    cwd: string,
-    experimentName: string,
-    branchName: string
-  ) {
+  public expBranch(cwd: string, experimentName: string, branchName: string) {
     return this.executeExperimentProcess(
       cwd,
       ExperimentSubCommand.BRANCH,
@@ -99,10 +95,7 @@ export class DvcExecutor extends DvcCli {
     )
   }
 
-  public experimentGarbageCollect(
-    cwd: string,
-    ...preserveFlags: GcPreserveFlag[]
-  ) {
+  public expGarbageCollect(cwd: string, ...preserveFlags: GcPreserveFlag[]) {
     return this.executeExperimentProcess(
       cwd,
       ExperimentSubCommand.GARBAGE_COLLECT,
@@ -111,7 +104,7 @@ export class DvcExecutor extends DvcCli {
     )
   }
 
-  public experimentPush(cwd: string, id: string) {
+  public expPush(cwd: string, id: string) {
     return this.executeExperimentProcess(
       cwd,
       ExperimentSubCommand.PUSH,
@@ -120,7 +113,7 @@ export class DvcExecutor extends DvcCli {
     )
   }
 
-  public experimentRemove(cwd: string, ...experimentNames: string[]) {
+  public expRemove(cwd: string, ...experimentNames: string[]) {
     return this.executeExperimentProcess(
       cwd,
       ExperimentSubCommand.REMOVE,
@@ -128,11 +121,11 @@ export class DvcExecutor extends DvcCli {
     )
   }
 
-  public experimentRemoveQueue(cwd: string) {
-    return this.experimentRemove(cwd, ExperimentFlag.QUEUE)
+  public expRemoveQueue(cwd: string) {
+    return this.expRemove(cwd, ExperimentFlag.QUEUE)
   }
 
-  public experimentRunQueue(cwd: string, ...args: Args) {
+  public expRunQueue(cwd: string, ...args: Args) {
     return this.executeExperimentProcess(
       cwd,
       ExperimentSubCommand.RUN,

--- a/extension/src/experiments/commands/index.ts
+++ b/extension/src/experiments/commands/index.ts
@@ -8,12 +8,7 @@ import { RegisteredCommands } from '../../commands/external'
 export const getBranchExperimentCommand =
   (experiments: WorkspaceExperiments) =>
   (cwd: string, name: string, input: string) =>
-    experiments.runCommand(
-      AvailableCommands.EXPERIMENT_BRANCH,
-      cwd,
-      name,
-      input
-    )
+    experiments.runCommand(AvailableCommands.EXP_BRANCH, cwd, name, input)
 
 export const getShareExperimentToStudioCommand =
   (internalCommands: InternalCommands, setup: Setup) =>
@@ -31,7 +26,7 @@ export const getShareExperimentToStudioCommand =
       await Toast.runCommandAndIncrementProgress(
         () =>
           internalCommands.executeCommand(
-            AvailableCommands.EXPERIMENT_PUSH,
+            AvailableCommands.EXP_PUSH,
             dvcRoot,
             id
           ),

--- a/extension/src/experiments/commands/register.ts
+++ b/extension/src/experiments/commands/register.ts
@@ -24,7 +24,7 @@ const registerExperimentCwdCommands = (
     RegisteredCliCommands.QUEUE_EXPERIMENT,
     () =>
       experiments.pauseUpdatesThenRun(() =>
-        experiments.getCwdThenReport(AvailableCommands.EXPERIMENT_QUEUE)
+        experiments.getCwdThenReport(AvailableCommands.EXP_QUEUE)
       )
   )
 
@@ -110,8 +110,7 @@ const registerExperimentCwdCommands = (
 
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.EXPERIMENT_REMOVE_QUEUE,
-    () =>
-      experiments.getCwdThenReport(AvailableCommands.EXPERIMENT_REMOVE_QUEUE)
+    () => experiments.getCwdThenReport(AvailableCommands.EXP_REMOVE_QUEUE)
   )
 }
 
@@ -121,24 +120,19 @@ const registerExperimentNameCommands = (
 ): void => {
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.EXPERIMENT_APPLY,
-    () =>
-      experiments.getCwdAndExpNameThenRun(AvailableCommands.EXPERIMENT_APPLY)
+    () => experiments.getCwdAndExpNameThenRun(AvailableCommands.EXP_APPLY)
   )
 
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.EXPERIMENT_VIEW_APPLY,
     ({ dvcRoot, id }: ExperimentDetails) =>
-      experiments.runCommand(AvailableCommands.EXPERIMENT_APPLY, dvcRoot, id)
+      experiments.runCommand(AvailableCommands.EXP_APPLY, dvcRoot, id)
   )
 
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.EXPERIMENT_VIEW_REMOVE,
     ({ dvcRoot, ids }: { dvcRoot: string; ids: string[] }) =>
-      experiments.runCommand(
-        AvailableCommands.EXPERIMENT_REMOVE,
-        dvcRoot,
-        ...ids
-      )
+      experiments.runCommand(AvailableCommands.EXP_REMOVE, dvcRoot, ...ids)
   )
 }
 
@@ -175,7 +169,7 @@ const registerExperimentQuickPickCommands = (
     RegisteredCliCommands.EXPERIMENT_GARBAGE_COLLECT,
     () =>
       experiments.getCwdAndQuickPickThenRun(
-        AvailableCommands.EXPERIMENT_GARBAGE_COLLECT,
+        AvailableCommands.EXP_GARBAGE_COLLECT,
         pickGarbageCollectionFlags
       )
   )

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -477,7 +477,7 @@ export class Experiments extends BaseRepository<TableData> {
 
     await Toast.showOutput(
       this.internalCommands.executeCommand<string>(
-        AvailableCommands.EXPERIMENT_QUEUE,
+        AvailableCommands.EXP_QUEUE,
         this.dvcRoot,
         ...paramsToModify
       )

--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -185,11 +185,7 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
       return
     }
 
-    return this.runCommand(
-      AvailableCommands.EXPERIMENT_REMOVE,
-      cwd,
-      ...experimentIds
-    )
+    return this.runCommand(AvailableCommands.EXP_REMOVE, cwd, ...experimentIds)
   }
 
   public async modifyExperimentParamsAndRun(

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -551,7 +551,7 @@ suite('Experiments Test Suite', () => {
 
       const mockExperimentApply = stub(
         DvcExecutor.prototype,
-        'experimentApply'
+        'expApply'
       ).resolves(undefined)
 
       stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
@@ -577,7 +577,7 @@ suite('Experiments Test Suite', () => {
 
       const mockExperimentBranch = stub(
         DvcExecutor.prototype,
-        'experimentBranch'
+        'expBranch'
       ).resolves('undefined')
 
       stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
@@ -675,9 +675,9 @@ suite('Experiments Test Suite', () => {
           return 'isat_token'
         })
       )
-      const mockExperimentPush = stub(DvcExecutor.prototype, 'experimentPush')
+      const mockexpPush = stub(DvcExecutor.prototype, 'expPush')
       const commandExecuted = new Promise(resolve =>
-        mockExperimentPush.callsFake(() => {
+        mockexpPush.callsFake(() => {
           resolve(undefined)
           return Promise.resolve(
             `Pushed experiment ${mockExpId} to Git remote 'origin'`
@@ -692,7 +692,7 @@ suite('Experiments Test Suite', () => {
 
       await Promise.all([tokenFound, commandExecuted])
 
-      expect(mockExperimentPush).to.be.calledWithExactly(dvcDemoPath, mockExpId)
+      expect(mockexpPush).to.be.calledWithExactly(dvcDemoPath, mockExpId)
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it("should be able to handle a message to modify an experiment's params and queue an experiment", async () => {
@@ -709,10 +709,9 @@ suite('Experiments Test Suite', () => {
       stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
       stub(experiments, 'pickAndModifyParams').resolves(mockModifiedParams)
-      const mockQueueExperiment = stub(
-        dvcExecutor,
-        'experimentRunQueue'
-      ).resolves(undefined)
+      const mockQueueExperiment = stub(dvcExecutor, 'expRunQueue').resolves(
+        undefined
+      )
 
       const webview = await experiments.showWebview()
       const mockMessageReceived = getMessageReceivedEmitter(webview)
@@ -817,7 +816,7 @@ suite('Experiments Test Suite', () => {
 
       const mockExperimentRemove = stub(
         DvcExecutor.prototype,
-        'experimentRemove'
+        'expRemove'
       ).resolves(undefined)
 
       mockMessageReceived.fire({

--- a/extension/src/test/suite/experiments/model/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/tree.test.ts
@@ -256,7 +256,7 @@ suite('Experiments Tree Test Suite', () => {
 
       const mockExperimentRemove = stub(
         DvcExecutor.prototype,
-        'experimentRemove'
+        'expRemove'
       ).resolves('')
 
       stubPrivatePrototypeMethod(
@@ -280,7 +280,7 @@ suite('Experiments Tree Test Suite', () => {
 
       const mockExperimentRemove = stub(
         DvcExecutor.prototype,
-        'experimentRemove'
+        'expRemove'
       ).resolves('')
 
       stubPrivatePrototypeMethod(
@@ -309,7 +309,7 @@ suite('Experiments Tree Test Suite', () => {
 
       const mockExperimentRemove = stub(
         DvcExecutor.prototype,
-        'experimentRemove'
+        'expRemove'
       ).resolves('')
 
       stubPrivatePrototypeMethod(
@@ -354,7 +354,7 @@ suite('Experiments Tree Test Suite', () => {
 
       const mockExperimentApply = stub(
         DvcExecutor.prototype,
-        'experimentApply'
+        'expApply'
       ).resolves(
         `Changes for experiment '${mockExperimentId}' have been applied to your current workspace.`
       )
@@ -378,10 +378,7 @@ suite('Experiments Tree Test Suite', () => {
       const { experiments } = buildExperiments(disposable)
       await experiments.isReady()
 
-      const mockExperimentBranch = stub(
-        DvcExecutor.prototype,
-        'experimentBranch'
-      )
+      const mockExperimentBranch = stub(DvcExecutor.prototype, 'expBranch')
       const mockShowInputBox = stub(window, 'showInputBox').resolves(undefined)
       stub(WorkspaceExperiments.prototype, 'getRepository').returns(experiments)
 
@@ -406,7 +403,7 @@ suite('Experiments Tree Test Suite', () => {
 
       const mockExperimentBranch = stub(
         DvcExecutor.prototype,
-        'experimentBranch'
+        'expBranch'
       ).resolves(
         `Git branch '${mockBranch}' has been created from experiment '${mockExperimentId}'.        
        To switch to the new branch run:
@@ -440,10 +437,9 @@ suite('Experiments Tree Test Suite', () => {
 
       await experiments.isReady()
 
-      const mockExperimentRunQueue = stub(
-        dvcExecutor,
-        'experimentRunQueue'
-      ).resolves('true')
+      const mockExperimentRunQueue = stub(dvcExecutor, 'expRunQueue').resolves(
+        'true'
+      )
 
       const [mockGetOnlyOrPickProject] = stubWorkspaceExperimentsGetters(
         '',

--- a/extension/src/test/suite/experiments/workspace.test.ts
+++ b/extension/src/test/suite/experiments/workspace.test.ts
@@ -154,10 +154,9 @@ suite('Workspace Experiments Test Suite', () => {
 
       const { dvcExecutor, experiments } = buildExperiments(disposable)
 
-      const mockExperimentRunQueue = stub(
-        dvcExecutor,
-        'experimentRunQueue'
-      ).resolves('true')
+      const mockExperimentRunQueue = stub(dvcExecutor, 'expRunQueue').resolves(
+        'true'
+      )
 
       stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
@@ -325,7 +324,7 @@ suite('Workspace Experiments Test Suite', () => {
 
       const mockExperimentRunQueue = stub(
         DvcExecutor.prototype,
-        'experimentRunQueue'
+        'expRunQueue'
       ).resolves('true')
 
       stubWorkspaceExperimentsGetters(dvcDemoPath)
@@ -339,7 +338,7 @@ suite('Workspace Experiments Test Suite', () => {
     it('should send a telemetry event containing a duration when an experiment is queued', async () => {
       stub(DvcReader.prototype, 'listStages').resolves('train')
 
-      stub(DvcExecutor.prototype, 'experimentRunQueue').resolves('true')
+      stub(DvcExecutor.prototype, 'expRunQueue').resolves('true')
 
       const mockSendTelemetryEvent = stub(Telemetry, 'sendTelemetryEvent')
 
@@ -371,7 +370,7 @@ suite('Workspace Experiments Test Suite', () => {
         undefined
       )
 
-      stub(DvcExecutor.prototype, 'experimentRunQueue').callsFake(() => {
+      stub(DvcExecutor.prototype, 'expRunQueue').callsFake(() => {
         throw new Error(mockErrorMessage)
       })
 
@@ -554,7 +553,7 @@ suite('Workspace Experiments Test Suite', () => {
       const mockShowQuickPick = stub(window, 'showQuickPick').resolves({
         value: selectedExperiment
       } as QuickPickItemWithValue<string>)
-      const mockExperimentApply = stub(DvcExecutor.prototype, 'experimentApply')
+      const mockExperimentApply = stub(DvcExecutor.prototype, 'expApply')
 
       await commands.executeCommand(RegisteredCliCommands.EXPERIMENT_APPLY)
 
@@ -638,7 +637,7 @@ suite('Workspace Experiments Test Suite', () => {
 
       const mockExperimentBranch = stub(
         DvcExecutor.prototype,
-        'experimentBranch'
+        'expBranch'
       ).resolves(
         `Git branch '${mockBranch}' has been created from experiment '${testExperiment}'.        
      To switch to the new branch run:
@@ -691,10 +690,7 @@ suite('Workspace Experiments Test Suite', () => {
             value: secondMockExperimentId
           }
         ] as QuickPickReturnValue)
-      const mockExperimentRemove = stub(
-        DvcExecutor.prototype,
-        'experimentRemove'
-      )
+      const mockExperimentRemove = stub(DvcExecutor.prototype, 'expRemove')
 
       await commands.executeCommand(RegisteredCliCommands.EXPERIMENT_REMOVE)
       expect(mockShowQuickPick).calledWithExactly(
@@ -786,10 +782,7 @@ suite('Workspace Experiments Test Suite', () => {
 
       stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
-      const mockExperimentRemove = stub(
-        DvcExecutor.prototype,
-        'experimentRemove'
-      )
+      const mockExperimentRemove = stub(DvcExecutor.prototype, 'expRemove')
 
       await commands.executeCommand(
         RegisteredCliCommands.EXPERIMENT_REMOVE_QUEUE


### PR DESCRIPTION
# 5/6 `main` <-  #3768 <- #3701 <- #3771 <- #3777 <- this <- #3779

This PR renames the `exp` commands in the `DvcExecutor` to more closely match the corresponding CLI commands.