### PR TITLE
Add multi-select versions of exp push

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -512,6 +512,12 @@
         "icon": "$(repo-push)"
       },
       {
+        "title": "Push",
+        "command": "dvc.views.experimentsTree.pushExperiment",
+        "category": "DVC",
+        "icon": "$(repo-push)"
+      },
+      {
         "title": "Show Logs",
         "command": "dvc.views.experiments.showLogs",
         "category": "DVC"
@@ -864,6 +870,14 @@
           "when": "false"
         },
         {
+          "command": "dvc.views.experiments.pushExperiment",
+          "when": "false"
+        },
+        {
+          "command": "dvc.views.experimentsTree.pushExperiment",
+          "when": "false"
+        },
+        {
           "command": "dvc.views.experiments.queueExperiment",
           "when": "false"
         },
@@ -885,10 +899,6 @@
         },
         {
           "command": "dvc.views.experiments.resetAndRunCheckpointExperiment",
-          "when": "false"
-        },
-        {
-          "command": "dvc.views.experiments.pushExperiment",
           "when": "false"
         },
         {
@@ -1152,7 +1162,7 @@
           "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem =~ /^(experiment|queued)$/ && !dvc.experiment.running"
         },
         {
-          "command": "dvc.views.experiments.pushExperiment",
+          "command": "dvc.views.experimentsTree.pushExperiment",
           "group": "1_share@0",
           "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem == experiment && !dvc.experiment.running"
         },

