### PR TITLE
Add GIT_TERMINAL_PROMPT=0 to DVC environment variables

### DIFF
--- a/extension/src/cli/dvc/executor.test.ts
+++ b/extension/src/cli/dvc/executor.test.ts
@@ -24,6 +24,7 @@ const mockedGetProcessEnv = jest.mocked(getProcessEnv)
 const mockedEnv = {
   DVCLIVE_OPEN: 'false',
   DVC_NO_ANALYTICS: 'true',
+  GIT_TERMINAL_PROMPT: '0',
   PATH: '/some/special/path'
 }
 

--- a/extension/src/cli/dvc/index.test.ts
+++ b/extension/src/cli/dvc/index.test.ts
@@ -86,7 +86,12 @@ describe('executeDvcProcess', () => {
     expect(mockedCreateProcess).toHaveBeenCalledWith({
       args,
       cwd,
-      env: { ...processEnv, DVCLIVE_OPEN: 'false', DVC_NO_ANALYTICS: 'true' },
+      env: {
+        ...processEnv,
+        DVCLIVE_OPEN: 'false',
+        DVC_NO_ANALYTICS: 'true',
+        GIT_TERMINAL_PROMPT: '0'
+      },
       executable: 'dvc'
     })
   })
@@ -129,6 +134,7 @@ describe('executeDvcProcess', () => {
       env: {
         DVCLIVE_OPEN: 'false',
         DVC_NO_ANALYTICS: 'true',
+        GIT_TERMINAL_PROMPT: '0',
         PATH: joinEnvPath('/some/path/to', existingPath),
         SECRET_KEY
       },

--- a/extension/src/cli/dvc/options.test.ts
+++ b/extension/src/cli/dvc/options.test.ts
@@ -11,6 +11,7 @@ const mockedPATH = '/some/special/path'
 const mockedEnv = {
   DVCLIVE_OPEN: 'false',
   DVC_NO_ANALYTICS: 'true',
+  GIT_TERMINAL_PROMPT: '0',
   PATH: mockedPATH
 }
 const mockedGetProcessEnv = jest.mocked(getProcessEnv)
@@ -42,6 +43,7 @@ describe('getOptions', () => {
       env: {
         DVCLIVE_OPEN: 'false',
         DVC_NO_ANALYTICS: 'true',
+        GIT_TERMINAL_PROMPT: '0',
         PATH: joinEnvPath(join('path', 'to', 'python', '.venv'), mockedPATH)
       },
       executable: pythonBinPath
@@ -58,6 +60,7 @@ describe('getOptions', () => {
       env: {
         DVCLIVE_OPEN: 'false',
         DVC_NO_ANALYTICS: 'true',
+        GIT_TERMINAL_PROMPT: '0',
         PATH: joinEnvPath(join('path', 'to', 'python', '.venv'), mockedPATH)
       },
       executable: cliPath

--- a/extension/src/cli/dvc/options.ts
+++ b/extension/src/cli/dvc/options.ts
@@ -21,6 +21,7 @@ const getEnv = (pythonBinPath?: string): NodeJS.ProcessEnv => {
     ...env,
     DVCLIVE_OPEN: 'false',
     DVC_NO_ANALYTICS: 'true',
+    GIT_TERMINAL_PROMPT: '0',
     PATH
   }
 }

--- a/extension/src/cli/dvc/reader.test.ts
+++ b/extension/src/cli/dvc/reader.test.ts
@@ -28,6 +28,7 @@ const mockedGetProcessEnv = jest.mocked(getProcessEnv)
 const mockedEnv = {
   DVCLIVE_OPEN: 'false',
   DVC_NO_ANALYTICS: 'true',
+  GIT_TERMINAL_PROMPT: '0',
   PATH: '/all/of/the/goodies:/in/my/path'
 }
 const JSON_FLAG = '--json'


### PR DESCRIPTION
# 6/6 `main` <-  #3768 <- #3701 <- #3771 <- #3777 <- #3778 <- this

Follow up to https://github.com/iterative/dvc/issues/9339.

This PR adds `GIT_TERMINAL_PROMPT: '0'` to the environment variables when calling DVC. This will stop the process from hanging whilst waiting for the user to enter credentials. For more details read the above issue 🙏🏻. 

Git docs are [here](https://git-scm.com/docs/git#Documentation/git.txt-codeGITTERMINALPROMPTcode).