### PR TITLE
Add available codicons to Storybook

### DIFF
--- a/webview/src/stories/Icons.stories.tsx
+++ b/webview/src/stories/Icons.stories.tsx
@@ -19,13 +19,24 @@ export default {
 
 const Template: StoryFn = () => {
   return (
-    <IconsWrapper>
-      {Object.values(Icons).map(IconComponent => (
-        <IconWrapper key={IconComponent.name} name={IconComponent.name}>
-          <Icon icon={IconComponent} />
-        </IconWrapper>
-      ))}
-    </IconsWrapper>
+    <>
+      <IconsWrapper>
+        {Object.values(Icons).map(IconComponent => (
+          <IconWrapper key={IconComponent.name} name={IconComponent.name}>
+            <Icon icon={IconComponent} />
+          </IconWrapper>
+        ))}
+      </IconsWrapper>
+      <p>
+        <a href="https://microsoft.github.io/vscode-codicons/dist/codicon.html">
+          Other icons that can be added
+        </a>
+      </p>
+      <p>
+        Copy the icon name, add it to `codicons` constant in
+        `webview/icons/generate.mjs` and run `yarn svgr`.
+      </p>
+    </>
   )
 }
 


### PR DESCRIPTION
# 4/4 main <= #3871 <= #3872 <= #3873 <= this

Last step of #3848 

No need to add a story of available codicons as they are not yet (all) in our codebase and there is already a page that list them all. Thought it'd be nice to link to that page so that it makes things easier when chosing an icon (pick one available or copy a codicon one).