### PR TITLE
Show terminal when queueing grid search

### DIFF
--- a/extension/src/cli/dvc/runner.ts
+++ b/extension/src/cli/dvc/runner.ts
@@ -22,8 +22,9 @@ import {
 } from '../util'
 
 export const autoRegisteredCommands = {
-  EXPERIMENT_RESET_AND_RUN: 'runExperimentReset',
-  EXPERIMENT_RUN: 'runExperiment'
+  EXP_RESET_AND_RUN: 'runExperimentReset',
+  EXP_RUN: 'runExperiment',
+  EXP_RUN_QUEUE: 'runQueue'
 } as const
 
 export class DvcRunner extends Disposable implements ICli {
@@ -101,6 +102,10 @@ export class DvcRunner extends Disposable implements ICli {
 
   public runExperimentReset(dvcRoot: string, ...args: Args) {
     return this.runExperiment(dvcRoot, ExperimentFlag.RESET, ...args)
+  }
+
+  public runQueue(dvcRoot: string, ...args: Args) {
+    return this.runExperiment(dvcRoot, ExperimentFlag.QUEUE, ...args)
   }
 
   public async run(cwd: string, ...args: Args) {

--- a/extension/src/experiments/commands/register.ts
+++ b/extension/src/experiments/commands/register.ts
@@ -48,7 +48,7 @@ const registerExperimentCwdCommands = (
 
   const modifyExperimentParamsAndRun = () =>
     experiments.pauseUpdatesThenRun(() =>
-      experiments.modifyExperimentParamsAndRun(AvailableCommands.EXPERIMENT_RUN)
+      experiments.modifyExperimentParamsAndRun(AvailableCommands.EXP_RUN)
     )
 
   internalCommands.registerExternalCliCommand(
@@ -67,7 +67,7 @@ const registerExperimentCwdCommands = (
   }: ExperimentDetails) =>
     experiments.pauseUpdatesThenRun(() =>
       experiments.modifyExperimentParamsAndRun(
-        AvailableCommands.EXPERIMENT_RUN,
+        AvailableCommands.EXP_RUN,
         dvcRoot,
         id
       )
@@ -88,7 +88,7 @@ const registerExperimentCwdCommands = (
     () =>
       experiments.pauseUpdatesThenRun(() =>
         experiments.modifyExperimentParamsAndRun(
-          AvailableCommands.EXPERIMENT_RESET_AND_RUN
+          AvailableCommands.EXP_RESET_AND_RUN
         )
       )
   )
@@ -98,7 +98,7 @@ const registerExperimentCwdCommands = (
     ({ dvcRoot, id }: ExperimentDetails) =>
       experiments.pauseUpdatesThenRun(() =>
         experiments.modifyExperimentParamsAndRun(
-          AvailableCommands.EXPERIMENT_RESET_AND_RUN,
+          AvailableCommands.EXP_RESET_AND_RUN,
           dvcRoot,
           id
         )
@@ -240,19 +240,19 @@ const registerExperimentRunCommands = (
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.EXPERIMENT_RUN,
     showSetupOrExecuteCommand(setup, () =>
-      experiments.getCwdThenRun(AvailableCommands.EXPERIMENT_RUN)
+      experiments.getCwdThenRun(AvailableCommands.EXP_RUN)
     )
   )
 
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.EXPERIMENT_RESUME,
-    () => experiments.getCwdThenRun(AvailableCommands.EXPERIMENT_RUN)
+    () => experiments.getCwdThenRun(AvailableCommands.EXP_RUN)
   )
 
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.EXPERIMENT_RESET_AND_RUN,
     showSetupOrExecuteCommand(setup, () =>
-      experiments.getCwdThenRun(AvailableCommands.EXPERIMENT_RESET_AND_RUN)
+      experiments.getCwdThenRun(AvailableCommands.EXP_RESET_AND_RUN)
     )
   )
 

--- a/extension/src/experiments/workspace.test.ts
+++ b/extension/src/experiments/workspace.test.ts
@@ -71,9 +71,8 @@ describe('Experiments', () => {
     mockedExpFunc(...args)
   )
 
-  mockedInternalCommands.registerCommand(
-    AvailableCommands.EXPERIMENT_RUN,
-    (...args) => mockedRun(...args)
+  mockedInternalCommands.registerCommand(AvailableCommands.EXP_RUN, (...args) =>
+    mockedRun(...args)
   )
 
   mockedInternalCommands.registerCommand(AvailableCommands.STAGE_LIST, () =>

--- a/extension/src/test/suite/experiments/workspace.test.ts
+++ b/extension/src/test/suite/experiments/workspace.test.ts
@@ -142,7 +142,7 @@ suite('Workspace Experiments Test Suite', () => {
       ).resolves(undefined)
 
       stub(DvcReader.prototype, 'listStages').resolves('train')
-      await workspaceExperiments.getCwdThenRun(AvailableCommands.EXPERIMENT_RUN)
+      await workspaceExperiments.getCwdThenRun(AvailableCommands.EXP_RUN)
 
       expect(mockQuickPickOne).not.to.be.calledOnce
       expect(mockRunExperiment).to.be.calledWith(dvcDemoPath)


### PR DESCRIPTION
### Demo


https://user-images.githubusercontent.com/37993418/235824871-68a6e65d-c16e-4889-9f5c-446b73b244b2.mov

Still not sure that we need this as the table is being updated as every experiment is queued and we do have a spinner at the bottom of the IDE