### PR TITLE
Remove node-fetch as a dependency (not used)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1646,7 +1646,6 @@
     "lodash.isequal": "4.5.0",
     "lodash.merge": "4.6.2",
     "lodash.omit": "4.5.0",
-    "node-fetch": "2.6.9",
     "process-exists": "5.0.0",
     "tree-kill": "1.2.2",
     "uuid": "9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15321,7 +15321,7 @@ node-fetch@2.6.7, node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-fetch@2.6.9, node-fetch@^2.6.1:
+node-fetch@^2.6.1:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.9.tgz#7c7f744b5cc6eb5fd404e0c7a9fec630a55657e6"
   integrity sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==


### PR DESCRIPTION
Should have happened as part of #3701 

Only usage was here: https://github.com/iterative/vscode-dvc/pull/3701/files#diff-0c095cd50907ac209c355a668b44f0fd44115f936f75133ec41ad8754c3293fdL2