--- a/extension/src/experiments/commands/index.ts
+++ b/extension/src/experiments/commands/index.ts
@@ -44,7 +44,7 @@ const convertUrlTextToLink = (stdout: string) => {
 
 export const getPushExperimentCommand =
   (internalCommands: InternalCommands, setup: Setup) =>
-  ({ dvcRoot, id }: { dvcRoot: string; id: string }) => {
+  ({ dvcRoot, ids }: { dvcRoot: string; ids: string[] }) => {
     const studioAccessToken = setup.getStudioAccessToken()
     if (
       !(
@@ -58,14 +58,14 @@ export const getPushExperimentCommand =
     return Toast.showProgress('exp push', async progress => {
       progress.report({ increment: 0 })
 
-      progress.report({ increment: 25, message: `Pushing ${id}...` })
+      progress.report({ increment: 25, message: `Pushing ${ids.join(' ')}...` })
 
       const remainingProgress = 75
 
       const stdout = await internalCommands.executeCommand(
         AvailableCommands.EXP_PUSH,
         dvcRoot,
-        id
+        ...ids
       )
 
       progress.report({

--- a/extension/src/experiments/model/collect.ts
+++ b/extension/src/experiments/model/collect.ts
@@ -328,10 +328,10 @@ export const collectExperiments = (
   return acc
 }
 
-type DeletableExperimentAccumulator = { [dvcRoot: string]: Set<string> }
+type ExperimentTypesAccumulator = { [dvcRoot: string]: Set<string> }
 
 const initializeAccumulatorRoot = (
-  acc: DeletableExperimentAccumulator,
+  acc: ExperimentTypesAccumulator,
   dvcRoot: string
 ) => {
   if (!acc[dvcRoot]) {
@@ -340,12 +340,12 @@ const initializeAccumulatorRoot = (
 }
 
 const collectExperimentItem = (
-  acc: DeletableExperimentAccumulator,
-  deletable: Set<string>,
+  acc: ExperimentTypesAccumulator,
+  types: Set<string>,
   experimentItem: ExperimentItem
 ) => {
   const { dvcRoot, type, id, label } = experimentItem
-  if (!deletable.has(type)) {
+  if (!types.has(type)) {
     return
   }
   initializeAccumulatorRoot(acc, dvcRoot)
@@ -357,18 +357,17 @@ const collectExperimentItem = (
   acc[dvcRoot].add(id)
 }
 
-export const collectDeletable = (
-  experimentItems: (string | ExperimentItem)[]
-): DeletableExperimentAccumulator => {
-  const deletable = new Set([ExperimentType.EXPERIMENT, ExperimentType.QUEUED])
-
-  const acc: DeletableExperimentAccumulator = {}
+export const collectExperimentType = (
+  experimentItems: (string | ExperimentItem)[],
+  types: Set<ExperimentType>
+): ExperimentTypesAccumulator => {
+  const acc: ExperimentTypesAccumulator = {}
   for (const experimentItem of experimentItems) {
     if (typeof experimentItem === 'string') {
       continue
     }
 
-    collectExperimentItem(acc, deletable, experimentItem)
+    collectExperimentItem(acc, types, experimentItem)
   }
 
   return acc

--- a/extension/src/experiments/webview/messages.ts
+++ b/extension/src/experiments/webview/messages.ts
@@ -197,7 +197,7 @@ export class WebviewMessages {
       case MessageFromWebviewType.PUSH_EXPERIMENT:
         return commands.executeCommand(
           RegisteredCliCommands.EXPERIMENT_VIEW_PUSH,
-          { dvcRoot: this.dvcRoot, id: message.payload }
+          { dvcRoot: this.dvcRoot, ids: message.payload }
         )
 
       case MessageFromWebviewType.SHOW_EXPERIMENT_LOGS:

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -671,7 +671,7 @@ suite('Experiments Test Suite', () => {
       )
 
       mockMessageReceived.fire({
-        payload: mockExpId,
+        payload: [mockExpId],
         type: MessageFromWebviewType.PUSH_EXPERIMENT
       })
 
@@ -712,7 +712,7 @@ suite('Experiments Test Suite', () => {
       )
 
       mockMessageReceived.fire({
-        payload: mockExpId,
+        payload: [mockExpId],
         type: MessageFromWebviewType.PUSH_EXPERIMENT
       })
 

--- a/extension/src/webview/contract.ts
+++ b/extension/src/webview/contract.ts
@@ -155,7 +155,7 @@ export type MessageFromWebview =
   | { type: MessageFromWebviewType.SHOW_EXPERIMENT_LOGS; payload: string }
   | {
       type: MessageFromWebviewType.PUSH_EXPERIMENT
-      payload: string
+      payload: string[]
     }
   | {
       type: MessageFromWebviewType.REMOVE_COLUMN_SORT

--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -801,6 +801,7 @@ describe('App', () => {
     })
   })
 
+  // eslint-disable-next-line sonarjs/cognitive-complexity
   describe('Row Context Menu', () => {
     beforeAll(() => {
       jest.useFakeTimers()
@@ -932,7 +933,7 @@ describe('App', () => {
       expect(itemLabels).toContain('Remove')
     })
 
-    it('should present the Remove option if multiple checkpoint tip rows are selected', () => {
+    it('should present the remove option if only experiments are selected', () => {
       renderTableWithoutRunningExperiments()
 
       clickRowCheckbox('4fb124a')
@@ -944,10 +945,10 @@ describe('App', () => {
       advanceTimersByTime(100)
       const menuitems = screen.getAllByRole('menuitem')
       const itemLabels = menuitems.map(item => item.textContent)
-      expect(itemLabels).toContain('Remove Selected Rows')
+      expect(itemLabels).toContain('Remove Selected')
 
       const removeOption = menuitems.find(item =>
-        item.textContent?.includes('Remove Selected Rows')
+        item.textContent?.includes('Remove Selected')
       )
 
       expect(removeOption).toBeDefined()
@@ -957,6 +958,34 @@ describe('App', () => {
       expect(sendMessage).toHaveBeenCalledWith({
         payload: ['exp-e7a67', 'test-branch'],
         type: MessageFromWebviewType.REMOVE_EXPERIMENT
+      })
+    })
+
+    it('should present the push option if only experiments are selected', () => {
+      renderTableWithoutRunningExperiments()
+
+      clickRowCheckbox('4fb124a')
+      clickRowCheckbox('42b8736')
+
+      const target = screen.getByText('4fb124a')
+      fireEvent.contextMenu(target, { bubbles: true })
+
+      advanceTimersByTime(100)
+      const menuitems = screen.getAllByRole('menuitem')
+      const itemLabels = menuitems.map(item => item.textContent)
+      expect(itemLabels).toContain('Push Selected')
+
+      const pushOption = menuitems.find(item =>
+        item.textContent?.includes('Push Selected')
+      )
+
+      expect(pushOption).toBeDefined()
+
+      pushOption && fireEvent.click(pushOption)
+
+      expect(sendMessage).toHaveBeenCalledWith({
+        payload: ['exp-e7a67', 'test-branch'],
+        type: MessageFromWebviewType.PUSH_EXPERIMENT
       })
     })
 
@@ -1034,7 +1063,7 @@ describe('App', () => {
       shareOption && fireEvent.click(shareOption)
 
       expect(sendMessage).toHaveBeenCalledWith({
-        payload: 'exp-e7a67',
+        payload: ['exp-e7a67'],
         type: MessageFromWebviewType.PUSH_EXPERIMENT
       })
     })
@@ -1106,8 +1135,13 @@ describe('App', () => {
       fireEvent.contextMenu(target, { bubbles: true })
 
       advanceTimersByTime(100)
-      const clearOption = screen.getByText('Clear row selection')
-      fireEvent.click(clearOption)
+
+      const menuitems = screen.getAllByRole('menuitem')
+
+      const clearOption = menuitems.find(item =>
+        item.textContent?.includes('Clear')
+      )
+      clearOption && fireEvent.click(clearOption)
 
       advanceTimersByTime(100)
       expect(selectedRows().length).toBe(0)

--- a/webview/src/experiments/components/table/body/RowContextMenu.tsx
+++ b/webview/src/experiments/components/table/body/RowContextMenu.tsx
@@ -50,12 +50,12 @@ const getMultiSelectMenuOptions = (
 
   const selectedIds = selectedRowsList.map(value => value.row.original.id)
 
-  const removableRowIds = selectedRowsList
+  const experimentRowIds = selectedRowsList
     .filter(value => value.row.depth === 1)
     .map(value => value.row.original.id)
 
-  const hideRemoveOption =
-    removableRowIds.length !== selectedRowsList.length || hasRunningExperiment
+  const hideExperimentOnlyOption =
+    experimentRowIds.length !== selectedRowsList.length || hasRunningExperiment
 
   const stoppableRows = selectedRowsList
     .filter(value => isRunning(value.row.original.status))
@@ -105,17 +105,24 @@ const getMultiSelectMenuOptions = (
       true
     ),
     experimentMenuOption(
-      removableRowIds,
-      'Remove Selected Rows',
+      experimentRowIds,
+      'Push Selected',
+      MessageFromWebviewType.PUSH_EXPERIMENT,
+      hideExperimentOnlyOption,
+      true
+    ),
+    experimentMenuOption(
+      experimentRowIds,
+      'Remove Selected',
       MessageFromWebviewType.REMOVE_EXPERIMENT,
-      hideRemoveOption,
+      hideExperimentOnlyOption,
       true
     ),
     {
       divider: true,
       id: 'clear-selection',
       keyboardShortcut: 'Esc',
-      label: 'Clear row selection'
+      label: 'Clear'
     }
   ]
 }
@@ -200,9 +207,11 @@ const getSingleSelectMenuOptions = (
       'Create new Branch',
       MessageFromWebviewType.CREATE_BRANCH_FROM_EXPERIMENT
     ),
-    hideIfRunningOrNotExperiment(
+    experimentMenuOption(
+      [id],
       'Push',
       MessageFromWebviewType.PUSH_EXPERIMENT,
+      isNotExperiment,
       true
     ),
     ...getRunResumeOptions(


### PR DESCRIPTION
# 2/3 `main` <- #3781 <- this <- #3793

Relates to #3574.

This PR gives users the ability to push multiple experiments at the same time.

### Demo

https://user-images.githubusercontent.com/37993418/235396270-ca4a28ca-7281-43ba-a9a9-a8de07af8d06.mov


