### PR TITLE
Prevent queued experiment from being selected as most recent

### DIFF
--- a/extension/src/experiments/model/status/collect.test.ts
+++ b/extension/src/experiments/model/status/collect.test.ts
@@ -356,11 +356,16 @@ describe('collectFinishedRunningExperiments', () => {
     expect(finishedRunning).toStrictEqual({})
   })
 
-  it('should return the most recently created and unseen (without a status) experiment if there is no longer an experiment running in the workspace', () => {
+  it('should return the most recently created and unseen and unqueued (without a status) experiment if there is no longer an experiment running in the workspace', () => {
     const latestCreatedId = 'exp-123'
     const finishedRunning = collectFinishedRunningExperiments(
       {},
       [
+        {
+          Created: '2023-12-01T10:48:24',
+          id: 'exp-queued',
+          status: ExperimentStatus.QUEUED
+        },
         { Created: '2022-12-02T10:48:24', id: 'exp-456' },
         { Created: '2022-10-02T07:48:24', id: 'exp-789' },
         { Created: '2022-12-02T07:48:25', id: latestCreatedId },

--- a/extension/src/experiments/model/status/collect.ts
+++ b/extension/src/experiments/model/status/collect.ts
@@ -293,7 +293,9 @@ const getMostRecentExperiment = (
   coloredStatus: ColoredStatus
 ): Experiment | undefined =>
   experiments
-    .filter(({ id }) => coloredStatus[id] === undefined)
+    .filter(
+      ({ id, status }) => coloredStatus[id] === undefined && !isQueued(status)
+    )
     .sort(({ Created: aCreated }, { Created: bCreated }) => {
       if (!aCreated) {
         return 1


### PR DESCRIPTION
Fixes the bug shown at the end of this demo:


https://user-images.githubusercontent.com/37993418/236996763-b7963a94-fe0c-4cab-b48c-8cc6f2c77cf8.mov

