### PR TITLE
Combine/enhance commands used to stop experiments

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1243,6 +1243,11 @@
           "group": "navigation@2"
         },
         {
+          "command": "dvc.stopAllRunningExperiments",
+          "when": "view == dvc.views.experimentsTree && dvc.experiments.webview.active && dvc.experiment.running",
+          "group": "navigation@0"
+        },
+        {
           "command": "dvc.runExperiment",
           "when": "view == dvc.views.experimentsTree && !dvc.experiment.running.workspace && !dvc.experiment.checkpoints",
           "group": "navigation@1"
@@ -1261,11 +1266,6 @@
           "command": "dvc.stopAllRunningExperiments",
           "when": "view == dvc.views.experimentsTree && !dvc.experiments.webview.active && dvc.experiment.running",
           "group": "1_run@1"
-        },
-        {
-          "command": "dvc.stopAllRunningExperiments",
-          "when": "view == dvc.views.experimentsTree && dvc.experiments.webview.active && dvc.experiment.running",
-          "group": "navigation@1"
         },
         {
           "command": "dvc.views.experimentsTree.selectExperiments",

--- a/extension/package.json
+++ b/extension/package.json
@@ -362,8 +362,8 @@
         "category": "DVC"
       },
       {
-        "title": "Stop Running Queued Experiment(s)",
-        "command": "dvc.stopQueuedExperiments",
+        "title": "Stop Running Experiment(s)",
+        "command": "dvc.stopExperiments",
         "category": "DVC"
       },
       {
@@ -827,7 +827,7 @@
           "when": "dvc.commands.available && dvc.project.available"
         },
         {
-          "command": "dvc.stopQueuedExperiments",
+          "command": "dvc.stopExperiments",
           "when": "dvc.commands.available && dvc.project.available"
         },
         {
@@ -1286,11 +1286,6 @@
           "command": "dvc.stopExperimentsQueue",
           "when": "view == dvc.views.experimentsTree",
           "group": "3_queue@3"
-        },
-        {
-          "command": "dvc.stopQueuedExperiments",
-          "when": "view == dvc.views.experimentsTree",
-          "group": "3_queue@5"
         },
         {
           "command": "dvc.addExperimentsTableSort",

--- a/extension/package.json
+++ b/extension/package.json
@@ -430,6 +430,18 @@
         "category": "DVC"
       },
       {
+        "title": "Stop",
+        "command": "dvc.views.experimentsTree.stopExperiment",
+        "category": "DVC",
+        "icon": "$(debug-stop)"
+      },
+      {
+        "title": "Stop",
+        "command": "dvc.views.experiments.stopExperiment",
+        "category": "DVC",
+        "icon": "$(debug-stop)"
+      },
+      {
         "title": "Stop All Running Experiments",
         "command": "dvc.stopAllRunningExperiments",
         "category": "DVC",
@@ -915,6 +927,14 @@
           "when": "false"
         },
         {
+          "command": "dvc.views.experimentsTree.stopExperiment",
+          "when": "false"
+        },
+        {
+          "command": "dvc.views.experiments.stopExperiment",
+          "when": "false"
+        },
+        {
           "command": "dvc.views.experimentsFilterByTree.removeAllFilters",
           "when": "false"
         },
@@ -1159,6 +1179,11 @@
           "command": "dvc.views.experimentsFilterByTree.removeFilter",
           "group": "inline",
           "when": "view == dvc.views.experimentsFilterByTree && dvc.commands.available && viewItem != dvcRoot"
