### PR TITLE
Fix DVC setup showing false info on incompatible global DVC

### DIFF
--- a/extension/src/cli/dvc/discovery.ts
+++ b/extension/src/cli/dvc/discovery.ts
@@ -127,7 +127,7 @@ const tryGlobalFallbackVersion = async (
   const tryGlobal = await getVersionDetails(setup, cwd, true)
   const { cliCompatible, isAvailable, isCompatible, version } = tryGlobal
 
-  if (isCompatible) {
+  if (version) {
     setup.unsetPythonBinPath()
   }
 

--- a/extension/src/cli/dvc/discovery.ts
+++ b/extension/src/cli/dvc/discovery.ts
@@ -127,9 +127,15 @@ const tryGlobalFallbackVersion = async (
   const tryGlobal = await getVersionDetails(setup, cwd, true)
   const { cliCompatible, isAvailable, isCompatible, version } = tryGlobal
 
-  if (version) {
-    setup.unsetPythonBinPath()
+  if (!isCompatible) {
+    return {
+      isAvailable,
+      isCompatible,
+      version
+    }
   }
+
+  setup.unsetPythonBinPath()
 
   return processVersionDetails(
     setup,
@@ -152,7 +158,11 @@ const extensionCanAutoRunCli = async (
   } = await getVersionDetails(setup, cwd)
 
   if (pythonCliCompatible === CliCompatible.NO_NOT_FOUND) {
-    return tryGlobalFallbackVersion(setup, cwd)
+    const globalResults = await tryGlobalFallbackVersion(setup, cwd)
+
+    if (globalResults.isCompatible) {
+      return globalResults
+    }
   }
 
   return processVersionDetails(

--- a/extension/src/setup/runner.test.ts
+++ b/extension/src/setup/runner.test.ts
@@ -485,8 +485,9 @@ describe('run', () => {
     await flushPromises()
     expect(mockedWarnWithOptions).toHaveBeenCalledTimes(1)
     expect(mockedWarnWithOptions).toHaveBeenCalledWith(
-      'The extension cannot initialize because the DVC CLI version is incompatible.',
-      Response.SHOW_SETUP
+      'An error was thrown when trying to access the CLI.',
+      Response.SHOW_SETUP,
+      Response.NEVER
     )
     expect(mockedGetCliVersion).toHaveBeenCalledTimes(2)
     expect(mockedResetMembers).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
* keeps section (and extension status) showing accurate information when extension encounters an incompatible version of DVC

## Demo

Demo environment details: I have a `MIN_CLI_VERSION` of `2.58.0` (updated for test so I could easily test global DVC incompatibility), a global DVC installation of `2.57.0`, and a selected python environment with no DVC. 

## main

<img width="1219" alt="image" src="https://github.com/iterative/vscode-dvc/assets/43496356/8c2be764-baf7-4dc7-9cfd-82e8e79c229b">

## PR

<img width="1209" alt="image" src="https://github.com/iterative/vscode-dvc/assets/43496356/c3de012c-4cd3-466f-84e8-3a79b797871c">


Part of #3878