### PR TITLE
Add basic remote management

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -335,6 +335,12 @@
         "icon": "$(close-all)"
       },
       {
+        "title": "Remove Remote",
+        "command": "dvc.removeRemote",
+        "category": "DVC",
+        "icon": "$(trash)"
+      },
+      {
         "title": "Remove Studio Access Token",
         "command": "dvc.removeStudioAccessToken",
         "category": "DVC"
@@ -821,6 +827,10 @@
         {
           "command": "dvc.removeExperimentsTableSorts",
           "when": "dvc.commands.available && dvc.project.available"
+        },
+        {
+          "command": "dvc.removeRemote",
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running.workspace"
         },
         {
           "command": "dvc.removeStudioAccessToken",

--- a/extension/package.json
+++ b/extension/package.json
@@ -294,6 +294,12 @@
         "icon": "$(play)"
       },
       {
+        "title": "Modify Remote",
+        "command": "dvc.modifyRemote",
+        "category": "DVC",
+        "icon": "$(database)"
+      },
+      {
         "title": "Queue Experiment",
         "command": "dvc.queueExperiment",
         "category": "DVC",
@@ -747,6 +753,10 @@
         {
           "command": "dvc.init",
           "when": "dvc.commands.available && !dvc.cli.incompatible && !dvc.project.available && !dvc.scm.command.running"
+        },
+        {
+          "command": "dvc.modifyRemote",
+          "when": "dvc.commands.available && dvc.project.available && !dvc.experiment.running.workspace"
         },
         {
           "command": "dvc.moveTargets",

--- a/extension/src/cli/dvc/constants.ts
+++ b/extension/src/cli/dvc/constants.ts
@@ -41,6 +41,9 @@ export enum SubCommand {
   ADD = 'add',
   DIFF = 'diff',
   LIST = 'list',
+  MODIFY = 'modify',
+  REMOVE = 'remove',
+  RENAME = 'rename',
   STATUS = 'status',
   SHOW = 'show'
 }

--- a/extension/src/commands/external.ts
+++ b/extension/src/commands/external.ts
@@ -43,6 +43,7 @@ export enum RegisteredCliCommands {
 
   REMOTE_ADD = 'dvc.addRemote',
   REMOTE_MODIFY = 'dvc.modifyRemote',
+  REMOTE_REMOVE = 'dvc.removeRemote',
 
   GIT_STAGE_ALL = 'dvc.gitStageAll',
   GIT_UNSTAGE_ALL = 'dvc.gitUnstageAll'

--- a/extension/src/commands/external.ts
+++ b/extension/src/commands/external.ts
@@ -42,6 +42,7 @@ export enum RegisteredCliCommands {
   RENAME_TARGET = 'dvc.renameTarget',
 
   REMOTE_ADD = 'dvc.addRemote',
+  REMOTE_MODIFY = 'dvc.modifyRemote',
 
   GIT_STAGE_ALL = 'dvc.gitStageAll',
   GIT_UNSTAGE_ALL = 'dvc.gitUnstageAll'

--- a/extension/src/setup/collect.ts
+++ b/extension/src/setup/collect.ts
@@ -35,10 +35,10 @@ export const collectRemoteList = async (
       continue
     }
     const remotes = trimAndSplit(remoteList)
-    const dvcRootRemotes: { [alias: string]: string } = {}
+    const dvcRootRemotes: { [name: string]: string } = {}
     for (const remote of remotes) {
-      const [alias, url] = remote.split(/\s+/)
-      dvcRootRemotes[alias] = url
+      const [name, url] = remote.split(/\s+/)
+      dvcRootRemotes[name] = url
     }
     acc[dvcRoot] = dvcRootRemotes
   }

--- a/extension/src/setup/collect.ts
+++ b/extension/src/setup/collect.ts
@@ -22,6 +22,9 @@ export const collectSectionCollapsed = (
   return acc
 }
 
+export const extractRemoteDetails = (remote: string): string[] =>
+  remote.split(/\s+/)
+
 export const collectRemoteList = async (
   dvcRoots: string[],
   getRemoteList: (cwd: string) => Promise<string | undefined>
@@ -37,7 +40,7 @@ export const collectRemoteList = async (
     const remotes = trimAndSplit(remoteList)
     const dvcRootRemotes: { [name: string]: string } = {}
     for (const remote of remotes) {
-      const [name, url] = remote.split(/\s+/)
+      const [name, url] = extractRemoteDetails(remote)
       dvcRootRemotes[name] = url
     }
     acc[dvcRoot] = dvcRootRemotes

--- a/extension/src/setup/commands/index.ts
+++ b/extension/src/setup/commands/index.ts
@@ -2,8 +2,14 @@ import { Setup } from '..'
 import { Flag, SubCommand } from '../../cli/dvc/constants'
 import { AvailableCommands, InternalCommands } from '../../commands/internal'
 import { definedAndNonEmpty } from '../../util/array'
+import { trimAndSplit } from '../../util/stdout'
 import { getInput } from '../../vscode/inputBox'
-import { quickPickYesOrNo } from '../../vscode/quickPick'
+import {
+  QuickPickItemWithValue,
+  quickPickOne,
+  quickPickValue,
+  quickPickYesOrNo
+} from '../../vscode/quickPick'
 import { Title } from '../../vscode/title'
 import { Toast } from '../../vscode/toast'
 import { getOnlyOrPickProject } from '../../workspace/util'
@@ -83,4 +89,129 @@ export const getAddRemoteCommand =
       return
     }
     return addRemoteToProject(internalCommands, dvcRoot)
+  }
+
+const getRemoteItems = (remotes: string[]): QuickPickItemWithValue[] => {
+  const acc: QuickPickItemWithValue[] = []
+  for (const remote of remotes) {
+    const [name, url] = remote.split(/\s+/)
+    acc.push({ description: url, label: name, value: name })
+  }
+  return acc
+}
+
+const getOnlyOrPickRemote = async (
+  remotes: string[],
+  title: Title
+): Promise<string | undefined> => {
+  if (remotes.length === 1) {
+    return remotes[0]
+  }
+
+  return await quickPickValue(getRemoteItems(remotes), {
+    title
+  })
+}
+
+enum ModifyOptions {
+  NAME = 'Name',
+  URL = 'URL'
+}
+
+const modifyRemoteName = async (
+  internalCommands: InternalCommands,
+  dvcRoot: string,
+  remote: string
+): Promise<void> => {
+  const newName = await getInput(Title.ENTER_REMOTE_NAME)
+  if (!newName) {
+    return
+  }
+  return await Toast.showOutput(
+    internalCommands.executeCommand(
+      AvailableCommands.REMOTE,
+      dvcRoot,
+      SubCommand.RENAME,
+      remote,
+      newName
+    )
+  )
+}
+
+const modifyRemoteUrl = async (
+  internalCommands: InternalCommands,
+  dvcRoot: string,
+  remote: string
+): Promise<void> => {
+  const newUrl = await getInput(Title.ENTER_REMOTE_URL)
+  if (!newUrl) {
+    return
+  }
+  return await Toast.showOutput(
+    internalCommands.executeCommand(
+      AvailableCommands.REMOTE,
+      SubCommand.MODIFY,
+      dvcRoot,
+      remote,
+      'url',
+      newUrl
+    )
+  )
+}
+
+const modifyRemote = async (
+  internalCommands: InternalCommands,
+  dvcRoot: string
+): Promise<void> => {
+  const remoteList = await internalCommands.executeCommand(
+    AvailableCommands.REMOTE,
+    dvcRoot,
+    SubCommand.LIST
+  )
+
+  const remotes = trimAndSplit(remoteList)
+
+  if (!definedAndNonEmpty(remotes)) {
+    return Toast.showError('No remotes to modify')
+  }
+
+  const remote = await getOnlyOrPickRemote(
+    remotes,
+    Title.SELECT_REMOTE_TO_MODIFY
+  )
+  if (!remote) {
+    return
+  }
+
+  const option = await quickPickOne(
+    Object.values(ModifyOptions),
+    'Select an Option to Modify'
+  )
+
+  if (!option) {
+    return
+  }
+
+  if (option === ModifyOptions.NAME) {
+    return modifyRemoteName(internalCommands, dvcRoot, remote)
+  }
+
+  if (option === ModifyOptions.URL) {
+    return modifyRemoteUrl(internalCommands, dvcRoot, remote)
+  }
+}
+
+export const getModifyRemoteCommand =
+  (setup: Setup, internalCommands: InternalCommands) =>
+  async (): Promise<void> => {
+    const dvcRoots = setup.getRoots()
+    if (!definedAndNonEmpty(dvcRoots)) {
+      return Toast.showError('Cannot add a remote without a DVC project')
+    }
+    const dvcRoot = await getOnlyOrPickProject(dvcRoots)
+
+    if (!dvcRoot) {
+      return
+    }
+    return modifyRemote(internalCommands, dvcRoot)
   }

--- a/extension/src/setup/commands/index.ts
+++ b/extension/src/setup/commands/index.ts
@@ -257,29 +257,11 @@ const collectRemoveItems = (remotes: string[]): QuickPickItemWithValue[] => {
   return acc
 }
 
-export const pickRemoteAndRemove = async (
+const confirmAndRemove = async (
   internalCommands: InternalCommands,
-  dvcRoot: string
+  dvcRoot: string,
+  remote: string
 ): Promise<void> => {
-  const remoteList = await internalCommands.executeCommand(
-    AvailableCommands.REMOTE,
-    dvcRoot,
-    SubCommand.LIST
-  )
-
-  const remotes = trimAndSplit(remoteList)
-
-  if (!definedAndNonEmpty(remotes)) {
-    return Toast.showError('No remotes to remove')
-  }
-
-  const remote = await getOnlyOrPickRemote(
-    collectRemoveItems(remotes),
-    Title.SELECT_REMOTE_TO_REMOVE
-  )
-  if (!remote) {
-    return
-  }
   const removalConfirmed = await Modal.warnOfConsequences(
     'Are you sure you want to remove this remote? This could be IRREVERSIBLE!',
     Response.REMOVE
@@ -308,4 +290,31 @@ export const pickRemoteAndRemove = async (
       remote
     )
   } catch {}
+}
+
+export const pickRemoteAndRemove = async (
+  internalCommands: InternalCommands,
+  dvcRoot: string
+): Promise<void> => {
+  const remoteList = await internalCommands.executeCommand(
+    AvailableCommands.REMOTE,
+    dvcRoot,
+    SubCommand.LIST
+  )
+
+  const remotes = trimAndSplit(remoteList)
+
+  if (!definedAndNonEmpty(remotes)) {
+    return Toast.showError('No remotes to remove')
+  }
+
+  const remote = await getOnlyOrPickRemote(
+    collectRemoveItems(remotes),
+    Title.SELECT_REMOTE_TO_REMOVE
+  )
+  if (!remote) {
+    return
+  }
+
+  return confirmAndRemove(internalCommands, dvcRoot, remote)
 }

--- a/extension/src/setup/commands/index.ts
+++ b/extension/src/setup/commands/index.ts
@@ -15,6 +15,7 @@ import { Response } from '../../vscode/response'
 import { Title } from '../../vscode/title'
 import { Toast } from '../../vscode/toast'
 import { getOnlyOrPickProject } from '../../workspace/util'
+import { extractRemoteDetails } from '../collect'
 
 export const runCallback = async (
   setup: Setup,
@@ -193,7 +194,7 @@ const collectFromRemoteList = (
   config: typeof Flag.LOCAL | typeof Flag.PROJECT
 ): void => {
   for (const remote of trimAndSplit(remoteList ?? '')) {
-    const [name, url] = remote.split(/\s+/)
+    const [name, url] = extractRemoteDetails(remote)
     acc.push({
       description: `(${config.slice(2)} config)`,
       detail: url,
@@ -251,7 +252,7 @@ export const pickRemoteAndModify = async (
 const collectRemoveItems = (remotes: string[]): QuickPickItemWithValue[] => {
   const acc: QuickPickItemWithValue[] = []
   for (const remote of remotes) {
-    const [name, url] = remote.split(/\s+/)
+    const [name, url] = extractRemoteDetails(remote)
     acc.push({ detail: url, label: name, value: name })
   }
   return acc

--- a/extension/src/setup/commands/index.ts
+++ b/extension/src/setup/commands/index.ts
@@ -4,12 +4,14 @@ import { AvailableCommands, InternalCommands } from '../../commands/internal'
 import { definedAndNonEmpty } from '../../util/array'
 import { trimAndSplit } from '../../util/stdout'
 import { getInput } from '../../vscode/inputBox'
+import { Modal } from '../../vscode/modal'
 import {
   QuickPickItemWithValue,
   quickPickOne,
   quickPickValue,
   quickPickYesOrNo
 } from '../../vscode/quickPick'
+import { Response } from '../../vscode/response'
 import { Title } from '../../vscode/title'
 import { Toast } from '../../vscode/toast'
 import { getOnlyOrPickProject } from '../../workspace/util'
@@ -105,7 +107,7 @@ const getOnlyOrPickRemote = async (
   title: Title
 ): Promise<string | undefined> => {
   if (remotes.length === 1) {
-    return remotes[0]
+    return remotes[0].split(/\s+/)[0]
   }
 
   return await quickPickValue(getRemoteItems(remotes), {
@@ -161,6 +163,29 @@ const modifyRemoteUrl = async (
 
 const modifyRemote = async (
   internalCommands: InternalCommands,
+  dvcRoot: string,
+  remote: string
+): Promise<void> => {
+  const option = await quickPickOne(
+    Object.values(ModifyOptions),
+    'Select an Option to Modify'
+  )
+
+  if (!option) {
+    return
+  }
+
+  if (option === ModifyOptions.NAME) {
+    return modifyRemoteName(internalCommands, dvcRoot, remote)
+  }
+
+  if (option === ModifyOptions.URL) {
+    return modifyRemoteUrl(internalCommands, dvcRoot, remote)
+  }
+}
+
+const pickRemoteAndModify = async (
+  internalCommands: InternalCommands,
   dvcRoot: string
 ): Promise<void> => {
   const remoteList = await internalCommands.executeCommand(
@@ -183,22 +208,7 @@ const modifyRemote = async (
     return
   }
 
-  const option = await quickPickOne(
-    Object.values(ModifyOptions),
-    'Select an Option to Modify'
-  )
-
-  if (!option) {
-    return
-  }
-
-  if (option === ModifyOptions.NAME) {
-    return modifyRemoteName(internalCommands, dvcRoot, remote)
-  }
-
-  if (option === ModifyOptions.URL) {
-    return modifyRemoteUrl(internalCommands, dvcRoot, remote)
-  }
+  return modifyRemote(internalCommands, dvcRoot, remote)
 }
 
 export const getModifyRemoteCommand =
@@ -206,12 +216,80 @@ export const getModifyRemoteCommand =
   async (): Promise<void> => {
     const dvcRoots = setup.getRoots()
     if (!definedAndNonEmpty(dvcRoots)) {
-      return Toast.showError('Cannot add a remote without a DVC project')
+      return Toast.showError('Cannot modify a remote without a DVC project')
     }
     const dvcRoot = await getOnlyOrPickProject(dvcRoots)
 
     if (!dvcRoot) {
       return
     }
-    return modifyRemote(internalCommands, dvcRoot)
+    return pickRemoteAndModify(internalCommands, dvcRoot)
+  }
+
+const pickRemoteAndRemove = async (
+  internalCommands: InternalCommands,
+  dvcRoot: string
+): Promise<void> => {
+  const remoteList = await internalCommands.executeCommand(
+    AvailableCommands.REMOTE,
+    dvcRoot,
+    SubCommand.LIST
+  )
+
+  const remotes = trimAndSplit(remoteList)
+
+  if (!definedAndNonEmpty(remotes)) {
+    return Toast.showError('No remotes to remove')
+  }
+
+  const remote = await getOnlyOrPickRemote(
+    remotes,
+    Title.SELECT_REMOTE_TO_REMOVE
+  )
+  if (!remote) {
+    return
+  }
+  const shouldRemove = await Modal.warnOfConsequences(
+    'This action is irreversible. Are you sure you want to remove this remote?',
+    Response.REMOVE
+  )
+
+  if (shouldRemove !== Response.REMOVE) {
+    return
+  }
+
+  try {
+    await internalCommands.executeCommand(
+      AvailableCommands.REMOTE,
+      dvcRoot,
+      SubCommand.REMOVE,
+      Flag.PROJECT,
+      remote
+    )
+  } catch {}
+
+  try {
+    await internalCommands.executeCommand(
+      AvailableCommands.REMOTE,
+      dvcRoot,
+      SubCommand.REMOVE,
+      Flag.LOCAL,
+      remote
+    )
+  } catch {}
+}
+
+export const getRemoveRemoteCommand =
+  (setup: Setup, internalCommands: InternalCommands) =>
+  async (): Promise<void> => {
+    const dvcRoots = setup.getRoots()
+    if (!definedAndNonEmpty(dvcRoots)) {
+      return Toast.showError('Cannot modify a remote without a DVC project')
+    }
+    const dvcRoot = await getOnlyOrPickProject(dvcRoots)
+
+    if (!dvcRoot) {
+      return
+    }
+    return pickRemoteAndRemove(internalCommands, dvcRoot)
   }

--- a/extension/src/setup/commands/index.ts
+++ b/extension/src/setup/commands/index.ts
@@ -178,8 +178,8 @@ const modifyRemote = async (
 }
 
 const collectModifyItems = (
-  localRemoteList: string,
-  projectRemoteList: string
+  localRemoteList: string | undefined,
+  projectRemoteList: string | undefined
 ): QuickPickItemWithValue<{
   config: typeof Flag.LOCAL | typeof Flag.PROJECT
   name: string
@@ -188,7 +188,7 @@ const collectModifyItems = (
     config: typeof Flag.LOCAL | typeof Flag.PROJECT
     name: string
   }>[] = []
-  for (const localRemote of trimAndSplit(localRemoteList)) {
+  for (const localRemote of trimAndSplit(localRemoteList ?? '')) {
     const config = Flag.LOCAL
     const [name, url] = localRemote.split(/\s+/)
     acc.push({
@@ -199,7 +199,7 @@ const collectModifyItems = (
     })
   }
 
-  for (const projectRemote of trimAndSplit(projectRemoteList)) {
+  for (const projectRemote of trimAndSplit(projectRemoteList ?? '')) {
     const config = Flag.PROJECT
     const [name, url] = projectRemote.split(/\s+/)
     acc.push({

--- a/extension/src/setup/commands/index.ts
+++ b/extension/src/setup/commands/index.ts
@@ -17,7 +17,7 @@ import { Toast } from '../../vscode/toast'
 import { getOnlyOrPickProject } from '../../workspace/util'
 import { extractRemoteDetails } from '../collect'
 
-export const runCallback = async (
+export const runCallbackOnDvcRoot = async (
   setup: Setup,
   internalCommands: InternalCommands,
   callback: (
@@ -120,6 +120,7 @@ enum ModifyOptions {
 type RemoteWithConfig = {
   config: typeof Flag.LOCAL | typeof Flag.PROJECT
   name: string
+  url: string
 }
 
 const modifyRemoteName = async (
@@ -127,7 +128,8 @@ const modifyRemoteName = async (
   dvcRoot: string,
   remote: RemoteWithConfig
 ): Promise<void> => {
-  const newName = await getInput(Title.ENTER_REMOTE_NAME)
+  const { config, name } = remote
+  const newName = await getInput(Title.ENTER_REMOTE_NAME, name)
   if (!newName) {
     return
   }
@@ -136,8 +138,8 @@ const modifyRemoteName = async (
       AvailableCommands.REMOTE,
       dvcRoot,
       SubCommand.RENAME,
-      remote.config,
-      remote.name,
+      config,
+      name,
       newName
     )
   )
@@ -148,7 +150,8 @@ const modifyRemoteUrl = async (
   dvcRoot: string,
   remote: RemoteWithConfig
 ): Promise<void> => {
-  const newUrl = await getInput(Title.ENTER_REMOTE_URL)
+  const { name, config, url } = remote
+  const newUrl = await getInput(Title.ENTER_REMOTE_URL, url)
   if (!newUrl) {
     return
   }
@@ -157,8 +160,8 @@ const modifyRemoteUrl = async (
       AvailableCommands.REMOTE,
       dvcRoot,
       SubCommand.MODIFY,
-      remote.config,
-      remote.name,
+      config,
+      name,
       'url',
       newUrl
     )
@@ -199,7 +202,7 @@ const collectFromRemoteList = (
       description: `(${config.slice(2)} config)`,
       detail: url,
       label: `${name}`,
-      value: { config, name }
+      value: { config, name, url }
     })
   }
 }
@@ -264,7 +267,7 @@ const confirmAndRemove = async (
   remote: string
 ): Promise<void> => {
   const removalConfirmed = await Modal.warnOfConsequences(
-    'Are you sure you want to remove this remote? This could be IRREVERSIBLE!',
+    'Are you sure you want to remove this remote from your config(s)? This could be IRREVERSIBLE!',
     Response.REMOVE
   )
 

--- a/extension/src/setup/commands/register.ts
+++ b/extension/src/setup/commands/register.ts
@@ -1,5 +1,9 @@
 import { commands } from 'vscode'
-import { getAddRemoteCommand, getModifyRemoteCommand } from '.'
+import {
+  getAddRemoteCommand,
+  getModifyRemoteCommand,
+  getRemoveRemoteCommand
+} from '.'
 import { Setup } from '..'
 import { run } from '../runner'
 import { SetupSection } from '../webview/contract'
@@ -112,6 +116,11 @@ export const registerSetupCommands = (
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.REMOTE_MODIFY,
     getModifyRemoteCommand(setup, internalCommands)
+  )
+
+  internalCommands.registerExternalCliCommand(
+    RegisteredCliCommands.REMOTE_REMOVE,
+    getRemoveRemoteCommand(setup, internalCommands)
   )
 
   registerSetupConfigCommands(setup, internalCommands)

--- a/extension/src/setup/commands/register.ts
+++ b/extension/src/setup/commands/register.ts
@@ -3,7 +3,7 @@ import {
   addRemoteToProject,
   pickRemoteAndModify,
   pickRemoteAndRemove,
-  runCallback
+  runCallbackOnDvcRoot
 } from '.'
 import { Setup } from '..'
 import { run } from '../runner'
@@ -111,17 +111,17 @@ export const registerSetupCommands = (
 
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.REMOTE_ADD,
-    () => runCallback(setup, internalCommands, addRemoteToProject)
+    () => runCallbackOnDvcRoot(setup, internalCommands, addRemoteToProject)
   )
 
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.REMOTE_MODIFY,
-    () => runCallback(setup, internalCommands, pickRemoteAndModify)
+    () => runCallbackOnDvcRoot(setup, internalCommands, pickRemoteAndModify)
   )
 
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.REMOTE_REMOVE,
-    () => runCallback(setup, internalCommands, pickRemoteAndRemove)
+    () => runCallbackOnDvcRoot(setup, internalCommands, pickRemoteAndRemove)
   )
 
   registerSetupConfigCommands(setup, internalCommands)

--- a/extension/src/setup/commands/register.ts
+++ b/extension/src/setup/commands/register.ts
@@ -1,5 +1,5 @@
 import { commands } from 'vscode'
-import { getAddRemoteCommand } from '.'
+import { getAddRemoteCommand, getModifyRemoteCommand } from '.'
 import { Setup } from '..'
 import { run } from '../runner'
 import { SetupSection } from '../webview/contract'
@@ -107,6 +107,11 @@ export const registerSetupCommands = (
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.REMOTE_ADD,
     getAddRemoteCommand(setup, internalCommands)
+  )
+
+  internalCommands.registerExternalCliCommand(
+    RegisteredCliCommands.REMOTE_MODIFY,
+    getModifyRemoteCommand(setup, internalCommands)
   )
 
   registerSetupConfigCommands(setup, internalCommands)

--- a/extension/src/setup/commands/register.ts
+++ b/extension/src/setup/commands/register.ts
@@ -1,8 +1,9 @@
 import { commands } from 'vscode'
 import {
-  getAddRemoteCommand,
-  getModifyRemoteCommand,
-  getRemoveRemoteCommand
+  addRemoteToProject,
+  pickRemoteAndModify,
+  pickRemoteAndRemove,
+  runCallback
 } from '.'
 import { Setup } from '..'
 import { run } from '../runner'
@@ -110,17 +111,17 @@ export const registerSetupCommands = (
 
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.REMOTE_ADD,
-    getAddRemoteCommand(setup, internalCommands)
+    () => runCallback(setup, internalCommands, addRemoteToProject)
   )
 
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.REMOTE_MODIFY,
-    getModifyRemoteCommand(setup, internalCommands)
+    () => runCallback(setup, internalCommands, pickRemoteAndModify)
   )
 
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.REMOTE_REMOVE,
-    getRemoveRemoteCommand(setup, internalCommands)
+    () => runCallback(setup, internalCommands, pickRemoteAndRemove)
   )
 
   registerSetupConfigCommands(setup, internalCommands)

--- a/extension/src/setup/webview/messages.ts
+++ b/extension/src/setup/webview/messages.ts
@@ -108,7 +108,8 @@ export class WebviewMessages {
         return commands.executeCommand(RegisteredCommands.EXPERIMENT_SHOW)
       case MessageFromWebviewType.REMOTE_ADD:
         return commands.executeCommand(RegisteredCliCommands.REMOTE_ADD)
-
+      case MessageFromWebviewType.REMOTE_MODIFY:
+        return commands.executeCommand(RegisteredCliCommands.REMOTE_MODIFY)
       default:
         Logger.error(`Unexpected message: ${JSON.stringify(message)}`)
     }

--- a/extension/src/setup/webview/messages.ts
+++ b/extension/src/setup/webview/messages.ts
@@ -110,6 +110,9 @@ export class WebviewMessages {
         return commands.executeCommand(RegisteredCliCommands.REMOTE_ADD)
       case MessageFromWebviewType.REMOTE_MODIFY:
         return commands.executeCommand(RegisteredCliCommands.REMOTE_MODIFY)
+      case MessageFromWebviewType.REMOTE_REMOVE:
+        return commands.executeCommand(RegisteredCliCommands.REMOTE_REMOVE)
+
       default:
         Logger.error(`Unexpected message: ${JSON.stringify(message)}`)
     }

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -188,6 +188,7 @@ export interface IEventNamePropertyMapping {
   [EventName.RENAME_TARGET]: undefined
 
   [EventName.REMOTE_ADD]: undefined
+  [EventName.REMOTE_MODIFY]: undefined
 
   [EventName.GIT_STAGE_ALL]: undefined
   [EventName.GIT_UNSTAGE_ALL]: undefined

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -189,6 +189,7 @@ export interface IEventNamePropertyMapping {
 
   [EventName.REMOTE_ADD]: undefined
   [EventName.REMOTE_MODIFY]: undefined
+  [EventName.REMOTE_REMOVE]: undefined
 
   [EventName.GIT_STAGE_ALL]: undefined
   [EventName.GIT_UNSTAGE_ALL]: undefined

--- a/extension/src/test/suite/setup/index.test.ts
+++ b/extension/src/test/suite/setup/index.test.ts
@@ -963,6 +963,7 @@ suite('Setup Test Suite', () => {
 
     it('should be able to rename a remote', async () => {
       const mockRemote = stub(DvcExecutor.prototype, 'remote')
+      const newName = 'better-name'
 
       const remoteRenamed = new Promise(resolve =>
         mockRemote.callsFake((_, ...args) => {
@@ -981,9 +982,7 @@ suite('Setup Test Suite', () => {
         })
       )
 
-      const mockShowInputBox = stub(window, 'showInputBox').resolves(
-        'better-name'
-      )
+      const mockShowInputBox = stub(window, 'showInputBox').resolves(newName)
 
       const mockShowQuickPick = (
         stub(window, 'showQuickPick') as SinonStub<
@@ -1003,7 +1002,7 @@ suite('Setup Test Suite', () => {
         'rename',
         '--project',
         'storage',
-        'better-name'
+        newName
       )
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 

--- a/extension/src/test/suite/setup/index.test.ts
+++ b/extension/src/test/suite/setup/index.test.ts
@@ -4,6 +4,7 @@ import { ensureFileSync, remove } from 'fs-extra'
 import { expect } from 'chai'
 import { SinonStub, restore, spy, stub } from 'sinon'
 import {
+  MessageItem,
   QuickPickItem,
   Uri,
   WorkspaceConfiguration,
@@ -47,6 +48,7 @@ import { Setup } from '../../../setup'
 import { SetupSection } from '../../../setup/webview/contract'
 import { DvcExecutor } from '../../../cli/dvc/executor'
 import { getFirstWorkspaceFolder } from '../../../vscode/workspaceFolders'
+import { Response } from '../../../vscode/response'
 
 suite('Setup Test Suite', () => {
   const disposable = Disposable.fn()
@@ -874,7 +876,7 @@ suite('Setup Test Suite', () => {
       const mockRemote = stub(DvcExecutor.prototype, 'remote')
 
       const remoteAdded = new Promise(resolve =>
-        mockRemote.callsFake((cwd, ...args) => {
+        mockRemote.callsFake((_, ...args) => {
           if (args.includes('add')) {
             resolve(undefined)
           }
@@ -913,7 +915,7 @@ suite('Setup Test Suite', () => {
       const mockRemote = stub(DvcExecutor.prototype, 'remote')
 
       const remoteAdded = new Promise(resolve =>
-        mockRemote.callsFake((cwd, ...args) => {
+        mockRemote.callsFake((_, ...args) => {
           if (args.includes('list')) {
             return Promise.resolve('storage s3://my-bucket')
           }
@@ -956,6 +958,178 @@ suite('Setup Test Suite', () => {
         '--project',
         'backup',
         's3://my-backup-bucket'
+      )
+    }).timeout(WEBVIEW_TEST_TIMEOUT)
+
+    it('should be able to rename a remote', async () => {
+      const mockRemote = stub(DvcExecutor.prototype, 'remote')
+
+      const remoteRenamed = new Promise(resolve =>
+        mockRemote.callsFake((_, ...args) => {
+          if (args.includes('list') && args.includes('--project')) {
+            return Promise.resolve('storage s3://my-bucket')
+          }
+
+          if (args.includes('list')) {
+            return Promise.resolve('')
+          }
+
+          if (args.includes('rename')) {
+            resolve(undefined)
+          }
+          return Promise.resolve('')
+        })
+      )
+
+      const mockShowInputBox = stub(window, 'showInputBox').resolves(
+        'better-name'
+      )
+
+      const mockShowQuickPick = (
+        stub(window, 'showQuickPick') as SinonStub<
+          [items: readonly QuickPickItem[], options: QuickPickOptionsWithTitle],
+          Thenable<string | undefined>
+        >
+      ).resolves('Name')
+
+      await commands.executeCommand(RegisteredCliCommands.REMOTE_MODIFY)
+
+      await remoteRenamed
+
+      expect(mockShowInputBox).to.be.calledOnce
+      expect(mockShowQuickPick).to.be.calledOnce
+      expect(mockRemote).to.be.calledWithExactly(
+        dvcDemoPath,
+        'rename',
+        '--project',
+        'storage',
+        'better-name'
+      )
+    }).timeout(WEBVIEW_TEST_TIMEOUT)
+
+    it('should handle a message to modify a remote (modify URL)', async () => {
+      const { messageSpy, setup, mockExecuteCommand } = buildSetup(disposable)
+
+      const webview = await setup.showWebview()
+      await webview.isReady()
+      mockExecuteCommand.restore()
+
+      const mockMessageReceived = getMessageReceivedEmitter(webview)
+
+      const mockRemote = stub(DvcExecutor.prototype, 'remote')
+      const projectConfigUrl = 's3://different-url'
+
+      const remoteModified = new Promise(resolve =>
+        mockRemote.callsFake((_, ...args) => {
+          if (args.includes('list') && args.includes('--project')) {
+            return Promise.resolve(
+              `storage ${projectConfigUrl}\nbackup s3://my-backup-bucket`
+            )
+          }
+
+          if (args.includes('list') && args.includes('--local')) {
+            return Promise.resolve('storage s3://my-bucket')
+          }
+
+          if (args.includes('modify')) {
+            resolve(undefined)
+          }
+          return Promise.resolve('')
+        })
+      )
+
+      const mockShowInputBox = stub(window, 'showInputBox').resolves(
+        projectConfigUrl
+      )
+
+      const mockShowQuickPick = (
+        stub(window, 'showQuickPick') as SinonStub<
+          [items: readonly QuickPickItem[], options: QuickPickOptionsWithTitle],
+          Thenable<
+            | string
+            | undefined
+            | QuickPickItemWithValue<{ config: string; name: string }>
+          >
+        >
+      )
+        .onFirstCall()
+        .resolves({
+          label: 'storage',
+          value: { config: '--local', name: 'storage' }
+        })
+        .onSecondCall()
+        .resolves('URL')
+
+      messageSpy.resetHistory()
+      mockMessageReceived.fire({
+        type: MessageFromWebviewType.REMOTE_MODIFY
+      })
+
+      await remoteModified
+
+      expect(mockShowInputBox).to.be.calledOnce
+      expect(mockShowQuickPick).to.be.calledTwice
+      expect(mockRemote).to.be.calledWithExactly(
+        dvcDemoPath,
+        'modify',
+        '--local',
+        'storage',
+        'url',
+        projectConfigUrl
+      )
+    }).timeout(WEBVIEW_TEST_TIMEOUT)
+
+    it('should handle a message to remove a remote', async () => {
+      const { messageSpy, setup, mockExecuteCommand } = buildSetup(disposable)
+
+      const webview = await setup.showWebview()
+      await webview.isReady()
+      mockExecuteCommand.restore()
+
+      const mockMessageReceived = getMessageReceivedEmitter(webview)
+
+      const mockRemote = stub(DvcExecutor.prototype, 'remote')
+
+      let calls = 0
+
+      const remoteRemoved = new Promise(resolve =>
+        mockRemote.callsFake((_, ...args) => {
+          if (args.includes('list')) {
+            return Promise.resolve('storage s3://my-bucket')
+          }
+
+          if (args.includes('remove')) {
+            calls = calls + 1
+          }
+          if (calls === 2) {
+            resolve(undefined)
+          }
+          return Promise.resolve('')
+        })
+      )
+
+      stub(window, 'showWarningMessage').resolves(
+        Response.REMOVE as unknown as MessageItem
+      )
+
+      messageSpy.resetHistory()
+      mockMessageReceived.fire({
+        type: MessageFromWebviewType.REMOTE_REMOVE
+      })
+
+      await remoteRemoved
+
+      expect(mockRemote).to.be.calledWithExactly(
+        dvcDemoPath,
+        'remove',
+        '--local',
+        'storage'
+      )
+      expect(mockRemote).to.be.calledWithExactly(
+        dvcDemoPath,
+        'remove',
+        '--project',
+        'storage'
       )
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 

--- a/extension/src/vscode/quickPick.test.ts
+++ b/extension/src/vscode/quickPick.test.ts
@@ -105,13 +105,13 @@ describe('quickPickManyValues', () => {
 describe('quickPickOne', () => {
   it('should call window.showQuickPick with the correct arguments', async () => {
     mockedShowQuickPick.mockResolvedValueOnce(undefined)
-    const placeHolder = 'my placeholder'
+    const title = 'my title'
 
-    const noResponse = await quickPickOne(['a', 'b', 'c'], placeHolder)
+    const noResponse = await quickPickOne(['a', 'b', 'c'], title)
 
     expect(mockedShowQuickPick).toHaveBeenCalledWith(['a', 'b', 'c'], {
       canPickMany: false,
-      placeHolder
+      title
     })
     expect(noResponse).toStrictEqual(undefined)
   })

--- a/extension/src/vscode/quickPick.ts
+++ b/extension/src/vscode/quickPick.ts
@@ -35,11 +35,11 @@ export const quickPickManyValues: <T = string>(
 
 export const quickPickOne = (
   items: string[],
-  placeHolder: string
+  title: string
 ): Thenable<string | undefined> =>
   window.showQuickPick(items, {
     canPickMany: false,
-    placeHolder
+    title
   })
 
 const createQuickPick = <T>(

--- a/extension/src/vscode/response.ts
+++ b/extension/src/vscode/response.ts
@@ -6,6 +6,7 @@ export enum Response {
   MOVE = 'Move',
   NEVER = "Don't Show Again",
   NO = 'No',
+  REMOVE = 'Remove',
   SELECT_MOST_RECENT = 'Select Most Recent',
   SHOW_SETUP = 'Setup',
   SHOW = 'Show',

--- a/extension/src/vscode/title.ts
+++ b/extension/src/vscode/title.ts
@@ -33,6 +33,7 @@ export enum Title {
   SELECT_CUSTOM_PLOTS_TO_REMOVE = 'Select Custom Plot(s) to Remove',
   SELECT_PARAM_TO_MODIFY = 'Select Param(s) to Modify',
   SELECT_PLOTS = 'Select Plots to Display',
+  SELECT_REMOTE_TO_MODIFY = 'Select a Remote to Modify',
   SELECT_EXPERIMENTS_STOP = 'Select Experiments to Stop',
   SELECT_SORT_DIRECTION = 'Select Sort Direction',
   SELECT_SORTS_TO_REMOVE = 'Select Sort(s) to Remove',

--- a/extension/src/vscode/title.ts
+++ b/extension/src/vscode/title.ts
@@ -34,6 +34,7 @@ export enum Title {
   SELECT_PARAM_TO_MODIFY = 'Select Param(s) to Modify',
   SELECT_PLOTS = 'Select Plots to Display',
   SELECT_REMOTE_TO_MODIFY = 'Select a Remote to Modify',
+  SELECT_REMOTE_TO_REMOVE = 'Select a Remote to Remove',
   SELECT_EXPERIMENTS_STOP = 'Select Experiments to Stop',
   SELECT_SORT_DIRECTION = 'Select Sort Direction',
   SELECT_SORTS_TO_REMOVE = 'Select Sort(s) to Remove',

--- a/extension/src/webview/contract.ts
+++ b/extension/src/webview/contract.ts
@@ -54,6 +54,7 @@ export enum MessageFromWebviewType {
   TOGGLE_PLOTS_SECTION = 'toggle-plots-section',
   REMOTE_ADD = 'remote-add',
   REMOTE_MODIFY = 'remote-modify',
+  REMOTE_REMOVE = 'remote-remove',
   REMOVE_CUSTOM_PLOTS = 'remove-custom-plots',
   REMOVE_STUDIO_TOKEN = 'remove-studio-token',
   MODIFY_EXPERIMENT_PARAMS_AND_QUEUE = 'modify-experiment-params-and-queue',
@@ -165,6 +166,7 @@ export type MessageFromWebview =
     }
   | { type: MessageFromWebviewType.REMOTE_ADD }
   | { type: MessageFromWebviewType.REMOTE_MODIFY }
+  | { type: MessageFromWebviewType.REMOTE_REMOVE }
   | {
       type: MessageFromWebviewType.REMOVE_CUSTOM_PLOTS
     }

--- a/extension/src/webview/contract.ts
+++ b/extension/src/webview/contract.ts
@@ -53,6 +53,7 @@ export enum MessageFromWebviewType {
   SET_STUDIO_SHARE_EXPERIMENTS_LIVE = 'set-studio-share-experiments-live',
   TOGGLE_PLOTS_SECTION = 'toggle-plots-section',
   REMOTE_ADD = 'remote-add',
+  REMOTE_MODIFY = 'remote-modify',
   REMOVE_CUSTOM_PLOTS = 'remove-custom-plots',
   REMOVE_STUDIO_TOKEN = 'remove-studio-token',
   MODIFY_EXPERIMENT_PARAMS_AND_QUEUE = 'modify-experiment-params-and-queue',
@@ -163,6 +164,7 @@ export type MessageFromWebview =
       payload: string
     }
   | { type: MessageFromWebviewType.REMOTE_ADD }
+  | { type: MessageFromWebviewType.REMOTE_MODIFY }
   | {
       type: MessageFromWebviewType.REMOVE_CUSTOM_PLOTS
     }

--- a/extension/src/workspace/util.ts
+++ b/extension/src/workspace/util.ts
@@ -7,8 +7,5 @@ export const getOnlyOrPickProject = async (
     return dvcRoots[0]
   }
 
-  return await quickPickOne(
-    dvcRoots,
-    'Select which project to run command against'
-  )
+  return await quickPickOne(dvcRoots, 'Select a Project to Run Command Against')
 }

--- a/webview/src/setup/components/messages.ts
+++ b/webview/src/setup/components/messages.ts
@@ -62,3 +62,6 @@ export const addRemote = () =>
 
 export const modifyRemote = () =>
   sendMessage({ type: MessageFromWebviewType.REMOTE_MODIFY })
+
+export const removeRemote = () =>
+  sendMessage({ type: MessageFromWebviewType.REMOTE_REMOVE })

--- a/webview/src/setup/components/messages.ts
+++ b/webview/src/setup/components/messages.ts
@@ -59,3 +59,6 @@ export const removeStudioToken = () =>
 
 export const addRemote = () =>
   sendMessage({ type: MessageFromWebviewType.REMOTE_ADD })
+
+export const modifyRemote = () =>
+  sendMessage({ type: MessageFromWebviewType.REMOTE_MODIFY })

--- a/webview/src/setup/components/remotes/RemoteDetails.tsx
+++ b/webview/src/setup/components/remotes/RemoteDetails.tsx
@@ -3,6 +3,8 @@ import { RemoteList } from 'dvc/src/setup/webview/contract'
 import { MultiProjectRemotes } from './MultiProjectRemotes'
 import { ProjectRemotes } from './ProjectRemotes'
 import { EmptyState } from '../../../shared/components/emptyState/EmptyState'
+import { Button } from '../../../shared/components/button/Button'
+import { addRemote, modifyRemote } from '../messages'
 
 export const RemoteDetails: React.FC<{
   remoteList: NonNullable<RemoteList>
@@ -18,6 +20,19 @@ export const RemoteDetails: React.FC<{
           remotes={remoteValues[0] as { [alias: string]: string }}
         />
       )}
+      <Button text="Modify" onClick={modifyRemote} />
+      <Button
+        appearance="secondary"
+        isNested={true}
+        onClick={addRemote}
+        text="Add"
+      />
+      <Button
+        appearance="secondary"
+        isNested={true}
+        onClick={() => undefined}
+        text="Remove"
+      />
     </EmptyState>
   )
 }

--- a/webview/src/setup/components/remotes/RemoteDetails.tsx
+++ b/webview/src/setup/components/remotes/RemoteDetails.tsx
@@ -4,7 +4,7 @@ import { MultiProjectRemotes } from './MultiProjectRemotes'
 import { ProjectRemotes } from './ProjectRemotes'
 import { EmptyState } from '../../../shared/components/emptyState/EmptyState'
 import { Button } from '../../../shared/components/button/Button'
-import { addRemote, modifyRemote } from '../messages'
+import { addRemote, modifyRemote, removeRemote } from '../messages'
 
 export const RemoteDetails: React.FC<{
   remoteList: NonNullable<RemoteList>
@@ -30,7 +30,7 @@ export const RemoteDetails: React.FC<{
       <Button
         appearance="secondary"
         isNested={true}
-        onClick={() => undefined}
+        onClick={removeRemote}
         text="Remove"
       />
     </EmptyState>


### PR DESCRIPTION
Part of #3867 

This PR adds some basic remote storage actions to the (complete) Remotes section of the Setup page.

Things to note: 

- I have not included the `jobs` or `verify` options in the modify command. 
- When modifying a remote I give the user the option to modify any remote by config. If the remote is found in both the local and project configs then two entries will be shown to choose from (see demo for example).
- When removing a remote I try to remove it from both the local and project-level configs. There is no option to remove the remote from one config.

The main reason for the above decisions is that these (more) simple actions complement onboarding to remotes. I think more advanced usage can be catered for but for now, I am not considering that as part of the scope of this effort.


### Demo

https://github.com/iterative/vscode-dvc/assets/37993418/d645454b-aca0-48c1-801b-c1f746d31d8e