+        },
+        {
+          "command": "dvc.views.experimentsTree.stopExperiment",
+          "group": "inline@0",
+          "when": "view == dvc.views.experimentsTree && dvc.commands.available && viewItem == running"
         },
         {
           "command": "dvc.views.experiments.applyExperiment",

--- a/extension/src/commands/external.ts
+++ b/extension/src/commands/external.ts
@@ -9,7 +9,6 @@ export enum RegisteredCliCommands {
   EXPERIMENT_RESUME = 'dvc.resumeCheckpointExperiment',
   EXPERIMENT_RUN = 'dvc.runExperiment',
   QUEUE_EXPERIMENT = 'dvc.queueExperiment',
-  QUEUE_KILL = 'dvc.stopQueuedExperiments',
   QUEUE_START = 'dvc.startExperimentsQueue',
   QUEUE_STOP = 'dvc.stopExperimentsQueue',
 
@@ -62,6 +61,7 @@ export enum RegisteredCommands {
   EXPERIMENT_SORT_REMOVE = 'dvc.views.experimentsSortByTree.removeSort',
   EXPERIMENT_SORTS_REMOVE = 'dvc.removeExperimentsTableSorts',
   EXPERIMENT_SORTS_REMOVE_ALL = 'dvc.views.experimentsSortByTree.removeAllSorts',
+  EXPERIMENT_STOP = 'dvc.stopExperiments',
   EXPERIMENT_TOGGLE = 'dvc.views.experiments.toggleStatus',
   STOP_EXPERIMENTS = 'dvc.stopAllRunningExperiments',
 

--- a/extension/src/commands/external.ts
+++ b/extension/src/commands/external.ts
@@ -17,7 +17,6 @@ export enum RegisteredCliCommands {
   EXPERIMENT_VIEW_PUSH = 'dvc.views.experiments.pushExperiment',
   EXPERIMENT_VIEW_REMOVE = 'dvc.views.experiments.removeExperiment',
   EXPERIMENT_VIEW_SHOW_LOGS = 'dvc.views.experiments.showLogs',
-  EXPERIMENT_VIEW_STOP = 'dvc.views.experiments.stopQueueExperiment',
 
   EXPERIMENT_VIEW_QUEUE = 'dvc.views.experiments.queueExperiment',
   EXPERIMENT_VIEW_RESUME = 'dvc.views.experiments.resumeCheckpointExperiment',
@@ -63,6 +62,7 @@ export enum RegisteredCommands {
   EXPERIMENT_SORTS_REMOVE_ALL = 'dvc.views.experimentsSortByTree.removeAllSorts',
   EXPERIMENT_STOP = 'dvc.stopExperiments',
   EXPERIMENT_TOGGLE = 'dvc.views.experiments.toggleStatus',
+  EXPERIMENT_VIEW_STOP = 'dvc.views.experiments.stopExperiment',
   STOP_EXPERIMENTS = 'dvc.stopAllRunningExperiments',
 
   PLOTS_PATH_TOGGLE = 'dvc.views.plotsPathsTree.toggleStatus',

--- a/extension/src/experiments/commands/register.ts
+++ b/extension/src/experiments/commands/register.ts
@@ -115,6 +115,12 @@ const registerExperimentNameCommands = (
     ({ dvcRoot, ids }: { dvcRoot: string; ids: string[] }) =>
       experiments.runCommand(AvailableCommands.EXP_REMOVE, dvcRoot, ...ids)
   )
+
+  internalCommands.registerExternalCommand(
+    RegisteredCommands.EXPERIMENT_VIEW_STOP,
+    ({ dvcRoot, ids }: { dvcRoot: string; ids: string[] }) =>
+      experiments.stopExperiments(dvcRoot, ...ids)
+  )
 }
 
 const registerExperimentInputCommands = (

--- a/extension/src/experiments/commands/register.ts
+++ b/extension/src/experiments/commands/register.ts
@@ -200,9 +200,9 @@ const registerExperimentQuickPickCommands = (
       experiments.selectColumns(getDvcRootFromContext(context))
   )
 
-  internalCommands.registerExternalCliCommand(
-    RegisteredCliCommands.QUEUE_KILL,
-    () => experiments.selectQueueTasksToKill()
+  internalCommands.registerExternalCommand(
+    RegisteredCommands.EXPERIMENT_STOP,
+    () => experiments.selectExperimentsToStop()
   )
 
   internalCommands.registerExternalCliCommand(

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -488,7 +488,7 @@ export class Experiments extends BaseRepository<TableData> {
   }
 
   public stopExperiments(ids: string[]) {
-    const { runningInQueueIds, workspaceDetails } =
+    const { runningInQueueIds, runningInWorkspaceId } =
       this.experiments.getStopDetails(ids)
 
     const promises: Promise<string | void>[] = []
@@ -502,10 +502,8 @@ export class Experiments extends BaseRepository<TableData> {
         )
       )
     }
-    if (workspaceDetails) {
-      promises.push(
-        stopWorkspaceExperiment(workspaceDetails.id, workspaceDetails.pid)
-      )
+    if (runningInWorkspaceId) {
+      promises.push(stopWorkspaceExperiment(this.dvcRoot, runningInWorkspaceId))
     }
 
     return Toast.showOutput(

--- a/extension/src/experiments/model/collect.ts
+++ b/extension/src/experiments/model/collect.ts
@@ -29,7 +29,6 @@ import { RegisteredCommands } from '../../commands/external'
 import { Resource } from '../../resourceLocator'
 import { shortenForLabel } from '../../util/string'
 import { COMMITS_SEPARATOR } from '../../cli/git/constants'
-import { createValidInteger } from '../../util/number'
 
 export type ExperimentItem = {
   command?: {
@@ -226,16 +225,14 @@ const collectExecutorInfo = (
 
 const collectRunningExperiment = (
   acc: ExperimentsAccumulator,
-  experiment: Experiment,
-  executor: ExecutorState
+  experiment: Experiment
 ): void => {
   if (!isRunning(experiment.status)) {
     return
   }
   acc.runningExperiments.push({
     executor: getExecutor(experiment),
-    id: experiment.id,
-    pid: createValidInteger(executor?.local?.pid)
+    id: experiment.id
   })
 }
 
@@ -271,7 +268,7 @@ const collectExpRange = (
   }
 
   collectExecutorInfo(experiment, executor)
-  collectRunningExperiment(acc, experiment, executor)
+  collectRunningExperiment(acc, experiment)
 
   addToMapArray(acc.experimentsByCommit, baseline.id, experiment)
 }
@@ -413,7 +410,7 @@ export const collectOrderedCommitsAndExperiments = (
   return acc
 }
 
-export const collectRunningQueueTaskIds = (
+export const collectRunningInQueue = (
   ids: Set<string>,
   runningExperiments: RunningExperiment[]
 ): string[] | undefined => {
@@ -429,16 +426,16 @@ export const collectRunningQueueTaskIds = (
   return runningInQueueIds.size > 0 ? [...runningInQueueIds] : undefined
 }
 
-export const collectWorkspaceExecutorPid = (
+export const collectRunningInWorkspace = (
   ids: Set<string>,
   runningExperiments: RunningExperiment[]
-): { pid: number; id: string } | undefined => {
-  for (const { executor, id, pid } of runningExperiments) {
+): string | undefined => {
+  for (const { executor, id } of runningExperiments) {
     if (!ids.has(id)) {
       continue
     }
-    if (executor === EXPERIMENT_WORKSPACE_ID && pid) {
-      return { id, pid }
+    if (executor === EXPERIMENT_WORKSPACE_ID) {
+      return id
     }
   }
 }

--- a/extension/src/experiments/model/collect.ts
+++ b/extension/src/experiments/model/collect.ts
@@ -208,18 +208,22 @@ const collectExecutorInfo = (
   acc: ExperimentsAccumulator,
   experiment: Experiment,
   executor: ExecutorState
+  // eslint-disable-next-line sonarjs/cognitive-complexity
 ): void => {
   if (!executor) {
     return
   }
 
-  const { name, state } = executor
+  const { name, state, local } = executor
 
   if (name && state === ExperimentStatus.RUNNING) {
     experiment.executor = name
   }
   if (state && state !== ExperimentStatus.SUCCESS) {
     experiment.status = state
+  }
+  if (local?.pid) {
+    experiment.executorPid = local.pid
   }
 
   if (experiment.status === ExperimentStatus.RUNNING) {

--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -3,7 +3,9 @@ import { SortDefinition, sortExperiments } from './sortBy'
 import { FilterDefinition, filterExperiment, getFilterId } from './filterBy'
 import {
   collectExperiments,
-  collectOrderedCommitsAndExperiments
+  collectOrderedCommitsAndExperiments,
+  collectRunningQueueTaskIds,
+  collectWorkspaceExecutorPid as collectWorkspaceRunDetails
 } from './collect'
 import {
   collectColoredStatus,
@@ -338,6 +340,15 @@ export class ExperimentsModel extends ModelWithPersistence {
     return this.getExperimentsAndQueued().filter(experiment =>
       isRunning(experiment.status)
     )
+  }
+
+  public getStopDetails(idsToStop: string[]) {
+    const running = [...this.running]
+    const ids = new Set(idsToStop)
+    return {
+      runningInQueueIds: collectRunningQueueTaskIds(ids, running),
+      workspaceDetails: collectWorkspaceRunDetails(ids, running)
+    }
   }
 
   public getRowData() {

--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -334,9 +334,9 @@ export class ExperimentsModel extends ModelWithPersistence {
     )
   }
 
-  public getRunningQueueTasks() {
+  public getRunningExperiments() {
     return this.getExperimentsAndQueued().filter(experiment =>
-      isRunningInQueue(experiment)
+      isRunning(experiment.status)
     )
   }
 

--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -286,7 +286,11 @@ export class ExperimentsModel extends ModelWithPersistence {
       {
         ...this.addDetails(this.workspace),
         hasChildren: false,
-        type: ExperimentType.WORKSPACE
+        type: this.running.some(
+          ({ executor }) => executor === Executor.WORKSPACE
+        )
+          ? ExperimentType.RUNNING
+          : ExperimentType.WORKSPACE
       },
       ...this.commits.map(commit => {
         return {

--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -4,8 +4,8 @@ import { FilterDefinition, filterExperiment, getFilterId } from './filterBy'
 import {
   collectExperiments,
   collectOrderedCommitsAndExperiments,
-  collectRunningQueueTaskIds,
-  collectWorkspaceExecutorPid as collectWorkspaceRunDetails
+  collectRunningInQueue,
+  collectRunningInWorkspace
 } from './collect'
 import {
   collectColoredStatus,
@@ -346,8 +346,8 @@ export class ExperimentsModel extends ModelWithPersistence {
     const running = [...this.running]
     const ids = new Set(idsToStop)
     return {
-      runningInQueueIds: collectRunningQueueTaskIds(ids, running),
-      workspaceDetails: collectWorkspaceRunDetails(ids, running)
+      runningInQueueIds: collectRunningInQueue(ids, running),
+      runningInWorkspaceId: collectRunningInWorkspace(ids, running)
     }
   }
 

--- a/extension/src/experiments/model/tree.ts
+++ b/extension/src/experiments/model/tree.ts
@@ -127,7 +127,8 @@ export class ExperimentsTree
     const callCommandWithSelected = async (
       command:
         | RegisteredCliCommands.EXPERIMENT_VIEW_REMOVE
-        | RegisteredCliCommands.EXPERIMENT_VIEW_PUSH,
+        | RegisteredCliCommands.EXPERIMENT_VIEW_PUSH
+        | RegisteredCommands.EXPERIMENT_VIEW_STOP,
       experimentItem: ExperimentItem | string,
       types: ExperimentType[]
     ) => {
@@ -160,6 +161,16 @@ export class ExperimentsTree
           RegisteredCliCommands.EXPERIMENT_VIEW_PUSH,
           experimentItem,
           [ExperimentType.EXPERIMENT]
+        )
+    )
+
+    commands.registerCommand(
+      'dvc.views.experimentsTree.stopExperiment',
+      (experimentItem: ExperimentItem) =>
+        callCommandWithSelected(
+          RegisteredCommands.EXPERIMENT_VIEW_STOP,
+          experimentItem,
+          [ExperimentType.RUNNING]
         )
     )
   }

--- a/extension/src/experiments/model/tree.ts
+++ b/extension/src/experiments/model/tree.ts
@@ -124,30 +124,10 @@ export class ExperimentsTree
   }
 
   private registerWorkaroundCommands() {
-    const callCommandWithSelected = async (
-      command:
-        | RegisteredCliCommands.EXPERIMENT_VIEW_REMOVE
-        | RegisteredCliCommands.EXPERIMENT_VIEW_PUSH
-        | RegisteredCommands.EXPERIMENT_VIEW_STOP,
-      experimentItem: ExperimentItem | string,
-      types: ExperimentType[]
-    ) => {
-      const selected = [
-        ...this.getSelectedExperimentItems(),
-        experimentItem
-      ] as (string | ExperimentItem)[]
-
-      const acc = collectExperimentType(selected, new Set(types))
-
-      for (const [dvcRoot, ids] of Object.entries(acc)) {
-        await commands.executeCommand(command, { dvcRoot, ids: [...ids] })
-      }
-    }
-
     commands.registerCommand(
       'dvc.views.experimentsTree.removeExperiment',
       (experimentItem: ExperimentItem) =>
-        callCommandWithSelected(
+        this.callCommandWithSelected(
           RegisteredCliCommands.EXPERIMENT_VIEW_REMOVE,
           experimentItem,
           [ExperimentType.EXPERIMENT, ExperimentType.QUEUED]
@@ -157,7 +137,7 @@ export class ExperimentsTree
     commands.registerCommand(
       'dvc.views.experimentsTree.pushExperiment',
       (experimentItem: ExperimentItem) =>
-        callCommandWithSelected(
+        this.callCommandWithSelected(
           RegisteredCliCommands.EXPERIMENT_VIEW_PUSH,
           experimentItem,
           [ExperimentType.EXPERIMENT]
@@ -167,12 +147,32 @@ export class ExperimentsTree
     commands.registerCommand(
       'dvc.views.experimentsTree.stopExperiment',
       (experimentItem: ExperimentItem) =>
-        callCommandWithSelected(
+        this.callCommandWithSelected(
           RegisteredCommands.EXPERIMENT_VIEW_STOP,
           experimentItem,
           [ExperimentType.RUNNING]
         )
     )
+  }
+
+  private async callCommandWithSelected(
+    command:
+      | RegisteredCliCommands.EXPERIMENT_VIEW_REMOVE
+      | RegisteredCliCommands.EXPERIMENT_VIEW_PUSH
+      | RegisteredCommands.EXPERIMENT_VIEW_STOP,
+    experimentItem: ExperimentItem | string,
+    types: ExperimentType[]
+  ) {
+    const selected = [...this.getSelectedExperimentItems(), experimentItem] as (
+      | string
+      | ExperimentItem
+    )[]
+
+    const acc = collectExperimentType(selected, new Set(types))
+
+    for (const [dvcRoot, ids] of Object.entries(acc)) {
+      await commands.executeCommand(command, { dvcRoot, ids: [...ids] })
+    }
   }
 
   private async getRootElements() {

--- a/extension/src/experiments/processExecution/collect.ts
+++ b/extension/src/experiments/processExecution/collect.ts
@@ -5,7 +5,7 @@ import {
 } from '../../cli/dvc/constants'
 import { getPidFromFile } from '../../fileSystem'
 
-const collectDvcRootPids = async (
+export const collectDvcRootPids = async (
   acc: Set<number>,
   dvcRoot: string
 ): Promise<void> => {

--- a/extension/src/experiments/processExecution/index.ts
+++ b/extension/src/experiments/processExecution/index.ts
@@ -1,7 +1,14 @@
+import { collectDvcRootPids } from './collect'
 import { processExists, stopProcesses } from '../../process/execution'
 
-export const stopWorkspaceExperiment = async (id: string, pid: number) => {
-  if (!(await processExists(pid))) {
+export const stopWorkspaceExperiment = async (dvcRoot: string, id: string) => {
+  const pids = new Set<number>()
+
+  await collectDvcRootPids(pids, dvcRoot)
+
+  const [pid] = [...pids]
+
+  if (!pid || !(await processExists(pid))) {
     return `process executing ${id} was not found.`
   }
 

--- a/extension/src/experiments/processExecution/index.ts
+++ b/extension/src/experiments/processExecution/index.ts
@@ -6,10 +6,16 @@ export const stopWorkspaceExperiment = async (dvcRoot: string, id: string) => {
 
   await collectDvcRootPids(pids, dvcRoot)
 
+  const notFound = `process executing ${id} was not found.`
+
+  if (pids.size === 0) {
+    return notFound
+  }
+
   const [pid] = [...pids]
 
   if (!pid || !(await processExists(pid))) {
-    return `process executing ${id} was not found.`
+    return notFound
   }
 
   const failedToStop = `failed to kill ${id}.`

--- a/extension/src/experiments/processExecution/index.ts
+++ b/extension/src/experiments/processExecution/index.ts
@@ -1,16 +1,16 @@
-import { Toast } from '../../vscode/toast'
 import { processExists, stopProcesses } from '../../process/execution'
 
-export const stopWorkspaceExperiment = async (pid: number) => {
+export const stopWorkspaceExperiment = async (id: string, pid: number) => {
   if (!(await processExists(pid))) {
-    return
+    return `process executing ${id} was not found.`
   }
 
-  void Toast.showOutput(
-    stopProcesses([pid]).then(stopped =>
-      stopped
-        ? 'The experiment running in the workspace was stopped.'
-        : 'Failed to stop the experiment running in the workspace.'
-    )
-  )
+  const failedToStop = `failed to kill ${id}.`
+
+  try {
+    const stopped = await stopProcesses([pid])
+    return stopped ? `${id} has been killed.` : failedToStop
+  } catch {
+    return failedToStop
+  }
 }

--- a/extension/src/experiments/processExecution/index.ts
+++ b/extension/src/experiments/processExecution/index.ts
@@ -1,14 +1,7 @@
-import { join } from 'path'
-import { EXP_RWLOCK_FILE } from '../../cli/dvc/constants'
-import { getPidFromFile } from '../../fileSystem'
 import { Toast } from '../../vscode/toast'
 import { processExists, stopProcesses } from '../../process/execution'
 
-export const stopWorkspaceExperiment = async (dvcRoot: string) => {
-  const pid = await getPidFromFile(join(dvcRoot, EXP_RWLOCK_FILE))
-  if (!pid) {
-    return
-  }
+export const stopWorkspaceExperiment = async (pid: number) => {
   if (!(await processExists(pid))) {
     return
   }

--- a/extension/src/experiments/webview/contract.ts
+++ b/extension/src/experiments/webview/contract.ts
@@ -16,7 +16,11 @@ export interface DepColumns {
   [path: string]: ValueWithChanges
 }
 
-export type RunningExperiment = { executor: Executor; id: string }
+export type RunningExperiment = {
+  executor: Executor
+  id: string
+  pid?: number | null
+}
 
 export type CommitData = {
   author: string
@@ -33,7 +37,6 @@ export type Experiment = {
   description?: string
   error?: string
   executor?: Executor
-  executorPid?: number
   id: string
   label: string
   metrics?: MetricOrParamColumns

--- a/extension/src/experiments/webview/contract.ts
+++ b/extension/src/experiments/webview/contract.ts
@@ -33,6 +33,7 @@ export type Experiment = {
   description?: string
   error?: string
   executor?: Executor
+  executorPid?: number
   id: string
   label: string
   metrics?: MetricOrParamColumns

--- a/extension/src/experiments/webview/contract.ts
+++ b/extension/src/experiments/webview/contract.ts
@@ -19,7 +19,6 @@ export interface DepColumns {
 export type RunningExperiment = {
   executor: Executor
   id: string
-  pid?: number | null
 }
 
 export type CommitData = {

--- a/extension/src/experiments/webview/messages.ts
+++ b/extension/src/experiments/webview/messages.ts
@@ -20,9 +20,6 @@ import { SortDefinition } from '../model/sortBy'
 import { getPositiveIntegerInput } from '../../vscode/inputBox'
 import { Title } from '../../vscode/title'
 import { ConfigKey, setConfigValue } from '../../vscode/config'
-import { Toast } from '../../vscode/toast'
-import { Executor, EXPERIMENT_WORKSPACE_ID } from '../../cli/dvc/contract'
-import { stopWorkspaceExperiment } from '../processExecution'
 import { hasDvcYamlFile } from '../../fileSystem'
 import { NUM_OF_COMMITS_TO_INCREASE } from '../../cli/dvc/constants'
 
@@ -35,10 +32,7 @@ export class WebviewMessages {
   private readonly getWebview: () => BaseWebview<TableData> | undefined
   private readonly notifyChanged: () => void
   private readonly selectColumns: () => Promise<void>
-  private readonly stopQueuedExperiments: (
-    dvcRoot: string,
-    ...ids: string[]
-  ) => Promise<string | undefined>
+  private readonly stopExperiments: (ids: string[]) => void
 
   private readonly hasStages: () => Promise<string | undefined>
 
@@ -62,10 +56,7 @@ export class WebviewMessages {
     getWebview: () => BaseWebview<TableData> | undefined,
     notifyChanged: () => void,
     selectColumns: () => Promise<void>,
-    stopQueuedExperiments: (
-      dvcRoot: string,
-      ...ids: string[]
-    ) => Promise<string | undefined>,
+    stopExperiments: (ids: string[]) => void,
     hasStages: () => Promise<string>,
     addStage: () => Promise<boolean>,
     selectBranches: (
@@ -80,7 +71,7 @@ export class WebviewMessages {
     this.getWebview = getWebview
     this.notifyChanged = notifyChanged
     this.selectColumns = selectColumns
-    this.stopQueuedExperiments = stopQueuedExperiments
+    this.stopExperiments = stopExperiments
     this.hasStages = hasStages
     this.addStage = addStage
     this.selectBranches = selectBranches
@@ -187,8 +178,8 @@ export class WebviewMessages {
         return this.setMaxTableHeadDepth()
       }
 
-      case MessageFromWebviewType.STOP_EXPERIMENT: {
-        return this.stopExperiments(message.payload)
+      case MessageFromWebviewType.STOP_EXPERIMENTS: {
+        return this.stopExperimentsAndSend(message.payload)
       }
 
       case MessageFromWebviewType.ADD_CONFIGURATION: {
@@ -443,37 +434,9 @@ export class WebviewMessages {
     )
   }
 
-  private stopExperiments(
-    runningExperiments: { id: string; executor?: string | null }[]
-  ) {
-    const { runningInQueueIds, runningInWorkspace } =
-      this.groupRunningExperiments(runningExperiments)
-
-    if (runningInQueueIds.size > 0) {
-      void Toast.showOutput(
-        this.stopQueuedExperiments(this.dvcRoot, ...runningInQueueIds)
-      )
-    }
-    if (runningInWorkspace) {
-      void stopWorkspaceExperiment(this.dvcRoot)
-    }
+  private stopExperimentsAndSend(ids: string[]) {
+    this.stopExperiments(ids)
 
     sendTelemetryEvent(EventName.EXPERIMENT_VIEW_STOP, undefined, undefined)
-  }
-
-  private groupRunningExperiments(
-    experiments: { executor?: string | null; id: string }[]
-  ) {
-    let runningInWorkspace = false
-    const runningInQueueIds = new Set<string>()
-    for (const { executor, id } of experiments) {
-      if (executor === EXPERIMENT_WORKSPACE_ID) {
-        runningInWorkspace = true
-      }
-      if (executor === Executor.DVC_TASK) {
-        runningInQueueIds.add(id)
-      }
-    }
-    return { runningInQueueIds, runningInWorkspace }
   }
 }

--- a/extension/src/experiments/webview/messages.ts
+++ b/extension/src/experiments/webview/messages.ts
@@ -32,7 +32,6 @@ export class WebviewMessages {
   private readonly getWebview: () => BaseWebview<TableData> | undefined
   private readonly notifyChanged: () => void
   private readonly selectColumns: () => Promise<void>
-  private readonly stopExperiments: (ids: string[]) => void
 
   private readonly hasStages: () => Promise<string | undefined>
 
@@ -56,7 +55,6 @@ export class WebviewMessages {
     getWebview: () => BaseWebview<TableData> | undefined,
     notifyChanged: () => void,
     selectColumns: () => Promise<void>,
-    stopExperiments: (ids: string[]) => void,
     hasStages: () => Promise<string>,
     addStage: () => Promise<boolean>,
     selectBranches: (
@@ -71,7 +69,6 @@ export class WebviewMessages {
     this.getWebview = getWebview
     this.notifyChanged = notifyChanged
     this.selectColumns = selectColumns
-    this.stopExperiments = stopExperiments
     this.hasStages = hasStages
     this.addStage = addStage
     this.selectBranches = selectBranches
@@ -179,7 +176,13 @@ export class WebviewMessages {
       }
 
       case MessageFromWebviewType.STOP_EXPERIMENTS: {
-        return this.stopExperimentsAndSend(message.payload)
+        return commands.executeCommand(
+          RegisteredCommands.EXPERIMENT_VIEW_STOP,
+          {
+            dvcRoot: this.dvcRoot,
+            ids: message.payload
+          }
+        )
       }
 
       case MessageFromWebviewType.ADD_CONFIGURATION: {
@@ -432,11 +435,5 @@ export class WebviewMessages {
       RegisteredCommands.EXPERIMENT_AND_PLOTS_SHOW,
       this.dvcRoot
     )
-  }
-
-  private stopExperimentsAndSend(ids: string[]) {
-    this.stopExperiments(ids)
-
-    sendTelemetryEvent(EventName.EXPERIMENT_VIEW_STOP, undefined, undefined)
   }
 }

--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -122,11 +122,20 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
     return this.getRepositoryThenUpdate('selectColumns', overrideRoot)
   }
 
-  public selectQueueTasksToKill() {
-    return this.pickIdsThenRun(
-      'pickQueueTasksToKill',
-      AvailableCommands.QUEUE_KILL
-    )
+  public async selectExperimentsToStop() {
+    const cwd = await this.getFocusedOrOnlyOrPickProject()
+    if (!cwd) {
+      return
+    }
+
+    const repository = this.getRepository(cwd)
+
+    const ids = await repository.pickRunningExperiments()
+
+    if (!ids || isEmpty(ids)) {
+      return
+    }
+    return repository.stopExperiments(ids)
   }
 
   public async selectExperimentsToPush(setup: Setup) {
@@ -145,11 +154,18 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
     return pushCommand({ dvcRoot, ids })
   }
 
-  public selectExperimentsToRemove() {
-    return this.pickIdsThenRun(
-      'pickExperimentsToRemove',
-      AvailableCommands.EXP_REMOVE
-    )
+  public async selectExperimentsToRemove() {
+    const cwd = await this.getFocusedOrOnlyOrPickProject()
+    if (!cwd) {
+      return
+    }
+
+    const ids = await this.getRepository(cwd).pickExperimentsToRemove()
+
+    if (!ids || isEmpty(ids)) {
+      return
+    }
+    return this.runCommand(AvailableCommands.EXP_REMOVE, cwd, ...ids)
   }
 
   public async modifyExperimentParamsAndRun(
@@ -509,25 +525,6 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
       ''
     const enteredManually = pathOrSelect !== selectValue
     return { command, enteredManually, trainingScript }
-  }
-
-  private async pickIdsThenRun(
-    pickMethod: 'pickQueueTasksToKill' | 'pickExperimentsToRemove',
-    commandId:
-      | typeof AvailableCommands.QUEUE_KILL
-      | typeof AvailableCommands.EXP_REMOVE
-  ) {
-    const cwd = await this.getFocusedOrOnlyOrPickProject()
-    if (!cwd) {
-      return
-    }
-
-    const ids = await this.getRepository(cwd)[pickMethod]()
-
-    if (!ids || isEmpty(ids)) {
-      return
-    }
-    return this.runCommand(commandId, cwd, ...ids)
   }
 
   private async pickExpThenRun(

--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -128,14 +128,16 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
       return
     }
 
-    const repository = this.getRepository(cwd)
-
-    const ids = await repository.pickRunningExperiments()
+    const ids = await this.getRepository(cwd).pickRunningExperiments()
 
     if (!ids || isEmpty(ids)) {
       return
     }
-    return repository.stopExperiments(ids)
+    return this.stopExperiments(cwd, ...ids)
+  }
+
+  public stopExperiments(dvcRoot: string, ...ids: string[]) {
+    return this.getRepository(dvcRoot).stopExperiments(ids)
   }
 
   public async selectExperimentsToPush(setup: Setup) {

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -148,7 +148,7 @@ export interface IEventNamePropertyMapping {
   [EventName.EXPERIMENT_VIEW_SHOW_LOGS]: undefined
   [EventName.EXPERIMENT_VIEW_STOP]: undefined
   [EventName.QUEUE_EXPERIMENT]: undefined
-  [EventName.QUEUE_KILL]: undefined
+  [EventName.EXPERIMENT_STOP]: undefined
   [EventName.QUEUE_START]: undefined
   [EventName.QUEUE_STOP]: undefined
 

--- a/extension/src/test/fixtures/expShow/base/output.ts
+++ b/extension/src/test/fixtures/expShow/base/output.ts
@@ -579,7 +579,7 @@ const data: ExpShowOutput = [
         ],
         executor: {
           name: Executor.WORKSPACE,
-          local: null,
+          local: { pid: 1234, root: null, log: null, returncode: null },
           state: ExperimentStatus.RUNNING
         }
       },

--- a/extension/src/test/fixtures/expShow/base/rows.ts
+++ b/extension/src/test/fixtures/expShow/base/rows.ts
@@ -272,7 +272,6 @@ export const rowsFixtureWithBranches: Commit[] = [
         displayColor: undefined,
         description: '[exp-83425]',
         executor: Executor.WORKSPACE,
-        executorPid: 1234,
         id: 'exp-83425',
         label: EXPERIMENT_WORKSPACE_ID,
         metrics: {

--- a/extension/src/test/fixtures/expShow/base/rows.ts
+++ b/extension/src/test/fixtures/expShow/base/rows.ts
@@ -272,6 +272,7 @@ export const rowsFixtureWithBranches: Commit[] = [
         displayColor: undefined,
         description: '[exp-83425]',
         executor: Executor.WORKSPACE,
+        executorPid: 1234,
         id: 'exp-83425',
         label: EXPERIMENT_WORKSPACE_ID,
         metrics: {

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -1249,6 +1249,11 @@ suite('Experiments Test Suite', () => {
 
       stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
       const mockPid = 1234
+      const mockGetPidFromFile = stub(FileSystem, 'getPidFromFile')
+        .onFirstCall()
+        .resolves(mockPid)
+        .onSecondCall()
+        .resolves(undefined)
       const mockProcessExists = stub(
         ProcessExecution,
         'processExists'
@@ -1262,6 +1267,7 @@ suite('Experiments Test Suite', () => {
       await Promise.all([experimentsKilled, workspaceStopped])
 
       expect(mockQueueKill).to.be.calledWith(dvcDemoPath, 'exp-e7a67')
+      expect(mockGetPidFromFile).to.be.calledTwice
       expect(mockProcessExists).to.be.calledWithExactly(mockPid)
       expect(mockStopProcesses).to.be.calledWithExactly([mockPid])
     }).timeout(WEBVIEW_TEST_TIMEOUT)

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -63,7 +63,7 @@ import * as Telemetry from '../../../telemetry'
 import { EventName } from '../../../telemetry/constants'
 import * as VscodeContext from '../../../vscode/context'
 import { Title } from '../../../vscode/title'
-import { EXP_RWLOCK_FILE, ExperimentFlag } from '../../../cli/dvc/constants'
+import { ExperimentFlag } from '../../../cli/dvc/constants'
 import { DvcExecutor } from '../../../cli/dvc/executor'
 import { WorkspacePlots } from '../../../plots/workspace'
 import {
@@ -1245,32 +1245,23 @@ suite('Experiments Test Suite', () => {
 
       const webview = await experiments.showWebview()
       const mockMessageReceived = getMessageReceivedEmitter(webview)
-      const mockExperimentIds = ['exp-e7a67', 'test-branch']
+      const mockExperimentIds = ['exp-e7a67', 'exp-83425']
 
       stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
       const mockPid = 1234
-      const mockGetPidFromFile = stub(FileSystem, 'getPidFromFile').resolves(
-        mockPid
-      )
       const mockProcessExists = stub(
         ProcessExecution,
         'processExists'
       ).resolves(true)
 
       mockMessageReceived.fire({
-        payload: [
-          ...mockExperimentIds.map(id => ({ executor: Executor.DVC_TASK, id })),
-          { executor: Executor.WORKSPACE, id: EXPERIMENT_WORKSPACE_ID }
-        ],
-        type: MessageFromWebviewType.STOP_EXPERIMENT
+        payload: mockExperimentIds,
+        type: MessageFromWebviewType.STOP_EXPERIMENTS
       })
 
       await Promise.all([experimentsKilled, workspaceStopped])
 
-      expect(mockQueueKill).to.be.calledWith(dvcDemoPath, ...mockExperimentIds)
-      expect(mockGetPidFromFile).to.be.calledWithExactly(
-        join(dvcDemoPath, EXP_RWLOCK_FILE)
-      )
+      expect(mockQueueKill).to.be.calledWith(dvcDemoPath, 'exp-e7a67')
       expect(mockProcessExists).to.be.calledWithExactly(mockPid)
       expect(mockStopProcesses).to.be.calledWithExactly([mockPid])
     }).timeout(WEBVIEW_TEST_TIMEOUT)

--- a/extension/src/test/suite/experiments/model/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/tree.test.ts
@@ -439,6 +439,55 @@ suite('Experiments Tree Test Suite', () => {
       )
     })
 
+    it('should be able to stop multiple running experiments with dvc.views.experimentsTree.stopExperiment', async () => {
+      bypassProgressCloseDelay()
+      const mockFirstExperimentId = 'first-exp-stopped'
+      const mockSecondExperimentId = 'second-exp-stopped'
+      const mockQueuedExperimentLabel = 'queued-excluded'
+
+      const mockStopExperiments = stub(
+        WorkspaceExperiments.prototype,
+        'stopExperiments'
+      ).resolves(undefined)
+
+      stubPrivatePrototypeMethod(
+        ExperimentsTree,
+        'getSelectedExperimentItems'
+      ).returns([
+        dvcDemoPath,
+        {
+          dvcRoot: dvcDemoPath,
+          label: mockQueuedExperimentLabel,
+          type: ExperimentType.QUEUED
+        },
+        {
+          dvcRoot: dvcDemoPath,
+          id: mockFirstExperimentId,
+          type: ExperimentType.RUNNING
+        },
+        {
+          dvcRoot: dvcDemoPath,
+          id: 'workspace-excluded',
+          type: ExperimentType.WORKSPACE
+        }
+      ])
+
+      await commands.executeCommand(
+        'dvc.views.experimentsTree.stopExperiment',
+        {
+          dvcRoot: dvcDemoPath,
+          id: mockSecondExperimentId,
+          type: ExperimentType.RUNNING
+        }
+      )
+
+      expect(mockStopExperiments).to.be.calledWithExactly(
+        dvcDemoPath,
+        mockFirstExperimentId,
+        mockSecondExperimentId
+      )
+    })
+
     it('should be able to apply an experiment to the workspace with dvc.views.experiments.applyExperiment', async () => {
       const { experiments } = buildExperiments(disposable)
 

--- a/extension/src/test/suite/experiments/workspace.test.ts
+++ b/extension/src/test/suite/experiments/workspace.test.ts
@@ -447,8 +447,8 @@ suite('Workspace Experiments Test Suite', () => {
     })
   })
 
-  describe('dvc.stopQueuedExperiments', () => {
-    it('should be able to kill running queue tasks', async () => {
+  describe('dvc.stopExperiments', () => {
+    it('should be able to stop any running experiment', async () => {
       const mockQueueKill = stub(DvcExecutor.prototype, 'queueKill').resolves(
         undefined
       )
@@ -472,7 +472,7 @@ suite('Workspace Experiments Test Suite', () => {
 
       stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
-      await commands.executeCommand(RegisteredCliCommands.QUEUE_KILL)
+      await commands.executeCommand(RegisteredCommands.EXPERIMENT_STOP)
 
       expect(mockShowQuickPick).to.be.calledWithExactly(
         [
@@ -483,13 +483,21 @@ suite('Workspace Experiments Test Suite', () => {
             )}, loss:2.0205045, accuracy:0.37241668`,
             label: '4fb124a',
             value: queueTaskId
+          },
+          {
+            description: '[exp-83425]',
+            detail: `Created:${formatDate(
+              '2020-12-29T15:27:02'
+            )}, loss:1.7750162, accuracy:0.59265000`,
+            label: 'workspace',
+            value: 'exp-83425'
           }
         ],
         {
           canPickMany: true,
           matchOnDescription: true,
           matchOnDetail: true,
-          title: Title.SELECT_QUEUE_KILL
+          title: Title.SELECT_EXPERIMENTS_STOP
         }
       )
       expect(mockQueueKill).to.be.calledOnce

--- a/extension/src/util/number.ts
+++ b/extension/src/util/number.ts
@@ -11,12 +11,12 @@ export const formatNumber = (value: number): string => {
 }
 
 export const isValidStringInteger = (
-  input: string | undefined
+  input: string | undefined | null
 ): input is string =>
   !!input && Number.parseInt(input) === Number.parseFloat(input)
 
 export const createValidInteger = (
-  input: string | number | undefined
+  input: string | number | undefined | null
 ): number | undefined => {
   if (typeof input === 'number') {
     return validateNumericInteger(input)

--- a/extension/src/vscode/title.ts
+++ b/extension/src/vscode/title.ts
@@ -31,7 +31,7 @@ export enum Title {
   SELECT_CUSTOM_PLOTS_TO_REMOVE = 'Select Custom Plot(s) to Remove',
   SELECT_PARAM_TO_MODIFY = 'Select Param(s) to Modify',
   SELECT_PLOTS = 'Select Plots to Display',
-  SELECT_QUEUE_KILL = 'Select Queue Task(s) to Kill',
+  SELECT_EXPERIMENTS_STOP = 'Select Experiments to Stop',
   SELECT_SORT_DIRECTION = 'Select Sort Direction',
   SELECT_SORTS_TO_REMOVE = 'Select Sort(s) to Remove',
   SELECT_TRAINING_SCRIPT = 'Select your training script',

--- a/extension/src/webview/contract.ts
+++ b/extension/src/webview/contract.ts
@@ -38,7 +38,7 @@ export enum MessageFromWebviewType {
   RESIZE_PLOTS = 'resize-plots',
   SAVE_STUDIO_TOKEN = 'save-studio-token',
   SHOW_EXPERIMENT_LOGS = 'show-experiment-logs',
-  STOP_EXPERIMENT = 'stop-experiment',
+  STOP_EXPERIMENTS = 'stop-experiments',
   SORT_COLUMN = 'sort-column',
   TOGGLE_EXPERIMENT = 'toggle-experiment',
   TOGGLE_EXPERIMENT_STAR = 'toggle-experiment-star',
@@ -147,8 +147,8 @@ export type MessageFromWebview =
       payload: SortDefinition
     }
   | {
-      type: MessageFromWebviewType.STOP_EXPERIMENT
-      payload: { id: string; executor?: string | null }[]
+      type: MessageFromWebviewType.STOP_EXPERIMENTS
+      payload: string[]
     }
   | { type: MessageFromWebviewType.SHOW_EXPERIMENT_LOGS; payload: string }
   | {

--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -18,7 +18,7 @@ import {
 } from 'dvc/src/experiments/webview/contract'
 import { buildMetricOrParamPath } from 'dvc/src/experiments/columns/paths'
 import dataTypesTableFixture from 'dvc/src/test/fixtures/expShow/dataTypes/tableData'
-import { EXPERIMENT_WORKSPACE_ID, Executor } from 'dvc/src/cli/dvc/contract'
+import { EXPERIMENT_WORKSPACE_ID } from 'dvc/src/cli/dvc/contract'
 import { useIsFullyContained } from './overflowHoverTooltip/useIsFullyContained'
 import styles from './table/styles.module.scss'
 import { vsCodeApi } from '../../shared/api'
@@ -1144,8 +1144,8 @@ describe('App', () => {
       stopOption && fireEvent.click(stopOption)
 
       expect(sendMessage).toHaveBeenCalledWith({
-        payload: [{ executor: Executor.DVC_TASK, id: 'exp-e7a67' }],
-        type: MessageFromWebviewType.STOP_EXPERIMENT
+        payload: ['exp-e7a67'],
+        type: MessageFromWebviewType.STOP_EXPERIMENTS
       })
     })
 
@@ -1175,7 +1175,7 @@ describe('App', () => {
 
       expect(sendMessage).toHaveBeenCalledWith({
         payload: ['exp-e7a67', 'exp-83425'],
-        type: MessageFromWebviewType.STOP_EXPERIMENT
+        type: MessageFromWebviewType.STOP_EXPERIMENTS
       })
     })
 
@@ -1218,10 +1218,8 @@ describe('App', () => {
       stopOption && fireEvent.click(stopOption)
 
       expect(sendMessage).toHaveBeenCalledWith({
-        payload: [
-          { executor: Executor.WORKSPACE, id: EXPERIMENT_WORKSPACE_ID }
-        ],
-        type: MessageFromWebviewType.STOP_EXPERIMENT
+        payload: [EXPERIMENT_WORKSPACE_ID],
+        type: MessageFromWebviewType.STOP_EXPERIMENTS
       })
     })
 

--- a/webview/src/experiments/components/table/body/RowContextMenu.tsx
+++ b/webview/src/experiments/components/table/body/RowContextMenu.tsx
@@ -135,7 +135,7 @@ const getMultiSelectMenuOptions = (
     experimentMenuOption(
       selectedIds,
       'Stop',
-      MessageFromWebviewType.STOP_EXPERIMENT,
+      MessageFromWebviewType.STOP_EXPERIMENTS,
       disableStopOption,
       true
     ),
@@ -270,9 +270,9 @@ const getSingleSelectMenuOptions = (
       !hasRunningWorkspaceExperiment
     ),
     experimentMenuOption(
-      [{ executor, id }],
+      [id],
       'Stop',
-      MessageFromWebviewType.STOP_EXPERIMENT,
+      MessageFromWebviewType.STOP_EXPERIMENTS,
       !isRunning(status),
       id !== EXPERIMENT_WORKSPACE_ID
     ),


### PR DESCRIPTION
# 3/3 `main` <- #3832  <- #3834 <- this

This PR consolidates our "Stop Experiment" commands. There is now no external separation between stopping an experiment running in the workspace or queue. Experiments can now be stopped via an inline action shown in the experiments tree, the tree's view/title, the experiments table context menu, the editor/title and the command palette.

### Demo


https://user-images.githubusercontent.com/37993418/236997101-d7dc95e8-8b55-43a1-ae2a-799625bdbc4e.mov

https://user-images.githubusercontent.com/37993418/236997230-a74a6f7b-a106-49b8-98ad-53fd23072ba1.mov


https://user-images.githubusercontent.com/37993418/237008688-1c08b0b6-2f04-4c42-96a5-133e1d2f021e.mov



https://user-images.githubusercontent.com/37993418/236998675-ef50fe40-a5ce-4793-a056-24ef858a04b3.mov
