### PR TITLE
Display progress errors to users

### DIFF
--- a/extension/src/setup/autoInstall.ts
+++ b/extension/src/setup/autoInstall.ts
@@ -23,25 +23,33 @@ const showInstallProgress = (
   Toast.showProgress('Installing packages', async progress => {
     progress.report({ increment: 0 })
 
-    await Toast.runCommandAndIncrementProgress(
-      async () => {
-        await installPackages(root, pythonBinPath, 'dvclive')
-        return 'DVCLive Installed'
-      },
-      progress,
-      25
-    )
+    try {
+      await Toast.runCommandAndIncrementProgress(
+        async () => {
+          await installPackages(root, pythonBinPath, 'dvclive')
+          return 'DVCLive Installed'
+        },
+        progress,
+        25
+      )
+    } catch (error: unknown) {
+      return Toast.reportProgressError(error, progress)
+    }
 
-    await Toast.runCommandAndIncrementProgress(
-      async () => {
-        await installPackages(root, pythonBinPath, 'dvc')
-        return 'DVC Installed'
-      },
-      progress,
-      75
-    )
+    try {
+      await Toast.runCommandAndIncrementProgress(
+        async () => {
+          await installPackages(root, pythonBinPath, 'dvc')
+          return 'DVC Installed'
+        },
+        progress,
+        75
+      )
 
-    return Toast.delayProgressClosing()
+      return Toast.delayProgressClosing()
+    } catch (error: unknown) {
+      return Toast.reportProgressError(error, progress)
+    }
   })
 
 export const autoInstallDvc = async (): Promise<unknown> => {

--- a/extension/src/vscode/toast.ts
+++ b/extension/src/vscode/toast.ts
@@ -75,6 +75,22 @@ export class Toast {
     })
   }
 
+  static reportProgressError(
+    error: unknown,
+    progress: Progress<{
+      message?: string | undefined
+      increment?: number | undefined
+    }>
+  ) {
+    const message = (error as Error)?.message || 'an unexpected error occurred'
+
+    progress.report({
+      increment: 0,
+      message
+    })
+    return Toast.delayProgressClosing(60000)
+  }
+
   static delayProgressClosing(ms = 5000) {
     return delay(ms)
   }


### PR DESCRIPTION
This PR adds some code around handling errors that occur whilst we are displaying progress notifications to the user. We only need to handle these errors under the circumstances that the underlying command is not registered as a CLI command through `InternalCommands`.