### PR TITLE
Create default exp show output constant

### DIFF
--- a/extension/src/cli/dvc/contract.ts
+++ b/extension/src/cli/dvc/contract.ts
@@ -60,6 +60,13 @@ export type MetricsOrParams = RelPathObject<FileDataOrError>
 export const fileHasError = (file: FileDataOrError): file is DvcError =>
   !!(file as DvcError).error
 
+export const DEFAULT_EXP_SHOW_OUTPUT = [
+  {
+    branch: undefined,
+    rev: EXPERIMENT_WORKSPACE_ID
+  }
+]
+
 export type ExpData = {
   rev: string
   timestamp: string | null

--- a/extension/src/cli/dvc/reader.ts
+++ b/extension/src/cli/dvc/reader.ts
@@ -10,12 +10,12 @@ import {
 } from './constants'
 import {
   DataStatusOutput,
+  DEFAULT_EXP_SHOW_OUTPUT,
   DvcError,
-  EXPERIMENT_WORKSPACE_ID,
+  ExpShowOutput,
   PlotsOutput,
   PlotsOutputOrError,
-  RawPlotsOutput,
-  ExpShowOutput
+  RawPlotsOutput
 } from './contract'
 import { getOptions } from './options'
 import { typeCheckCommands } from '..'
@@ -76,8 +76,7 @@ export class DvcReader extends DvcCli {
     if (isDvcError(output) || isEmpty(output)) {
       return [
         {
-          branch: undefined,
-          rev: EXPERIMENT_WORKSPACE_ID,
+          ...DEFAULT_EXP_SHOW_OUTPUT[0],
           ...(output as DvcError)
         }
       ]

--- a/extension/src/test/cli/expShow.test.ts
+++ b/extension/src/test/cli/expShow.test.ts
@@ -5,9 +5,9 @@ import { TEMP_DIR } from './constants'
 import { dvcReader, initializeDemoRepo, initializeEmptyRepo } from './util'
 import { dvcDemoPath } from '../util'
 import {
-  EXPERIMENT_WORKSPACE_ID,
   fileHasError,
-  experimentHasError
+  experimentHasError,
+  DEFAULT_EXP_SHOW_OUTPUT
 } from '../../cli/dvc/contract'
 import { ExperimentFlag } from '../../cli/dvc/constants'
 
@@ -87,11 +87,7 @@ suite('exp show --show-json', () => {
       await initializeEmptyRepo()
       const output = await dvcReader.expShow(TEMP_DIR)
 
-      expect(output).to.deep.equal([
-        {
-          rev: EXPERIMENT_WORKSPACE_ID
-        }
-      ])
+      expect(output).to.deep.equal(DEFAULT_EXP_SHOW_OUTPUT)
     })
   })
 })


### PR DESCRIPTION
This PR fixes the scheduled CLI tests by creating a `DEFAULT_EXP_SHOW_OUTPUT` constant.

Failure was here: https://github.com/iterative/vscode-dvc/actions/runs/4998320234/jobs/8953599227