### PR TITLE
Remove pausing of data updates when running/queueing experiments

### DIFF
--- a/extension/src/data/index.ts
+++ b/extension/src/data/index.ts
@@ -33,7 +33,6 @@ export abstract class BaseData<
   constructor(
     dvcRoot: string,
     internalCommands: InternalCommands,
-    updatesPaused: EventEmitter<boolean>,
     updateProcesses: { name: string; process: () => Promise<unknown> }[],
     staticFiles: string[] = []
   ) {
@@ -41,7 +40,7 @@ export abstract class BaseData<
 
     this.dvcRoot = dvcRoot
     this.processManager = this.dispose.track(
-      new ProcessManager(updatesPaused, ...updateProcesses)
+      new ProcessManager(...updateProcesses)
     )
     this.internalCommands = internalCommands
     this.onDidUpdate = this.updated.event

--- a/extension/src/experiments/commands/register.ts
+++ b/extension/src/experiments/commands/register.ts
@@ -19,10 +19,7 @@ const registerExperimentCwdCommands = (
 ): void => {
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.QUEUE_EXPERIMENT,
-    () =>
-      experiments.pauseUpdatesThenRun(() =>
-        experiments.getCwdThenReport(AvailableCommands.EXP_QUEUE)
-      )
+    () => experiments.getCwdThenReport(AvailableCommands.EXP_QUEUE)
   )
 
   internalCommands.registerExternalCliCommand(
@@ -32,24 +29,17 @@ const registerExperimentCwdCommands = (
 
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.MODIFY_EXPERIMENT_PARAMS_AND_QUEUE,
-    () =>
-      experiments.pauseUpdatesThenRun(() =>
-        experiments.modifyExperimentParamsAndQueue()
-      )
+    () => experiments.modifyExperimentParamsAndQueue()
   )
 
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.EXPERIMENT_VIEW_QUEUE,
     ({ dvcRoot, id }: ExperimentDetails) =>
-      experiments.pauseUpdatesThenRun(() =>
-        experiments.modifyExperimentParamsAndQueue(dvcRoot, id)
-      )
+      experiments.modifyExperimentParamsAndQueue(dvcRoot, id)
   )
 
   const modifyExperimentParamsAndRun = () =>
-    experiments.pauseUpdatesThenRun(() =>
-      experiments.modifyExperimentParamsAndRun(AvailableCommands.EXPERIMENT_RUN)
-    )
+    experiments.modifyExperimentParamsAndRun(AvailableCommands.EXPERIMENT_RUN)
 
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.MODIFY_EXPERIMENT_PARAMS_AND_RESUME,
@@ -65,12 +55,10 @@ const registerExperimentCwdCommands = (
     dvcRoot,
     id
   }: ExperimentDetails) =>
