### PR TITLE
Ensure duplicate colors are not made available during collection

### DIFF
--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -79,10 +79,8 @@ export class ExperimentsModel extends ModelWithPersistence {
         []
       )
     )
-    this.coloredStatus = this.revive<ColoredStatus>(
-      PersistenceKey.EXPERIMENTS_STATUS,
-      {}
-    )
+
+    this.coloredStatus = this.reviveColoredStatus()
     this.starredExperiments = this.revive<StarredExperiments>(
       PersistenceKey.EXPERIMENTS_STARS,
       {}
@@ -581,5 +579,21 @@ export class ExperimentsModel extends ModelWithPersistence {
         acc.filter(item => item.displayColor === orderedItem)
       )
       .filter(Boolean)
+  }
+
+  private reviveColoredStatus() {
+    const uniqueStatus: ColoredStatus = {}
+    const colors = new Set<Color>()
+    for (const [id, color] of Object.entries(
+      this.revive<ColoredStatus>(PersistenceKey.EXPERIMENTS_STATUS, {})
+    )) {
+      if (color) {
+        uniqueStatus[id] = colors.has(color) ? UNSELECTED : color
+        colors.add(color)
+        continue
+      }
+      uniqueStatus[id] = UNSELECTED
+    }
+    return uniqueStatus
   }
 }

--- a/extension/src/experiments/model/status/collect.test.ts
+++ b/extension/src/experiments/model/status/collect.test.ts
@@ -303,7 +303,44 @@ describe('collectColoredStatus', () => {
       workspace: colors[0]
     })
 
-    expect(availableColors).toStrictEqual(colors.slice(1))
+    expect(availableColors).toStrictEqual(
+      colors.filter(color => ![colors[2], colors[0]].includes(color))
+    )
+  })
+
+  it('should prevent colors being available when they are already assigned', () => {
+    const colors = copyOriginalColors()
+    const selectedColor = colors[2]
+    const { availableColors, coloredStatus } = collectColoredStatus(
+      [
+        {
+          executor: null,
+          id: 'exp-1',
+          status: ExperimentStatus.SUCCESS
+        },
+        {
+          id: EXPERIMENT_WORKSPACE_ID
+        },
+        { id: 'main' }
+      ] as Experiment[],
+      new Map(),
+      {
+        'exp-1': selectedColor,
+        workspace: UNSELECTED
+      },
+      colors,
+      new Set(),
+      { 'exp-1': EXPERIMENT_WORKSPACE_ID }
+    )
+    expect(coloredStatus).toStrictEqual({
+      'exp-1': selectedColor,
+      main: UNSELECTED,
+      workspace: UNSELECTED
+    })
+
+    expect(availableColors).toStrictEqual(
+      colors.filter(color => color !== selectedColor)
+    )
   })
 })
 


### PR DESCRIPTION
Fixes https://github.com/iterative/vscode-dvc/issues/3758

I think the issue was caused by a color being inadvertently made available twice/duplicated. Once this happened the color selection model completely breaks. I was unable to recreate locally but I have added tests around the issue and also made sure that we completely fix any existing issue when the user reloads VS Code.