### PR TITLE
Make use of show experiments command for setup page

### DIFF
--- a/extension/src/setup/index.ts
+++ b/extension/src/setup/index.ts
@@ -1,5 +1,5 @@
 import { join } from 'path'
-import { Event, EventEmitter, ViewColumn, workspace } from 'vscode'
+import { Event, EventEmitter, workspace } from 'vscode'
 import { Disposable, Disposer } from '@hediet/std/disposable'
 import isEmpty from 'lodash.isempty'
 import {
@@ -75,7 +75,6 @@ export class Setup
   private readonly internalCommands: InternalCommands
 
   private readonly webviewMessages: WebviewMessages
-  private readonly showExperiments: () => void
   private readonly getHasData: () => boolean | undefined
   private readonly collectWorkspaceScale: () => Promise<WorkspaceScale>
 
@@ -128,10 +127,6 @@ export class Setup
 
     if (this.webview) {
       void this.sendDataToWebview()
-    }
-
-    this.showExperiments = () => {
-      void experiments.showWebview(this.dvcRoots[0], ViewColumn.Active)
     }
 
     this.getHasData = () => experiments.getHasData()
@@ -421,8 +416,7 @@ export class Setup
   private createWebviewMessageHandler() {
     const webviewMessages = new WebviewMessages(
       () => this.getWebview(),
-      () => this.initializeGit(),
-      () => this.showExperiments()
+      () => this.initializeGit()
     )
     this.dispose.track(
       this.onDidReceivedWebviewMessage(message =>

--- a/extension/src/setup/webview/messages.ts
+++ b/extension/src/setup/webview/messages.ts
@@ -20,16 +20,13 @@ import { openUrl } from '../../vscode/external'
 export class WebviewMessages {
   private readonly getWebview: () => BaseWebview<TSetupData> | undefined
   private readonly initializeGit: () => void
-  private readonly showExperiments: () => void
 
   constructor(
     getWebview: () => BaseWebview<TSetupData> | undefined,
-    initializeGit: () => void,
-    showExperiments: () => void
+    initializeGit: () => void
   ) {
     this.getWebview = getWebview
     this.initializeGit = initializeGit
-    this.showExperiments = showExperiments
   }
 
   public sendWebviewMessage({
@@ -100,7 +97,7 @@ export class WebviewMessages {
           message.payload
         )
       case MessageFromWebviewType.OPEN_EXPERIMENTS_WEBVIEW:
-        return this.showExperiments()
+        return commands.executeCommand(RegisteredCommands.EXPERIMENT_SHOW)
 
       default:
         Logger.error(`Unexpected message: ${JSON.stringify(message)}`)

--- a/extension/src/test/suite/setup/index.test.ts
+++ b/extension/src/test/suite/setup/index.test.ts
@@ -793,19 +793,30 @@ suite('Setup Test Suite', () => {
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should handle a message to open the experiments webview', async () => {
-      const { messageSpy, setup, mockOpenExperiments } = buildSetup(disposable)
+      const { messageSpy, setup, mockShowWebview, mockExecuteCommand } =
+        buildSetup(disposable)
 
       const webview = await setup.showWebview()
       await webview.isReady()
+      mockExecuteCommand.restore()
 
       const mockMessageReceived = getMessageReceivedEmitter(webview)
+
+      const showWebviewCalled = new Promise(resolve =>
+        mockShowWebview.callsFake(() => {
+          resolve(undefined)
+          return Promise.resolve(undefined)
+        })
+      )
+      stub(Setup.prototype, 'shouldBeShown').returns(false)
 
       messageSpy.resetHistory()
       mockMessageReceived.fire({
         type: MessageFromWebviewType.OPEN_EXPERIMENTS_WEBVIEW
       })
 
-      expect(mockOpenExperiments).to.be.calledOnce
+      await showWebviewCalled
+      expect(mockShowWebview).to.be.calledOnce
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should send the appropriate messages to the webview to focus different sections', async () => {

--- a/extension/src/test/suite/setup/util.ts
+++ b/extension/src/test/suite/setup/util.ts
@@ -63,7 +63,7 @@ export const buildSetup = (
   const mockAutoInstallDvc = stub(AutoInstall, 'autoInstallDvc')
   stub(AutoInstall, 'findPythonBinForInstall').resolves(undefined)
 
-  const mockOpenExperiments = fake()
+  const mockShowWebview = stub(WorkspaceExperiments.prototype, 'showWebview')
 
   const mockRunSetup = stub(Runner, 'run').resolves(undefined)
 
@@ -88,7 +88,7 @@ export const buildSetup = (
       {
         columnsChanged: mockEmitter,
         getHasData: () => hasData,
-        showWebview: mockOpenExperiments
+        showWebview: mockShowWebview
       } as unknown as WorkspaceExperiments,
       { setAvailability: stub() } as unknown as Status,
       resourceLocator.dvcIcon,
@@ -108,9 +108,9 @@ export const buildSetup = (
     mockGetGitRepositoryRoot,
     mockGlobalVersion,
     mockInitializeGit,
-    mockOpenExperiments,
     mockOpenExternal,
     mockRunSetup,
+    mockShowWebview,
     mockVersion,
     resourceLocator,
     setup,


### PR DESCRIPTION
Closes #3909 

This PR wires up the `dvc.showExperiments` command with the "Show Experiments" button in the setup webview to get around there being multiple DVC projects within the workspace.

### Demo

https://github.com/iterative/vscode-dvc/assets/37993418/a0310d43-62d6-4fdb-8627-10d9ec8fa2ee

