### PR TITLE
Ensure unique list of experiment passed to the rest of the app

### DIFF
--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -626,7 +626,7 @@ export class Experiments extends BaseRepository<TableData> {
     }
 
     return await pickExperiment(
-      this.experiments.getCombinedList(),
+      this.experiments.getUniqueList(),
       this.getFirstThreeColumnOrder(),
       Title.SELECT_BASE_EXPERIMENT
     )

--- a/extension/src/experiments/model/collect.test.ts
+++ b/extension/src/experiments/model/collect.test.ts
@@ -85,4 +85,47 @@ describe('collectExperiments', () => {
       tags: []
     })
   })
+
+  it('should not collect the same experiment twice', () => {
+    const main = {
+      experiments: [
+        {
+          name: 'campy-pall',
+          rev: '0b4b001dfaa8f2c4cd2a62238699131ab2c679ea'
+        },
+        {
+          name: 'shyer-stir',
+          rev: '450e672f0d8913517ab2ab443f5d87b34f308290'
+        }
+      ],
+      name: 'main',
+      rev: '61bed4ce8913eca7f73ca754d65bc5daad1520e2'
+    }
+
+    const expShowWithDuplicateCommits = generateTestExpShowOutput(
+      {},
+      main,
+      {
+        name: 'branchOffMainWithCommit',
+        rev: '351e42ace3cb6a3a853c65bef285e60748cc6341'
+      },
+      main
+    )
+
+    const { experimentsByCommit, commits } = collectExperiments(
+      expShowWithDuplicateCommits,
+      false,
+      ''
+    )
+
+    expect(commits.length).toStrictEqual(3)
+
+    const experiments = experimentsByCommit.get('main')
+
+    expect(experiments?.length).toStrictEqual(2)
+    expect(experiments?.map(({ id }) => id).sort()).toStrictEqual([
+      'campy-pall',
+      'shyer-stir'
+    ])
+  })
 })

--- a/extension/src/experiments/model/collect.ts
+++ b/extension/src/experiments/model/collect.ts
@@ -251,16 +251,25 @@ const collectExpRange = (
   const expState = revs[0]
 
   const { name, rev } = expState
-  const { branch, id } = baseline
+  const { id: baselineId } = baseline
 
   const label =
     rev === EXPERIMENT_WORKSPACE_ID
       ? EXPERIMENT_WORKSPACE_ID
       : shortenForLabel(rev)
 
+  const experimentId = name || label
+
+  if (
+    acc.experimentsByCommit
+      .get(baselineId)
+      ?.find(({ id }) => id === experimentId)
+  ) {
+    return
+  }
+
   const experiment = transformExpState(
     {
-      branch,
       id: name || label,
       label
     },
@@ -275,7 +284,7 @@ const collectExpRange = (
   collectExecutorInfo(experiment, executor)
   collectRunningExperiment(acc, experiment)
 
-  addToMapArray(acc.experimentsByCommit, id, experiment)
+  addToMapArray(acc.experimentsByCommit, baselineId, experiment)
 }
 
 const setWorkspaceAsRunning = (

--- a/extension/src/experiments/model/index.test.ts
+++ b/extension/src/experiments/model/index.test.ts
@@ -141,7 +141,7 @@ describe('ExperimentsModel', () => {
 
     model.transformAndSet(data, false, '')
 
-    const experiments = model.getCombinedList()
+    const experiments = model.getUniqueList()
 
     const changed: string[] = []
     for (const { deps, sha } of experiments) {
@@ -273,7 +273,7 @@ describe('ExperimentsModel', () => {
     model.setSelected([])
     expect(model.getSelectedRevisions().map(({ id }) => id)).toStrictEqual([])
 
-    model.setSelected(model.getCombinedList())
+    model.setSelected(model.getUniqueList())
     expect(model.getSelectedRevisions().map(({ id }) => id)).toStrictEqual([
       EXPERIMENT_WORKSPACE_ID,
       'testBranch',

--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -637,27 +637,6 @@ export class ExperimentsModel extends ModelWithPersistence {
     return color
   }
 
-  private getSelectedFromList(getList: () => Experiment[]) {
-    const acc: SelectedExperimentWithColor[] = []
-
-    const ids = new Set<string>()
-
-    for (const experiment of getList()) {
-      const { id } = experiment
-      const displayColor = this.coloredStatus[id]
-      if (displayColor && !ids.has(id)) {
-        acc.push({ ...experiment, displayColor } as SelectedExperimentWithColor)
-      }
-      ids.add(id)
-    }
-
-    return copyOriginalColors()
-      .flatMap(orderedItem =>
-        acc.filter(item => item.displayColor === orderedItem)
-      )
-      .filter(Boolean)
-  }
-
   private reviveColoredStatus() {
     const uniqueStatus: ColoredStatus = {}
     const colors = new Set<Color>()

--- a/extension/src/experiments/webview/contract.ts
+++ b/extension/src/experiments/webview/contract.ts
@@ -46,7 +46,7 @@ export type Experiment = {
   starred?: boolean
   status?: ExperimentStatus
   timestamp?: string | null
-  branch: string | undefined
+  branch?: string
 }
 
 export const isRunning = (status: ExperimentStatus | undefined): boolean =>

--- a/extension/src/experiments/webview/messages.ts
+++ b/extension/src/experiments/webview/messages.ts
@@ -407,7 +407,7 @@ export class WebviewMessages {
 
   private setSelectedExperiments(ids: string[]) {
     const experiments = this.experiments
-      .getCombinedList()
+      .getUniqueList()
       .filter(({ id }) => ids.includes(id))
 
     this.experiments.setSelected(experiments)

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -873,7 +873,7 @@ suite('Experiments Test Suite', () => {
       const queuedId = '90aea7f'
 
       const isExperimentSelected = (expId: string): boolean =>
-        !!experimentsModel.getCombinedList().find(({ id }) => id === expId)
+        !!experimentsModel.getUniqueList().find(({ id }) => id === expId)
           ?.selected
 
       expect(
@@ -1101,7 +1101,7 @@ suite('Experiments Test Suite', () => {
       const areExperimentsStarred = (expIds: string[]): boolean =>
         expIds
           .map(expId =>
-            experimentsModel.getCombinedList().find(({ id }) => id === expId)
+            experimentsModel.getUniqueList().find(({ id }) => id === expId)
           )
           .every(exp => exp?.starred)
 


### PR DESCRIPTION
Related to #3913 and for #1966

If an experiment was displayed twice in the experiments table/tree it could still be selected for plotting. This would result in the same id being sent to `plots diff` twice and the command would not return the required data. That resulted in an infinite loop and the plots not loading. Behaviour is shown below:


https://github.com/iterative/vscode-dvc/assets/37993418/0508c45e-445b-4f30-934b-a813c5114b62

In order to combat this I've ensured that whenever we access the commits data (outside of the table) that the list is de-duplicated. I've also made sure that we don't collect the same experiment twice (as they are stored per commit).

### Demo (after change)
 
https://github.com/iterative/vscode-dvc/assets/37993418/1f5358dc-f2a7-4eac-bc88-bbd751a5cbb2

Please LMK if you have any questions