-    experiments.pauseUpdatesThenRun(() =>
-      experiments.modifyExperimentParamsAndRun(
-        AvailableCommands.EXPERIMENT_RUN,
-        dvcRoot,
-        id
-      )
+    experiments.modifyExperimentParamsAndRun(
+      AvailableCommands.EXPERIMENT_RUN,
+      dvcRoot,
+      id
     )
 
   internalCommands.registerExternalCliCommand(
@@ -86,22 +74,18 @@ const registerExperimentCwdCommands = (
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.MODIFY_EXPERIMENT_PARAMS_RESET_AND_RUN,
     () =>
-      experiments.pauseUpdatesThenRun(() =>
-        experiments.modifyExperimentParamsAndRun(
-          AvailableCommands.EXPERIMENT_RESET_AND_RUN
-        )
+      experiments.modifyExperimentParamsAndRun(
+        AvailableCommands.EXPERIMENT_RESET_AND_RUN
       )
   )
 
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.EXPERIMENT_VIEW_RESET_AND_RUN,
     ({ dvcRoot, id }: ExperimentDetails) =>
-      experiments.pauseUpdatesThenRun(() =>
-        experiments.modifyExperimentParamsAndRun(
-          AvailableCommands.EXPERIMENT_RESET_AND_RUN,
-          dvcRoot,
-          id
-        )
+      experiments.modifyExperimentParamsAndRun(
+        AvailableCommands.EXPERIMENT_RESET_AND_RUN,
+        dvcRoot,
+        id
       )
   )
 

--- a/extension/src/experiments/data/index.ts
+++ b/extension/src/experiments/data/index.ts
@@ -1,5 +1,4 @@
 import { join } from 'path'
-import { EventEmitter } from 'vscode'
 import { collectFiles } from './collect'
 import {
   EXPERIMENTS_GIT_LOGS_REFS,
@@ -24,13 +23,11 @@ export class ExperimentsData extends BaseData<ExpShowOutput> {
   constructor(
     dvcRoot: string,
     internalCommands: InternalCommands,
-    updatesPaused: EventEmitter<boolean>,
     experiments: ExperimentsModel
   ) {
     super(
       dvcRoot,
       internalCommands,
-      updatesPaused,
       [{ name: 'update', process: () => this.update() }],
       ['dvc.lock', 'dvc.yaml', 'params.yaml', DOT_DVC]
     )

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -111,7 +111,6 @@ export class Experiments extends BaseRepository<TableData> {
   constructor(
     dvcRoot: string,
     internalCommands: InternalCommands,
-    updatesPaused: EventEmitter<boolean>,
     resourceLocator: ResourceLocator,
     workspaceState: Memento,
     addStage: () => Promise<boolean>,
@@ -150,13 +149,7 @@ export class Experiments extends BaseRepository<TableData> {
     )
 
     this.data = this.dispose.track(
-      data ||
-        new ExperimentsData(
-          dvcRoot,
-          internalCommands,
-          updatesPaused,
-          this.experiments
-        )
+      data || new ExperimentsData(dvcRoot, internalCommands, this.experiments)
     )
 
     this.dispose.track(this.data.onDidUpdate(data => this.setState(data)))

--- a/extension/src/experiments/workspace.test.ts
+++ b/extension/src/experiments/workspace.test.ts
@@ -85,11 +85,8 @@ describe('Experiments', () => {
     () => mockedGetBranches()
   )
 
-  const mockedUpdatesPaused = buildMockedEventEmitter<boolean>()
-
   const workspaceExperiments = new WorkspaceExperiments(
     mockedInternalCommands,
-    mockedUpdatesPaused,
     buildMockMemento(),
     {
       '/my/dvc/root': {
@@ -134,19 +131,6 @@ describe('Experiments', () => {
       await workspaceExperiments.getCwdThenReport(mockedCommandId)
 
       expect(mockedExpFunc).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('pauseUpdatesThenRun', () => {
-    it('should pause updates, run the function and then flush the queue', async () => {
-      const mockedFunc = jest.fn()
-
-      await workspaceExperiments.pauseUpdatesThenRun(mockedFunc)
-
-      expect(mockedUpdatesPaused.fire).toHaveBeenCalledTimes(2)
-      expect(mockedUpdatesPaused.fire).toHaveBeenCalledWith(true)
-      expect(mockedUpdatesPaused.fire).toHaveBeenLastCalledWith(false)
-      expect(mockedFunc).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -59,22 +59,17 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
     new EventEmitter<void>()
   )
 
-  public readonly updatesPaused: EventEmitter<boolean>
-
   private readonly checkpointsChanged: EventEmitter<void>
 
   private focusedParamsDvcRoot: string | undefined
 
   constructor(
     internalCommands: InternalCommands,
-    updatesPaused: EventEmitter<boolean>,
     workspaceState: Memento,
     experiments?: Record<string, Experiments>,
     checkpointsChanged?: EventEmitter<void>
   ) {
     super(internalCommands, workspaceState, experiments)
-
-    this.updatesPaused = updatesPaused
 
     this.checkpointsChanged = this.dispose.track(
       checkpointsChanged || new EventEmitter()
@@ -210,12 +205,6 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
     return this.internalCommands.executeCommand(commandId, cwd)
   }
 
-  public async pauseUpdatesThenRun(func: () => Promise<void> | undefined) {
-    this.updatesPaused.fire(true)
-    await func()
-    this.updatesPaused.fire(false)
-  }
-
   public getCwdThenReport(commandId: CommandId) {
     return Toast.showOutput(this.getCwdThenRun(commandId))
   }
@@ -293,16 +282,11 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
     )
   }
 
-  public createRepository(
-    dvcRoot: string,
-    updatesPaused: EventEmitter<boolean>,
-    resourceLocator: ResourceLocator
-  ) {
+  public createRepository(dvcRoot: string, resourceLocator: ResourceLocator) {
     const experiments = this.dispose.track(
       new Experiments(
         dvcRoot,
         this.internalCommands,
-        updatesPaused,
         resourceLocator,
         this.workspaceState,
         () => this.checkOrAddPipeline(dvcRoot),

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -1,10 +1,4 @@
-import {
-  commands,
-  env,
-  EventEmitter,
-  ExtensionContext,
-  ViewColumn
-} from 'vscode'
+import { commands, env, ExtensionContext, ViewColumn } from 'vscode'
 import { DvcExecutor } from './cli/dvc/executor'
 import { DvcRunner } from './cli/dvc/runner'
 import { DvcReader } from './cli/dvc/reader'
@@ -73,10 +67,6 @@ export class Extension extends Disposable {
   private readonly gitExecutor: GitExecutor
   private readonly gitReader: GitReader
 
-  private updatesPaused: EventEmitter<boolean> = this.dispose.track(
-    new EventEmitter<boolean>()
-  )
-
   constructor(context: ExtensionContext) {
     super()
 
@@ -130,11 +120,7 @@ export class Extension extends Disposable {
     const status = this.dispose.track(new Status(config, ...clis))
 
     this.experiments = this.dispose.track(
-      new WorkspaceExperiments(
-        this.internalCommands,
-        this.updatesPaused,
-        context.workspaceState
-      )
+      new WorkspaceExperiments(this.internalCommands, context.workspaceState)
     )
 
     this.plots = this.dispose.track(
@@ -290,20 +276,11 @@ export class Extension extends Disposable {
     this.resetMembers()
 
     await Promise.all([
-      this.repositories.create(this.getRoots(), this.updatesPaused),
+      this.repositories.create(this.getRoots()),
       this.repositoriesTree.initialize(this.getRoots()),
-      this.experiments.create(
-        this.getRoots(),
-        this.updatesPaused,
-        this.resourceLocator
-      )
+      this.experiments.create(this.getRoots(), this.resourceLocator)
     ])
-    this.plots.create(
-      this.getRoots(),
-      this.updatesPaused,
-      this.resourceLocator,
-      this.experiments
-    )
+    this.plots.create(this.getRoots(), this.resourceLocator, this.experiments)
 
     return Promise.all([
       this.repositories.isReady(),

--- a/extension/src/plots/data/index.ts
+++ b/extension/src/plots/data/index.ts
@@ -26,13 +26,11 @@ export class PlotsData extends BaseData<{
   constructor(
     dvcRoot: string,
     internalCommands: InternalCommands,
-    model: PlotsModel,
-    updatesPaused: EventEmitter<boolean>
+    model: PlotsModel
   ) {
     super(
       dvcRoot,
       internalCommands,
-      updatesPaused,
       [
         {
           name: 'update',

--- a/extension/src/plots/index.ts
+++ b/extension/src/plots/index.ts
@@ -45,7 +45,6 @@ export class Plots extends BaseRepository<TPlotsData> {
     dvcRoot: string,
     internalCommands: InternalCommands,
     experiments: Experiments,
-    updatesPaused: EventEmitter<boolean>,
     webviewIcon: Resource,
     workspaceState: Memento
   ) {
@@ -69,7 +68,7 @@ export class Plots extends BaseRepository<TPlotsData> {
     )
 
     this.data = this.dispose.track(
-      new PlotsData(dvcRoot, internalCommands, this.plots, updatesPaused)
+      new PlotsData(dvcRoot, internalCommands, this.plots)
     )
 
     this.decorationProvider = new ErrorDecorationProvider(

--- a/extension/src/plots/workspace.ts
+++ b/extension/src/plots/workspace.ts
@@ -10,7 +10,6 @@ export class WorkspacePlots extends BaseWorkspaceWebviews<Plots, PlotsData> {
 
   public createRepository(
     dvcRoot: string,
-    updatesPaused: EventEmitter<boolean>,
     resourceLocator: ResourceLocator,
     experiments: WorkspaceExperiments
   ) {
@@ -19,7 +18,6 @@ export class WorkspacePlots extends BaseWorkspaceWebviews<Plots, PlotsData> {
         dvcRoot,
         this.internalCommands,
         experiments.getRepository(dvcRoot),
-        updatesPaused,
         resourceLocator.scatterGraph,
         this.workspaceState
       )

--- a/extension/src/repository/data/index.ts
+++ b/extension/src/repository/data/index.ts
@@ -43,16 +43,12 @@ export class RepositoryData extends DeferredDisposable {
     new EventEmitter()
   )
 
-  constructor(
-    dvcRoot: string,
-    internalCommands: InternalCommands,
-    updatesPaused: EventEmitter<boolean>
-  ) {
+  constructor(dvcRoot: string, internalCommands: InternalCommands) {
     super()
 
     this.dvcRoot = dvcRoot
     this.processManager = this.dispose.track(
-      new ProcessManager(updatesPaused, {
+      new ProcessManager({
         name: 'update',
         process: () => this.update()
       })

--- a/extension/src/repository/index.ts
+++ b/extension/src/repository/index.ts
@@ -28,7 +28,6 @@ export class Repository extends DeferredDisposable {
   constructor(
     dvcRoot: string,
     internalCommands: InternalCommands,
-    updatesPaused: EventEmitter<boolean>,
     treeDataChanged: EventEmitter<void>
   ) {
     super()
@@ -36,7 +35,7 @@ export class Repository extends DeferredDisposable {
     this.dvcRoot = dvcRoot
     this.model = this.dispose.track(new RepositoryModel(dvcRoot))
     this.data = this.dispose.track(
-      new RepositoryData(dvcRoot, internalCommands, updatesPaused)
+      new RepositoryData(dvcRoot, internalCommands)
     )
 
     this.errorDecorationProvider = this.dispose.track(

--- a/extension/src/repository/workspace.ts
+++ b/extension/src/repository/workspace.ts
@@ -23,17 +23,9 @@ export class WorkspaceRepositories extends BaseWorkspace<Repository> {
     return cwd
   }
 
-  public createRepository(
-    dvcRoot: string,
-    updatesPaused: EventEmitter<boolean>
-  ): Repository {
+  public createRepository(dvcRoot: string): Repository {
     const repository = this.dispose.track(
-      new Repository(
-        dvcRoot,
-        this.internalCommands,
-        updatesPaused,
-        this.treeDataChanged
-      )
+      new Repository(dvcRoot, this.internalCommands, this.treeDataChanged)
     )
 
     this.setRepository(dvcRoot, repository)

--- a/extension/src/test/suite/experiments/data/index.test.ts
+++ b/extension/src/test/suite/experiments/data/index.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path'
 import { afterEach, beforeEach, describe, it, suite } from 'mocha'
-import { EventEmitter, RelativePattern } from 'vscode'
+import { RelativePattern } from 'vscode'
 import { expect } from 'chai'
 import { stub, restore, spy } from 'sinon'
 import { ensureFileSync, removeSync } from 'fs-extra'
@@ -92,7 +92,6 @@ suite('Experiments Data Test Suite', () => {
               }
             }
           } as unknown as InternalCommands,
-          disposable.track(new EventEmitter<boolean>()),
           {
             getIsBranchesView: () => false,
             getNbOfCommitsToShow: () => DEFAULT_NUM_OF_COMMITS_TO_SHOW,
@@ -149,7 +148,6 @@ suite('Experiments Data Test Suite', () => {
               }
             }
           } as unknown as InternalCommands,
-          disposable.track(new EventEmitter<boolean>()),
           {
             getIsBranchesView: () => false,
             getNbOfCommitsToShow: () => DEFAULT_NUM_OF_COMMITS_TO_SHOW,

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -4,7 +4,6 @@ import { after, afterEach, beforeEach, describe, it, suite } from 'mocha'
 import { expect } from 'chai'
 import { stub, spy, restore, SinonStub } from 'sinon'
 import {
-  EventEmitter,
   window,
   commands,
   workspace,
@@ -1447,8 +1446,6 @@ suite('Experiments Test Suite', () => {
 
       const messageSpy = spy(BaseWebview.prototype, 'show')
 
-      const updatesPaused = disposable.track(new EventEmitter<boolean>())
-
       const resourceLocator = disposable.track(
         new ResourceLocator(extensionUri)
       )
@@ -1457,7 +1454,6 @@ suite('Experiments Test Suite', () => {
         new Experiments(
           dvcDemoPath,
           internalCommands,
-          updatesPaused,
           resourceLocator,
           buildMockMemento(),
           () => Promise.resolve(true),
@@ -1690,7 +1686,6 @@ suite('Experiments Test Suite', () => {
         new Experiments(
           'test',
           internalCommands,
-          {} as EventEmitter<boolean>,
           {} as ResourceLocator,
           mockMemento,
           () => Promise.resolve(true),
@@ -1846,7 +1841,6 @@ suite('Experiments Test Suite', () => {
         new Experiments(
           'test',
           internalCommands,
-          {} as EventEmitter<boolean>,
           {} as ResourceLocator,
           mockMemento,
           () => Promise.resolve(true),

--- a/extension/src/test/suite/experiments/model/filterBy/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/filterBy/tree.test.ts
@@ -279,7 +279,6 @@ suite('Experiments Filter By Tree Test Suite', () => {
       const workspaceExperiments = disposable.track(
         new WorkspaceExperiments(
           internalCommands,
-          disposable.track(new EventEmitter()),
           buildMockMemento(),
           { [dvcDemoPath]: experiments },
           disposable.track(new EventEmitter())

--- a/extension/src/test/suite/experiments/util.ts
+++ b/extension/src/test/suite/experiments/util.ts
@@ -1,5 +1,4 @@
 import { stub } from 'sinon'
-import { EventEmitter } from 'vscode'
 import { WorkspaceExperiments } from '../../../experiments/workspace'
 import { Experiments } from '../../../experiments'
 import { Disposer } from '../../../extension'
@@ -33,7 +32,6 @@ export const buildExperiments = (
     mockCheckSignalFile,
     mockExpShow,
     mockGetCommitMessages,
-    updatesPaused,
     resourceLocator
   } = buildDependencies(disposer, experimentShowData)
 
@@ -47,7 +45,6 @@ export const buildExperiments = (
     new Experiments(
       dvcRoot,
       internalCommands,
-      updatesPaused,
       resourceLocator,
       buildMockMemento(),
       mockCheckOrAddPipeline,
@@ -78,8 +75,7 @@ export const buildExperiments = (
     mockGetCommitMessages,
     mockSelectBranches,
     mockUpdateExperimentsData,
-    resourceLocator,
-    updatesPaused
+    resourceLocator
   }
 }
 
@@ -89,24 +85,17 @@ export const buildMultiRepoExperiments = (disposer: SafeWatcherDisposer) => {
     experiments: mockExperiments,
     gitReader,
     messageSpy,
-    updatesPaused,
     resourceLocator
   } = buildExperiments(disposer, expShowFixture, 'other/dvc/root')
 
   stub(gitReader, 'getGitRepositoryRoot').resolves(dvcDemoPath)
   const workspaceExperiments = disposer.track(
-    new WorkspaceExperiments(
-      internalCommands,
-      updatesPaused,
-      buildMockMemento(),
-      {
-        'other/dvc/root': mockExperiments
-      }
-    )
+    new WorkspaceExperiments(internalCommands, buildMockMemento(), {
+      'other/dvc/root': mockExperiments
+    })
   )
   const [experiments] = workspaceExperiments.create(
     [dvcDemoPath],
-    updatesPaused,
     resourceLocator
   )
 
@@ -115,26 +104,15 @@ export const buildMultiRepoExperiments = (disposer: SafeWatcherDisposer) => {
 }
 
 export const buildSingleRepoExperiments = (disposer: SafeWatcherDisposer) => {
-  const {
-    config,
-    internalCommands,
-    gitReader,
-    messageSpy,
-    updatesPaused,
-    resourceLocator
-  } = buildDependencies(disposer)
+  const { config, internalCommands, gitReader, messageSpy, resourceLocator } =
+    buildDependencies(disposer)
 
   stub(gitReader, 'getGitRepositoryRoot').resolves(dvcDemoPath)
   const workspaceExperiments = disposer.track(
-    new WorkspaceExperiments(
-      internalCommands,
-      updatesPaused,
-      buildMockMemento()
-    )
+    new WorkspaceExperiments(internalCommands, buildMockMemento())
   )
   const [experiments] = workspaceExperiments.create(
     [dvcDemoPath],
-    updatesPaused,
     resourceLocator
   )
 
@@ -165,16 +143,11 @@ export const buildExperimentsData = (disposer: SafeWatcherDisposer) => {
     buildExperimentsDataDependencies(disposer)
 
   const data = disposer.track(
-    new ExperimentsData(
-      dvcDemoPath,
-      internalCommands,
-      disposer.track(new EventEmitter<boolean>()),
-      {
-        getIsBranchesView: () => false,
-        getNbOfCommitsToShow: () => DEFAULT_NUM_OF_COMMITS_TO_SHOW,
-        setAvailableBranchesToShow: stub()
-      } as unknown as ExperimentsModel
-    )
+    new ExperimentsData(dvcDemoPath, internalCommands, {
+      getIsBranchesView: () => false,
+      getNbOfCommitsToShow: () => DEFAULT_NUM_OF_COMMITS_TO_SHOW,
+      setAvailableBranchesToShow: stub()
+    } as unknown as ExperimentsModel)
   )
 
   return { data, mockCreateFileSystemWatcher, mockExpShow }

--- a/extension/src/test/suite/plots/data/index.test.ts
+++ b/extension/src/test/suite/plots/data/index.test.ts
@@ -1,6 +1,5 @@
 import { join } from 'path'
 import { afterEach, beforeEach, describe, it, suite } from 'mocha'
-import { EventEmitter } from 'vscode'
 import { expect } from 'chai'
 import { restore, spy, stub } from 'sinon'
 import { PlotsData } from '../../../../plots/data'
@@ -35,8 +34,7 @@ suite('Plots Data Test Suite', () => {
   })
 
   const buildPlotsData = (selectedRevisions: string[] = []) => {
-    const { internalCommands, updatesPaused, mockPlotsDiff } =
-      buildDependencies(disposable)
+    const { internalCommands, mockPlotsDiff } = buildDependencies(disposable)
 
     const mockGetSelectedOrderedIds = stub().returns(selectedRevisions)
 
@@ -45,12 +43,7 @@ suite('Plots Data Test Suite', () => {
     } as unknown as PlotsModel
 
     const data = disposable.track(
-      new PlotsData(
-        dvcDemoPath,
-        internalCommands,
-        mockPlotsModel,
-        updatesPaused
-      )
+      new PlotsData(dvcDemoPath, internalCommands, mockPlotsModel)
     )
 
     return {
@@ -119,8 +112,7 @@ suite('Plots Data Test Suite', () => {
           } as unknown as InternalCommands,
           {
             getSelectedOrderedIds: () => []
-          } as unknown as PlotsModel,
-          disposable.track(new EventEmitter<boolean>())
+          } as unknown as PlotsModel
         )
       )
 

--- a/extension/src/test/suite/plots/util.ts
+++ b/extension/src/test/suite/plots/util.ts
@@ -25,13 +25,8 @@ export const buildPlots = async (
   plotsDiff: PlotsOutput | undefined = undefined,
   expShow = expShowFixtureWithoutErrors
 ) => {
-  const {
-    internalCommands,
-    mockPlotsDiff,
-    messageSpy,
-    updatesPaused,
-    resourceLocator
-  } = buildDependencies(disposer, expShow, plotsDiff)
+  const { internalCommands, mockPlotsDiff, messageSpy, resourceLocator } =
+    buildDependencies(disposer, expShow, plotsDiff)
 
   const mockRemoveDir = stub(FileSystem, 'removeDir').returns(undefined)
   const mockGetModifiedTime = stub(FileSystem, 'getModifiedTime').returns(
@@ -42,7 +37,6 @@ export const buildPlots = async (
     new Experiments(
       dvcDemoPath,
       internalCommands,
-      updatesPaused,
       resourceLocator,
       buildMockMemento(),
       () => Promise.resolve(true),
@@ -55,7 +49,6 @@ export const buildPlots = async (
       dvcDemoPath,
       internalCommands,
       experiments,
-      updatesPaused,
       resourceLocator.scatterGraph,
       buildMockMemento()
     )

--- a/extension/src/test/suite/process/manager.test.ts
+++ b/extension/src/test/suite/process/manager.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, it, suite } from 'mocha'
 import { expect } from 'chai'
 import { restore, stub } from 'sinon'
-import { EventEmitter } from 'vscode'
 import { Disposable } from '../../../extension'
 import { ProcessManager } from '../../../process/manager'
 import { delay } from '../../../util/time'
@@ -21,7 +20,7 @@ suite('Process Manager Test Suite', () => {
     it('should manage calls to a process', async () => {
       const mockRefresh = stub()
       const processManager = disposable.track(
-        new ProcessManager(new EventEmitter(), {
+        new ProcessManager({
           name: 'refresh',
           process: mockRefresh
         })
@@ -84,40 +83,6 @@ suite('Process Manager Test Suite', () => {
 
       expect(mockRefresh, 'should queue the next call made after 200ms').to.be
         .calledTwice
-    })
-
-    it('should send all calls to the queue when processes are paused', async () => {
-      const mockUpdate = stub()
-      const processesPaused = disposable.track(new EventEmitter<boolean>())
-      const processManager = disposable.track(
-        new ProcessManager(processesPaused, {
-          name: 'update',
-          process: mockUpdate
-        })
-      )
-      processesPaused.fire(true)
-
-      await Promise.all([
-        processManager.run('update'),
-        processManager.run('update'),
-        processManager.run('update'),
-        processManager.run('update')
-      ])
-
-      expect(
-        mockUpdate,
-        'should send all calls to the queue when processes are paused'
-      ).not.to.be.called
-
-      const onDidUnpauseProcesses = processesPaused.event
-
-      const updatesRestartedEvent = new Promise(resolve =>
-        disposable.track(onDidUnpauseProcesses(paused => resolve(paused)))
-      )
-      processesPaused.fire(false)
-
-      expect(await updatesRestartedEvent).to.be.false
-      expect(mockUpdate, 'the queue is flushed on restart').to.be.calledOnce
     })
   })
 })

--- a/extension/src/test/suite/repository/data/index.test.ts
+++ b/extension/src/test/suite/repository/data/index.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, it, suite } from 'mocha'
 import { expect } from 'chai'
 import { restore, spy, stub } from 'sinon'
-import { EventEmitter } from 'vscode'
 import { buildRepositoryData } from '../util'
 import { dvcDemoPath } from '../../../util'
 import { fireWatcher } from '../../../../fileSystem/watcher'
@@ -51,14 +50,10 @@ suite('Repository Data Test Suite', () => {
       }
 
       const data = disposable.track(
-        new RepositoryData(
-          dvcDemoPath,
-          {
-            dispose: stub(),
-            executeCommand: mockExecuteCommand
-          } as unknown as InternalCommands,
-          disposable.track(new EventEmitter())
-        )
+        new RepositoryData(dvcDemoPath, {
+          dispose: stub(),
+          executeCommand: mockExecuteCommand
+        } as unknown as InternalCommands)
       )
       await data.isReady()
 

--- a/extension/src/test/suite/repository/index.test.ts
+++ b/extension/src/test/suite/repository/index.test.ts
@@ -41,7 +41,6 @@ suite('Repository Test Suite', () => {
         mockDataStatus,
         mockGetAllUntracked,
         mockGetHasChanges,
-        updatesPaused,
         treeDataChanged
       } = buildDependencies(disposable)
 
@@ -57,12 +56,7 @@ suite('Repository Test Suite', () => {
       mockGetHasChanges.resolves(true)
 
       const { setScmDecorationStateSpy, setScmStateSpy } =
-        await buildRepository(
-          disposable,
-          internalCommands,
-          updatesPaused,
-          treeDataChanged
-        )
+        await buildRepository(disposable, internalCommands, treeDataChanged)
 
       const modified = makeAbsPathSet(
         dvcDemoPath,
@@ -172,7 +166,6 @@ suite('Repository Test Suite', () => {
         mockGetHasChanges,
         mockNow,
         onDidChangeTreeData,
-        updatesPaused,
         treeDataChanged
       } = buildDependencies(disposable)
 
@@ -222,12 +215,7 @@ suite('Repository Test Suite', () => {
         )
 
       const { repository, setScmDecorationStateSpy, setScmStateSpy } =
-        await buildRepository(
-          disposable,
-          internalCommands,
-          updatesPaused,
-          treeDataChanged
-        )
+        await buildRepository(disposable, internalCommands, treeDataChanged)
 
       bypassProcessManagerDebounce(mockNow)
 
@@ -323,7 +311,6 @@ suite('Repository Test Suite', () => {
         mockGetHasChanges,
         mockNow,
         onDidChangeTreeData,
-        updatesPaused,
         treeDataChanged
       } = buildDependencies(disposable)
 
@@ -357,12 +344,7 @@ suite('Repository Test Suite', () => {
         setErrorDecorationStateSpy,
         setScmDecorationStateSpy,
         setScmStateSpy
-      } = await buildRepository(
-        disposable,
-        internalCommands,
-        updatesPaused,
-        treeDataChanged
-      )
+      } = await buildRepository(disposable, internalCommands, treeDataChanged)
 
       bypassProcessManagerDebounce(mockNow)
 

--- a/extension/src/test/suite/repository/model/tree.test.ts
+++ b/extension/src/test/suite/repository/model/tree.test.ts
@@ -284,7 +284,7 @@ suite('Repositories Tree Test Suite', () => {
     })
 
     it('should pull the correct target(s) when asked to dvc.pullTarget a non-tracked directory', async () => {
-      const { gitReader, internalCommands, mockDataStatus, updatesPaused } =
+      const { gitReader, internalCommands, mockDataStatus } =
         buildDependencies(disposable)
 
       mockDataStatus.resetBehavior()
@@ -308,8 +308,7 @@ suite('Repositories Tree Test Suite', () => {
         new Repository(
           dvcDemoPath,
           internalCommands,
-          updatesPaused,
-          new EventEmitter<void>()
+          disposable.track(new EventEmitter<void>())
         )
       )
 

--- a/extension/src/test/suite/repository/util.ts
+++ b/extension/src/test/suite/repository/util.ts
@@ -31,7 +31,6 @@ export const buildDependencies = (disposer: Disposer) => {
 
   const treeDataChanged = disposer.track(new EventEmitter<void>())
   const onDidChangeTreeData = treeDataChanged.event
-  const updatesPaused = disposer.track(new EventEmitter<boolean>())
 
   return {
     internalCommands,
@@ -41,8 +40,7 @@ export const buildDependencies = (disposer: Disposer) => {
     mockGetHasChanges,
     mockNow,
     onDidChangeTreeData,
-    treeDataChanged,
-    updatesPaused
+    treeDataChanged
   }
 }
 
@@ -52,17 +50,14 @@ export const buildRepositoryData = async (disposer: SafeWatcherDisposer) => {
     mockCreateFileSystemWatcher,
     mockDataStatus,
     mockGetAllUntracked,
-    mockNow,
-    updatesPaused
+    mockNow
   } = buildDependencies(disposer)
 
   mockDataStatus.resolves({})
   mockGetAllUntracked.resolves(new Set())
   mockNow.returns(FIRST_TRUTHY_TIME)
 
-  const data = disposer.track(
-    new RepositoryData(dvcDemoPath, internalCommands, updatesPaused)
-  )
+  const data = disposer.track(new RepositoryData(dvcDemoPath, internalCommands))
   await data.isReady()
 
   mockDataStatus.resetHistory()
@@ -78,12 +73,11 @@ export const buildRepositoryData = async (disposer: SafeWatcherDisposer) => {
 export const buildRepository = async (
   disposer: SafeWatcherDisposer,
   internalCommands: InternalCommands,
-  updatesPaused: EventEmitter<boolean>,
   treeDataChanged: EventEmitter<void>,
   dvcRoot = dvcDemoPath
 ) => {
   const repository = disposer.track(
-    new Repository(dvcRoot, internalCommands, updatesPaused, treeDataChanged)
+    new Repository(dvcRoot, internalCommands, treeDataChanged)
   )
 
   const setErrorDecorationStateSpy = spyOnPrivateMemberMethod(

--- a/extension/src/test/suite/util.ts
+++ b/extension/src/test/suite/util.ts
@@ -228,8 +228,6 @@ export const buildDependencies = (
     ''
   )
 
-  const updatesPaused = disposer.track(new EventEmitter<boolean>())
-
   const resourceLocator = buildResourceLocator(disposer)
 
   const messageSpy = spy(BaseWebview.prototype, 'show')
@@ -250,8 +248,7 @@ export const buildDependencies = (
     mockExpShow,
     mockGetCommitMessages,
     mockPlotsDiff,
-    resourceLocator,
-    updatesPaused
+    resourceLocator
   }
 }
 

--- a/extension/src/workspace/index.ts
+++ b/extension/src/workspace/index.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from 'vscode'
 import { InternalCommands } from '../commands/internal'
 import { Disposables, reset } from '../util/disposable'
 import { quickPickOne } from '../vscode/quickPick'
@@ -17,13 +16,9 @@ export abstract class BaseWorkspace<
     this.internalCommands = internalCommands
   }
 
-  public create(
-    dvcRoots: string[],
-    updatesPaused: EventEmitter<boolean>,
-    ...args: U[]
-  ): T[] {
+  public create(dvcRoots: string[], ...args: U[]): T[] {
     const repositories = dvcRoots.map(dvcRoot =>
-      this.createRepository(dvcRoot, updatesPaused, ...args)
+      this.createRepository(dvcRoot, ...args)
     )
 
     void Promise.all(repositories.map(repository => repository.isReady())).then(
@@ -65,9 +60,5 @@ export abstract class BaseWorkspace<
     this.repositories[dvcRoot] = repository
   }
 
-  abstract createRepository(
-    dvcRoot: string,
-    updatesPaused: EventEmitter<boolean>,
-    ...args: U[]
-  ): T
+  abstract createRepository(dvcRoot: string, ...args: U[]): T
 }


### PR DESCRIPTION
Related to #3178

Back in https://github.com/iterative/vscode-dvc/pull/1123 I added code to pause data updates whilst we queue experiments. This was because the commands used to update the data would take the read/write lock on the repository and cause the queueing process to fail. Now these commands are lockless so we don't need to pause updates anymore. The same thing happened intermittently when we started running experiments.

We need to do this to avoid trying to provide progress updates for batch-queueing experiments - e.g a grid search (see https://github.com/iterative/vscode-dvc/pull/3814)

### Demo


https://user-images.githubusercontent.com/37993418/235829745-938456d1-66c9-4671-867f-2770960467b7.mov

