### PR TITLE
Add import/no-unused-modules rule to eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -69,6 +69,23 @@ module.exports = {
       rules: {
         'unicorn/filename-case': 'off'
       }
+    },
+    {
+      files: [
+        'src/extension.ts',
+        '**/*.stories.tsx',
+        '**/stories/util.ts',
+        '**/__mocks__/**',
+        'src/test/util/index.ts',
+        'src/test/e2e/**',
+        'src/test/suite/index.ts',
+        '**/*Slice.ts',
+        '**/store.ts',
+        '**/contract.ts'
+      ],
+      rules: {
+        'import/no-unused-modules': 'off'
+      }
     }
   ],
   plugins: [
@@ -104,6 +121,7 @@ module.exports = {
     'etc/no-commented-out-code': 'error',
     'etc/no-assign-mutated-array': 'error',
     'import/no-unresolved': 'off',
+    'import/no-unused-modules': [2, { unusedExports: true }],
     'import/order': [
       'error',
       {

--- a/extension/src/cli/dvc/discovery.ts
+++ b/extension/src/cli/dvc/discovery.ts
@@ -91,9 +91,7 @@ type CanRunCli = {
   version: string | undefined
 }
 
-export const isCliCompatible = (
-  cliCompatible: CliCompatible
-): boolean | undefined => {
+const isCliCompatible = (cliCompatible: CliCompatible): boolean | undefined => {
   if (cliCompatible === CliCompatible.NO_NOT_FOUND) {
     return
   }

--- a/extension/src/experiments/columns/collect/metricsAndParams.ts
+++ b/extension/src/experiments/columns/collect/metricsAndParams.ts
@@ -73,7 +73,7 @@ const walkValueTree = (
   }
 }
 
-export const walkMetricsOrParamsFile = (
+const walkMetricsOrParamsFile = (
   acc: ColumnAccumulator,
   type: ColumnType,
   file: MetricsOrParams

--- a/extension/src/experiments/columns/paths.ts
+++ b/extension/src/experiments/columns/paths.ts
@@ -12,9 +12,10 @@ const FILE_SPLIT_REGEX = new RegExp(
   `([^${FILE_SEPARATOR}]*)(?:${FILE_SEPARATOR}([^${FILE_SEPARATOR}]*))?(?:${FILE_SEPARATOR}(.*))?`
 )
 
-export const encodeColumn = (segment: string) =>
+const encodeColumn = (segment: string) =>
   segment.replace(ENCODE_METRIC_PARAM_REGEX, ENCODED_METRIC_PARAM_SEPARATOR)
-export const decodeColumn = (segment: string) =>
+
+const decodeColumn = (segment: string) =>
   segment.replace(DECODE_METRIC_PARAM_REGEX, METRIC_PARAM_SEPARATOR)
 
 export const appendColumnToPath = (...pathSegments: string[]) => {

--- a/extension/src/experiments/data/index.ts
+++ b/extension/src/experiments/data/index.ts
@@ -1,4 +1,3 @@
-import { join } from 'path'
 import { collectFiles } from './collect'
 import {
   EXPERIMENTS_GIT_LOGS_REFS,
@@ -14,8 +13,6 @@ import { DOT_DVC, ExperimentFlag } from '../../cli/dvc/constants'
 import { gitPath } from '../../cli/git/constants'
 import { getGitPath } from '../../fileSystem'
 import { ExperimentsModel } from '../model'
-
-export const QUEUED_EXPERIMENT_PATH = join(DOT_DVC, 'tmp', 'exps')
 
 export class ExperimentsData extends BaseData<ExpShowOutput> {
   private readonly experiments: ExperimentsModel

--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -31,7 +31,7 @@ import { PersistenceKey } from '../../persistence/constants'
 import { sum } from '../../util/math'
 import { DEFAULT_NUM_OF_COMMITS_TO_SHOW } from '../../cli/dvc/constants'
 
-export type StarredExperiments = Record<string, boolean | undefined>
+type StarredExperiments = Record<string, boolean | undefined>
 
 export type SelectedExperimentWithColor = Experiment & {
   displayColor: Color

--- a/extension/src/experiments/model/status/colors.ts
+++ b/extension/src/experiments/model/status/colors.ts
@@ -1,4 +1,4 @@
-export const colorsList = [
+const colorsList = [
   '#945dd6',
   '#13adc7',
   '#f46837',
@@ -11,6 +11,3 @@ export const colorsList = [
 export type Color = (typeof colorsList)[number]
 
 export const copyOriginalColors = (): Color[] => [...colorsList]
-
-export const copyReverseOriginalColors = (): Color[] =>
-  [...colorsList].reverse()

--- a/extension/src/experiments/model/tree.ts
+++ b/extension/src/experiments/model/tree.ts
@@ -35,7 +35,7 @@ import { Experiment, ExperimentStatus, isRunning } from '../webview/contract'
 import { getMarkdownString } from '../../vscode/markdownString'
 import { truncateFromLeft } from '../../util/string'
 
-export type ExperimentAugmented = Experiment & {
+type ExperimentAugmented = Experiment & {
   hasChildren: boolean
   selected?: boolean
   starred: boolean

--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -33,7 +33,7 @@ export enum scriptCommand {
   PYTHON = 'python'
 }
 
-export const getScriptCommand = (script: string) => {
+const getScriptCommand = (script: string) => {
   switch (getFileExtension(script)) {
     case '.py':
       return scriptCommand.PYTHON

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -51,7 +51,7 @@ import { registerSetupCommands } from './setup/register'
 import { Status } from './status'
 import { registerPersistenceCommands } from './persistence/register'
 
-export class Extension extends Disposable {
+class Extension extends Disposable {
   protected readonly internalCommands: InternalCommands
 
   private readonly resourceLocator: ResourceLocator

--- a/extension/src/plots/index.ts
+++ b/extension/src/plots/index.ts
@@ -8,7 +8,6 @@ import { PlotsModel } from './model'
 import { collectEncodingElements, collectScale } from './paths/collect'
 import { PathsModel } from './paths/model'
 import { pickCustomPlots, pickMetricAndParam } from './model/quickPick'
-import { BaseWebview } from '../webview'
 import { ViewKey } from '../webview/constants'
 import { BaseRepository } from '../webview/repository'
 import { Experiments } from '../experiments'
@@ -21,8 +20,6 @@ import { pickPaths } from '../path/selection/quickPick'
 import { ErrorDecorationProvider } from '../tree/decorationProvider/error'
 import { DecoratableTreeItemScheme } from '../tree'
 import { Title } from '../vscode/title'
-
-export type PlotsWebview = BaseWebview<TPlotsData>
 
 export class Plots extends BaseRepository<TPlotsData> {
   public readonly viewKey = ViewKey.PLOTS

--- a/extension/src/plots/multiSource/constants.ts
+++ b/extension/src/plots/multiSource/constants.ts
@@ -12,12 +12,12 @@ export type StrokeDashValue = (typeof StrokeDash)[number]
 export const Shape = ['square', 'circle', 'triangle', 'diamond'] as const
 export type ShapeValue = (typeof Shape)[number]
 
-export type Scale<T extends StrokeDashValue | ShapeValue> = {
+type Scale<T extends StrokeDashValue | ShapeValue> = {
   domain: string[]
   range: T[]
 }
 
-export type Encoding<T extends StrokeDashValue | ShapeValue> = {
+type Encoding<T extends StrokeDashValue | ShapeValue> = {
   scale: Scale<T>
 } & { field: string }
 

--- a/extension/src/plots/paths/collect.ts
+++ b/extension/src/plots/paths/collect.ts
@@ -397,7 +397,7 @@ export enum EncodingType {
   STROKE_DASH = 'strokeDash'
 }
 
-export type EncodingElement =
+type EncodingElement =
   | {
       type: EncodingType.STROKE_DASH
       value: StrokeDashValue

--- a/extension/src/plots/vega/util.ts
+++ b/extension/src/plots/vega/util.ts
@@ -262,7 +262,7 @@ export const truncateVerticalTitle = (
 const isEndValue = (valueType: string) =>
   ['string', 'number', 'boolean'].includes(valueType)
 
-export const truncateTitles = (
+const truncateTitles = (
   spec: TopLevelSpec,
   width: number,
   height: number,

--- a/extension/src/repository/model/collect.ts
+++ b/extension/src/repository/model/collect.ts
@@ -25,11 +25,10 @@ const ExtendedDataStatus = Object.assign(
   DiscardedStatus
 )
 
-export type ExtendedStatus =
+type ExtendedStatus =
   (typeof ExtendedDataStatus)[keyof typeof ExtendedDataStatus]
 
-export type Status =
-  (typeof AvailableDataStatus)[keyof typeof AvailableDataStatus]
+type Status = (typeof AvailableDataStatus)[keyof typeof AvailableDataStatus]
 
 type DataStatusMapping = { [path: string]: ExtendedStatus }
 

--- a/extension/src/repository/model/error.ts
+++ b/extension/src/repository/model/error.ts
@@ -1,11 +1,5 @@
 import { PathItem } from './collect'
 
-type ErrorItem = { error: string }
-
-export const pathItemHasError = <T extends PathItem>(
-  maybeErrorItem: T
-): maybeErrorItem is T & ErrorItem => !!maybeErrorItem?.error
-
 export const createTreeFromError = (
   dvcRoot: string,
   msg: string

--- a/extension/src/setup/index.ts
+++ b/extension/src/setup/index.ts
@@ -14,7 +14,6 @@ import { findPythonBinForInstall } from './autoInstall'
 import { run, runWithRecheck, runWorkspace } from './runner'
 import { isStudioAccessToken } from './token'
 import { pickFocusedProjects } from './quickPick'
-import { BaseWebview } from '../webview'
 import { ViewKey } from '../webview/constants'
 import { BaseRepository } from '../webview/repository'
 import { Resource } from '../resourceLocator'
@@ -54,8 +53,6 @@ import { getValidInput } from '../vscode/inputBox'
 import { Title } from '../vscode/title'
 import { getDVCAppDir } from '../util/appdirs'
 import { getOptions } from '../cli/dvc/options'
-
-export type SetupWebviewWebview = BaseWebview<TSetupData>
 
 export class Setup
   extends BaseRepository<TSetupData>

--- a/extension/src/setup/token.ts
+++ b/extension/src/setup/token.ts
@@ -1,5 +1,3 @@
-export const STUDIO_ACCESS_TOKEN_KEY = 'dvc.studioAccessToken'
-
 export const isStudioAccessToken = (text?: string): boolean => {
   if (!text) {
     return false

--- a/extension/src/test/cli/util.ts
+++ b/extension/src/test/cli/util.ts
@@ -15,7 +15,7 @@ const config = {
 } as Config
 
 export const dvcReader = new DvcReader(config)
-export const dvcExecutor = new DvcExecutor(
+const dvcExecutor = new DvcExecutor(
   config,
   () => undefined,
   () => Promise.resolve('')

--- a/extension/src/test/suite/plots/util.ts
+++ b/extension/src/test/suite/plots/util.ts
@@ -104,20 +104,3 @@ export const buildPlots = async (
     webviewMessages
   }
 }
-
-export const buildWorkspacePlots = (disposer: Disposer) => {
-  const { config, internalCommands, messageSpy, resourceLocator } =
-    buildDependencies(disposer)
-
-  const workspacePlots = disposer.track(
-    new WorkspacePlots(internalCommands, buildMockMemento())
-  )
-
-  return {
-    config,
-    internalCommands,
-    messageSpy,
-    resourceLocator,
-    workspacePlots
-  }
-}

--- a/extension/src/test/suite/util.ts
+++ b/extension/src/test/suite/util.ts
@@ -88,7 +88,7 @@ export const experimentsUpdatedEvent = (experiments: Experiments) =>
     experiments.dispose.track(experiments.onDidChangeExperiments(resolve))
   })
 
-export const getFirstArgOfCall = (spy: SinonSpy, call: number) =>
+const getFirstArgOfCall = (spy: SinonSpy, call: number) =>
   spy.getCall(call).firstArg
 
 export const getArgOfCall = (spy: SinonSpy, call: number, arg: number) =>
@@ -190,7 +190,7 @@ export const buildMockExperimentsData = (update = stub()) =>
     update
   } as unknown as ExperimentsData)
 
-export const buildResourceLocator = (disposer: Disposer): ResourceLocator =>
+const buildResourceLocator = (disposer: Disposer): ResourceLocator =>
   disposer.track(new ResourceLocator(extensionUri))
 
 export const buildDependencies = (
@@ -275,17 +275,6 @@ export const stubPrivatePrototypeMethod = <T extends { prototype: unknown }>(
   classWithPrivateMethod: T,
   method: string
 ) => stubPrivateMethod(classWithPrivateMethod.prototype, method)
-
-export const stubPrivateMemberMethod = <T>(
-  classWithPrivateMember: T,
-  memberName: string,
-  method: string
-) => stubPrivateMethod((classWithPrivateMember as any)[memberName], method)
-
-export const spyOnPrivateMethod = <T>(
-  classWithPrivateMember: T,
-  method: string
-) => spy(classWithPrivateMember as any, method)
 
 export const spyOnPrivateMemberMethod = <T>(
   classWithPrivateMember: T,

--- a/extension/src/tree/index.ts
+++ b/extension/src/tree/index.ts
@@ -32,7 +32,7 @@ export const getDecoratableTreeItem = (
   return new TreeItem(decoratableUri, collapsibleState)
 }
 
-export type ErrorItem = { error: string }
+type ErrorItem = { error: string }
 
 export const isErrorItem = (
   maybeErrorItem: unknown

--- a/extension/src/util/map.ts
+++ b/extension/src/util/map.ts
@@ -26,16 +26,6 @@ export const addToMapSet = <K = string, V = unknown>(
   }
 }
 
-export const addToMapCount = (
-  key: string,
-  map: Map<string, number>
-): number => {
-  let count = map.get(key) || 0
-  count++
-  map.set(key, count)
-  return count
-}
-
 export const flattenMapValues = <T>(map: Map<string, T[]>): T[] => {
   const iterator: IterableIterator<T[]> = map.values()
   return [...iterator].flat()

--- a/extension/src/vscode/workspace.ts
+++ b/extension/src/vscode/workspace.ts
@@ -1,4 +1,0 @@
-import { workspace, WorkspaceFolder } from 'vscode'
-
-export const getWorkspaceFolders = (): readonly WorkspaceFolder[] =>
-  workspace.workspaceFolders || []

--- a/extension/src/webview/contract.ts
+++ b/extension/src/webview/contract.ts
@@ -75,15 +75,13 @@ export type ColumnResizePayload = {
   id: string
   width: number
 }
+
 export type PlotsResizedPayload = {
   section: PlotsSection
   nbItemsPerRow: number
   height: PlotHeight
 }
-export type PlotSectionRenamedPayload = {
-  section: PlotsSection
-  name: string
-}
+
 export type PlotsTemplatesReordered = {
   group: TemplatePlotGroup
   paths: string[]

--- a/languageServer/src/documentSelector.ts
+++ b/languageServer/src/documentSelector.ts
@@ -1,5 +1,0 @@
-export const documentSelector = [
-  {
-    pattern: '**/dvc.yaml'
-  }
-]

--- a/languageServer/src/test/utils/setup-test-connections.ts
+++ b/languageServer/src/test/utils/setup-test-connections.ts
@@ -12,7 +12,7 @@ class TestStream extends Duplex {
   _read(_size: number) {}
 }
 
-export let server: Connection
+let server: Connection
 export let client: Connection
 
 export const setupTestConnections = (

--- a/webview/src/experiments/components/table/Indicators.tsx
+++ b/webview/src/experiments/components/table/Indicators.tsx
@@ -19,11 +19,11 @@ import { pluralize } from '../../../util/strings'
 import { ExperimentsState } from '../../store'
 import { featureFlag } from '../../../util/flags'
 
-export type CounterBadgeProps = {
+type CounterBadgeProps = {
   count?: number
 }
 
-export const CounterBadge: React.FC<CounterBadgeProps> = ({ count }) => {
+const CounterBadge: React.FC<CounterBadgeProps> = ({ count }) => {
   return count ? (
     <span
       className={styles.indicatorCount}

--- a/webview/src/experiments/components/table/RowSelectionContext.tsx
+++ b/webview/src/experiments/components/table/RowSelectionContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useState } from 'react'
 import { RowProp } from '../../util/interfaces'
 
-export interface RowSelectionContextValue {
+interface RowSelectionContextValue {
   selectedRows: Record<string, RowProp | undefined>
   lastSelectedRow?: RowProp
   toggleRowSelected?: (row: RowProp) => void

--- a/webview/src/experiments/components/table/body/CellHintTooltip.tsx
+++ b/webview/src/experiments/components/table/body/CellHintTooltip.tsx
@@ -5,7 +5,7 @@ import Tooltip, {
   NORMAL_TOOLTIP_DELAY
 } from '../../../../shared/components/tooltip/Tooltip'
 
-export type CellHintTooltipProps = {
+type CellHintTooltipProps = {
   tooltipContent: ReactNode
   tooltipOffset?: [number, number]
   children: ReactElement

--- a/webview/src/experiments/components/table/body/CellRowActions.tsx
+++ b/webview/src/experiments/components/table/body/CellRowActions.tsx
@@ -27,7 +27,7 @@ export type CellRowActionsProps = {
   toggleStarred: () => void
 }
 
-export type CellRowActionProps = {
+type CellRowActionProps = {
   showSubRowStates: boolean
   subRowsAffected: number
   children: ReactElement
@@ -36,7 +36,7 @@ export type CellRowActionProps = {
   onClick?: MouseEventHandler
 }
 
-export const CellRowAction: React.FC<CellRowActionProps> = ({
+const CellRowAction: React.FC<CellRowActionProps> = ({
   showSubRowStates,
   subRowsAffected,
   children,

--- a/webview/src/experiments/components/table/content/Cell.tsx
+++ b/webview/src/experiments/components/table/content/Cell.tsx
@@ -21,7 +21,7 @@ export type CellValue = Value | ValueWithChanges
 export const isValueWithChanges = (raw: CellValue): raw is ValueWithChanges =>
   typeof (raw as ValueWithChanges)?.changes === 'boolean'
 
-export const cellValue = (raw: CellValue) =>
+const cellValue = (raw: CellValue) =>
   isValueWithChanges(raw) ? raw.value : raw
 
 export const Cell: React.FC<CellContext<Experiment, CellValue>> = cell => {

--- a/webview/src/experiments/components/table/header/TableHeaderCellContents.tsx
+++ b/webview/src/experiments/components/table/header/TableHeaderCellContents.tsx
@@ -29,7 +29,7 @@ const getIconMenuItems = (
   }
 ]
 
-export const ColumnDragHandle: React.FC<{
+const ColumnDragHandle: React.FC<{
   disabled: boolean
   header: Header<Experiment, unknown>
   onDragEnter: DragFunction

--- a/webview/src/plots/components/GetStarted.tsx
+++ b/webview/src/plots/components/GetStarted.tsx
@@ -6,7 +6,7 @@ import { sendMessage } from '../../shared/vscode'
 import { StartButton } from '../../shared/components/button/StartButton'
 import { RefreshButton } from '../../shared/components/button/RefreshButton'
 
-export type AddPlotsProps = {
+type AddPlotsProps = {
   hasUnselectedPlots: boolean
   hasNoCustomPlots: boolean
   cliError: string | undefined

--- a/webview/src/plots/components/PlotsContainer.tsx
+++ b/webview/src/plots/components/PlotsContainer.tsx
@@ -18,7 +18,7 @@ import { Slider } from '../../shared/components/slider/Slider'
 import { PlotsState } from '../store'
 import { SectionContainer } from '../../shared/components/sectionContainer/SectionContainer'
 
-export interface PlotsContainerProps {
+interface PlotsContainerProps {
   sectionCollapsed: boolean
   sectionKey: PlotsSection
   title: string

--- a/webview/src/plots/components/ZoomedInPlot.tsx
+++ b/webview/src/plots/components/ZoomedInPlot.tsx
@@ -7,7 +7,7 @@ import { reverseOfLegendSuppressionUpdate } from 'dvc/src/plots/vega/util'
 import styles from './styles.module.scss'
 import { getThemeValue, ThemeProperty } from '../../util/styles'
 
-export type ZoomedInPlotProps = {
+type ZoomedInPlotProps = {
   props: VegaLiteProps
 }
 

--- a/webview/src/plots/components/ribbon/RibbonBlock.tsx
+++ b/webview/src/plots/components/ribbon/RibbonBlock.tsx
@@ -13,11 +13,6 @@ interface RibbonBlockProps {
   onClear: () => void
 }
 
-export enum CopyTooltip {
-  NORMAL = 'Copy',
-  COPIED = 'Copied'
-}
-
 const RevisionIcon: React.FC<{ fetched: boolean; errors?: string[] }> = ({
   fetched,
   errors

--- a/webview/src/setup/components/Experiments.tsx
+++ b/webview/src/setup/components/Experiments.tsx
@@ -8,7 +8,7 @@ import { IconButton } from '../../shared/components/button/IconButton'
 import { Beaker } from '../../shared/components/icons'
 import { Button } from '../../shared/components/button/Button'
 
-export type ExperimentsProps = {
+type ExperimentsProps = {
   isDvcSetup: boolean
   hasData: boolean | undefined
   setSectionCollapsed: (sectionCollapsed: SectionCollapsed) => void

--- a/webview/src/setup/components/dvc/CliUnavailable.tsx
+++ b/webview/src/setup/components/dvc/CliUnavailable.tsx
@@ -3,7 +3,7 @@ import styles from './styles.module.scss'
 import { Button } from '../../../shared/components/button/Button'
 import { EmptyState } from '../../../shared/components/emptyState/EmptyState'
 
-export type CliUnavailableProps = {
+type CliUnavailableProps = {
   installDvc: () => void
   pythonBinPath: string | undefined
   setupWorkspace: () => void

--- a/webview/src/setup/components/dvc/Dvc.tsx
+++ b/webview/src/setup/components/dvc/Dvc.tsx
@@ -16,7 +16,7 @@ import { EmptyState } from '../../../shared/components/emptyState/EmptyState'
 import { Beaker } from '../../../shared/components/icons'
 import { IconButton } from '../../../shared/components/button/IconButton'
 
-export type DvcProps = {
+type DvcProps = {
   canGitInitialize: boolean | undefined
   cliCompatible: boolean | undefined
   dvcCliDetails: DvcCliDetails | undefined

--- a/webview/src/setup/components/dvc/ProjectUninitialized.tsx
+++ b/webview/src/setup/components/dvc/ProjectUninitialized.tsx
@@ -2,7 +2,7 @@ import React, { PropsWithChildren } from 'react'
 import { GitUninitialized } from './GitUnitialized'
 import { DvcUninitialized } from './DvcUnitialized'
 
-export interface ProjectUninitializedProps {
+interface ProjectUninitializedProps {
   canGitInitialize: boolean | undefined
   initializeDvc: () => void
   initializeGit: () => void

--- a/webview/src/shared/api.ts
+++ b/webview/src/shared/api.ts
@@ -1,6 +1,6 @@
 import { MessageFromWebview } from 'dvc/src/webview/contract'
 
-export interface InternalVsCodeApi {
+interface InternalVsCodeApi {
   postMessage(message: MessageFromWebview): void
 }
 

--- a/webview/src/shared/components/button/IconButton.tsx
+++ b/webview/src/shared/components/button/IconButton.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Button, ButtonProps } from './Button'
 import { Icon, IconValue } from '../Icon'
 
-export type IconButtonProps = ButtonProps & { icon: IconValue }
+type IconButtonProps = ButtonProps & { icon: IconValue }
 
 export const IconButton: React.FC<IconButtonProps> = ({
   appearance,

--- a/webview/src/shared/components/dragDrop/Draggable.tsx
+++ b/webview/src/shared/components/dragDrop/Draggable.tsx
@@ -2,7 +2,7 @@ import React, { DragEvent } from 'react'
 
 export type DragFunction = (e: DragEvent<HTMLElement>) => void
 
-export interface DraggableProps {
+interface DraggableProps {
   id: string
   disabled: boolean
   children: JSX.Element

--- a/webview/src/shared/components/getStarted/GetStarted.tsx
+++ b/webview/src/shared/components/getStarted/GetStarted.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { EmptyState } from '../emptyState/EmptyState'
 
-export type GetStartedProps = {
+type GetStartedProps = {
   addItems: React.ReactNode
   showEmpty: boolean
   welcome: React.ReactNode

--- a/webview/src/shared/components/iconMenu/IconMenuItem.tsx
+++ b/webview/src/shared/components/iconMenu/IconMenuItem.tsx
@@ -13,7 +13,7 @@ export interface IconMenuItemProps {
   hidden?: boolean
 }
 
-export interface IconMenuItemAllProps extends IconMenuItemProps {
+interface IconMenuItemAllProps extends IconMenuItemProps {
   tooltipTarget: TippyProps['singleton']
   menuTarget: TippyProps['singleton']
 }

--- a/webview/src/shared/components/messagesMenu/MessagesMenu.tsx
+++ b/webview/src/shared/components/messagesMenu/MessagesMenu.tsx
@@ -5,7 +5,7 @@ import {
   MessagesMenuOptionProps
 } from './MessagesMenuOption'
 
-export interface MessagesMenuProps {
+interface MessagesMenuProps {
   options: MessagesMenuOptionProps[]
   onOptionSelected?: () => void
 }

--- a/webview/src/shared/components/sectionContainer/SectionContainer.tsx
+++ b/webview/src/shared/components/sectionContainer/SectionContainer.tsx
@@ -73,7 +73,7 @@ export const SectionDescription = {
   )
 } as const
 
-export interface SectionContainerProps<T extends PlotsSection | SetupSection> {
+interface SectionContainerProps<T extends PlotsSection | SetupSection> {
   children: ReactNode
   menuItems?: IconMenuItemProps[]
   headerChildren?: ReactNode

--- a/webview/src/shared/components/selectMenu/SelectMenu.tsx
+++ b/webview/src/shared/components/selectMenu/SelectMenu.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { SelectMenuOption, SelectMenuOptionProps } from './SelectMenuOption'
 
-export interface SelectMenuProps {
+interface SelectMenuProps {
   options: SelectMenuOptionProps[]
   onClick: (id: string) => void
 }

--- a/webview/src/test/dragDrop.ts
+++ b/webview/src/test/dragDrop.ts
@@ -2,7 +2,7 @@ import { act } from 'react-dom/test-utils'
 import { DragEnterDirection } from '../shared/components/dragDrop/util'
 import { idToNode } from '../util/helpers'
 
-export type SpyableEventCurrentTargetDistances =
+type SpyableEventCurrentTargetDistances =
   typeof import('../shared/components/dragDrop/currentTarget')
 
 const testStorage = new Map()

--- a/webview/src/test/experimentsTable.tsx
+++ b/webview/src/test/experimentsTable.tsx
@@ -91,7 +91,7 @@ export const clickRowCheckbox = (label: string, multiSelection?: boolean) => {
   })
 }
 
-export const toggleExpansion = (label: string, btnTitle: string) => {
+const toggleExpansion = (label: string, btnTitle: string) => {
   const button = within(getRow(label)).getByTitle(`${btnTitle} Row`)
   fireEvent.click(button)
 }

--- a/webview/src/test/sort.ts
+++ b/webview/src/test/sort.ts
@@ -6,7 +6,7 @@ import {
   TableData
 } from 'dvc/src/experiments/webview/contract'
 
-export const defaultColumn = ['Experiment', 'Created']
+const defaultColumn = ['Experiment', 'Created']
 
 export const commonColumnFields = {
   hasChildren: false,
@@ -14,7 +14,7 @@ export const commonColumnFields = {
   type: ColumnType.PARAMS
 }
 
-export const columns = [
+const columns = [
   {
     hasChildren: false,
     type: ColumnType.TIMESTAMP

--- a/webview/src/test/tableDataFixture.ts
+++ b/webview/src/test/tableDataFixture.ts
@@ -1,9 +1,5 @@
-import { copyReverseOriginalColors } from 'dvc/src/experiments/model/status/colors'
-import {
-  ExperimentStatus,
-  Commit,
-  TableData
-} from 'dvc/src/experiments/webview/contract'
+import { copyOriginalColors } from 'dvc/src/experiments/model/status/colors'
+import { Commit, TableData } from 'dvc/src/experiments/webview/contract'
 
 const matchAndTransform = (
   rows: Commit[],
@@ -24,7 +20,7 @@ const matchAndTransform = (
   })
 }
 
-export const transformRows = (
+const transformRows = (
   fixture: TableData,
   labelOrIds: string[],
   transform: (source: Commit) => Commit
@@ -60,10 +56,10 @@ export const setExperimentsAsSelected = (
   fixture: TableData,
   labelOrIds: string[]
 ) => {
-  let colors = copyReverseOriginalColors()
+  let colors = [...copyOriginalColors()].reverse()
   const nextColor = () => {
     if (colors.length === 0) {
-      colors = copyReverseOriginalColors()
+      colors = copyOriginalColors()
     }
     return colors.pop()
   }
@@ -74,7 +70,3 @@ export const setExperimentsAsSelected = (
     selected: true
   }))
 }
-export const setExperimentsAsRunning = setRowProperty(
-  'status',
-  ExperimentStatus.RUNNING
-)

--- a/webview/src/util/objects.ts
+++ b/webview/src/util/objects.ts
@@ -11,7 +11,7 @@ export type BaseType =
 
 export type Any = BaseType | BaseType[]
 
-export type Obj = { [key: string]: Any }
+type Obj = { [key: string]: Any }
 
 export const keepReferenceIfEqual = (old: BaseType, recent: BaseType) =>
   isEqual(old, recent) ? old : recent


### PR DESCRIPTION
Noticed that we are carrying some dead code whilst working on #3825 so hunted around for this rule: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-unused-modules.md