### PR TITLE
Debounce calls to git branch

### DIFF
--- a/extension/src/experiments/data/index.ts
+++ b/extension/src/experiments/data/index.ts
@@ -41,6 +41,7 @@ export class ExperimentsData extends BaseData<ExpShowOutput> {
   }
 
   public async update(): Promise<void> {
+    void this.updateAvailableBranchesToSelect()
     const flags = this.experiments.getIsBranchesView()
       ? [ExperimentFlag.ALL_BRANCHES]
       : [
@@ -95,7 +96,6 @@ export class ExperimentsData extends BaseData<ExpShowOutput> {
         if (
           watchedRelPaths.some(watchedRelPath => path.includes(watchedRelPath))
         ) {
-          void this.updateAvailableBranchesToSelect()
           return this.managedUpdate()
         }
       }


### PR DESCRIPTION
Whilst testing with the output channel open I noticed this:

```
[version: 0.8.11, 2023-05-15T04:03:47.737Z, pid: 99240] > git branch --no-merge - INITIALIZED
[version: 0.8.11, 2023-05-15T04:03:47.738Z, pid: 99245] > git branch --no-merge - INITIALIZED
[version: 0.8.11, 2023-05-15T04:03:47.739Z, pid: 99250] > git branch --no-merge - INITIALIZED
[version: 0.8.11, 2023-05-15T04:03:47.741Z, pid: 99255] > git branch --no-merge - INITIALIZED
[version: 0.8.11, 2023-05-15T04:03:47.742Z, pid: 99260] > git branch --no-merge - INITIALIZED
[version: 0.8.11, 2023-05-15T04:03:47.744Z, pid: 99265] > git branch --no-merge - INITIALIZED
[version: 0.8.11, 2023-05-15T04:03:47.745Z, pid: 99270] > git branch --no-merge - INITIALIZED
[version: 0.8.11, 2023-05-15T04:03:47.749Z, pid: 99275] > git branch --no-merge - INITIALIZED
[version: 0.8.11, 2023-05-15T04:03:47.752Z, pid: 99280] > git branch --no-merge - INITIALIZED
[version: 0.8.11, 2023-05-15T04:03:47.754Z, pid: 99285] > git branch --no-merge - INITIALIZED
[version: 0.8.11, 2023-05-15T04:03:47.756Z, pid: 99290] > git branch --no-merge - INITIALIZED
[version: 0.8.11, 2023-05-15T04:03:47.758Z, pid: 99295] > git branch --no-merge - INITIALIZED
[version: 0.8.11, 2023-05-15T04:03:47.761Z, pid: 99300] > git branch --no-merge - INITIALIZED
[version: 0.8.11, 2023-05-15T04:03:47.764Z, pid: 99305] > git branch --no-merge - INITIALIZED
[version: 0.8.11, 2023-05-15T04:03:47.766Z, pid: 99310] > git branch --no-merge - INITIALIZED
[version: 0.8.11, 2023-05-15T04:03:47.767Z, pid: 99315] > git branch --no-merge - INITIALIZED
[version: 0.8.11, 2023-05-15T04:03:47.768Z, pid: 99320] > git branch --no-merge - INITIALIZED
[version: 0.8.11, 2023-05-15T04:03:47.770Z, pid: 99325] > git branch --no-merge - INITIALIZED
[version: 0.8.11, 2023-05-15T04:03:47.772Z, pid: 99330] > git branch --no-merge - INITIALIZED
[version: 0.8.11, 2023-05-15T04:03:47.773Z, pid: 99335] > git branch --no-merge - INITIALIZED
[version: 0.8.11, 2023-05-15T04:03:47.776Z, pid: 99340] > git branch --no-merge - INITIALIZED
[version: 0.8.11, 2023-05-15T04:03:47.778Z, pid: 99345] > git branch --no-merge - INITIALIZED
[version: 0.8.11, 2023-05-15T04:03:47.780Z, pid: 99350] > git branch --no-merge - INITIALIZED
[version: 0.8.11, 2023-05-15T04:03:47.800Z, pid: 99234] > git branch --no-merge - COMPLETED (68ms)
[version: 0.8.11, 2023-05-15T04:03:47.801Z, pid: 99240] > git branch --no-merge - COMPLETED (66ms)
[version: 0.8.11, 2023-05-15T04:03:47.801Z, pid: 99245] > git branch --no-merge - COMPLETED (64ms)
[version: 0.8.11, 2023-05-15T04:03:47.801Z, pid: 99250] > git branch --no-merge - COMPLETED (63ms)
[version: 0.8.11, 2023-05-15T04:03:47.801Z, pid: 99255] > git branch --no-merge - COMPLETED (61ms)
[version: 0.8.11, 2023-05-15T04:03:47.801Z, pid: 99260] > git branch --no-merge - COMPLETED (60ms)
[version: 0.8.11, 2023-05-15T04:03:47.802Z, pid: 99265] > git branch --no-merge - COMPLETED (59ms)
[version: 0.8.11, 2023-05-15T04:03:47.802Z, pid: 99270] > git branch --no-merge - COMPLETED (58ms)
[version: 0.8.11, 2023-05-15T04:03:47.802Z, pid: 99275] > git branch --no-merge - COMPLETED (55ms)
[version: 0.8.11, 2023-05-15T04:03:47.802Z, pid: 99280] > git branch --no-merge - COMPLETED (53ms)
[version: 0.8.11, 2023-05-15T04:03:47.802Z, pid: 99285] > git branch --no-merge - COMPLETED (50ms)
[version: 0.8.11, 2023-05-15T04:03:47.803Z, pid: 99290] > git branch --no-merge - COMPLETED (49ms)
[version: 0.8.11, 2023-05-15T04:03:47.803Z, pid: 99295] > git branch --no-merge - COMPLETED (46ms)
[version: 0.8.11, 2023-05-15T04:03:47.803Z, pid: 99300] > git branch --no-merge - COMPLETED (44ms)
[version: 0.8.11, 2023-05-15T04:03:47.804Z, pid: 99305] > git branch --no-merge - COMPLETED (42ms)
[version: 0.8.11, 2023-05-15T04:03:47.804Z, pid: 99310] > git branch --no-merge - COMPLETED (40ms)
[version: 0.8.11, 2023-05-15T04:03:47.804Z, pid: 99315] > git branch --no-merge - COMPLETED (38ms)
[version: 0.8.11, 2023-05-15T04:03:47.807Z, pid: 99320] > git branch --no-merge - COMPLETED (40ms)
[version: 0.8.11, 2023-05-15T04:03:47.808Z, pid: 99325] > git branch --no-merge - COMPLETED (39ms)
[version: 0.8.11, 2023-05-15T04:03:47.808Z, pid: 99330] > git branch --no-merge - COMPLETED (37ms)
[version: 0.8.11, 2023-05-15T04:03:47.808Z, pid: 99335] > git branch --no-merge - COMPLETED (36ms)
[version: 0.8.11, 2023-05-15T04:03:47.808Z, pid: 99340] > git branch --no-merge - COMPLETED (33ms)
[version: 0.8.11, 2023-05-15T04:03:47.809Z, pid: 99345] > git branch --no-merge - COMPLETED (32ms)
[version: 0.8.11, 2023-05-15T04:03:47.809Z, pid: 99350] > git branch --no-merge - COMPLETED (30ms)
```
This PR denounces calls to `git branch --no-merge` by moving them into `managedUpdate` in the `ExperimentsData` class. If you can foresee any problems with this approach then PLMK.