### PR TITLE
Add experiments table footer and move select branches action

### DIFF
--- a/extension/src/test/e2e/extension.test.ts
+++ b/extension/src/test/e2e/extension.test.ts
@@ -53,7 +53,9 @@ describe('Experiments Table Webview', function () {
   const workspaceRow = 1
   const commitRows = 3
   const branchRow = 1
-  const initialRows = headerRows + workspaceRow + commitRows + branchRow
+  const footerRow = 1
+  const initialRows =
+    headerRows + workspaceRow + commitRows + branchRow + footerRow
 
   it('should load as an editor', async function () {
     const workbench = await browser.getWorkbench()

--- a/webview/src/experiments/components/table/Table.tsx
+++ b/webview/src/experiments/components/table/Table.tsx
@@ -5,6 +5,7 @@ import styles from './styles.module.scss'
 import { TableHead } from './header/TableHead'
 import { RowSelectionContext } from './RowSelectionContext'
 import { TableContent } from './body/TableContent'
+import { TableFooter } from './TableFooter'
 import { InstanceProp } from '../../util/interfaces'
 
 interface TableProps extends InstanceProp {
@@ -51,6 +52,7 @@ export const Table: React.FC<TableProps> = ({
           tableRef={tableRef}
           tableHeadHeight={tableHeadHeight}
         />
+        <TableFooter />
       </table>
     </div>
   )

--- a/webview/src/experiments/components/table/TableFooter.tsx
+++ b/webview/src/experiments/components/table/TableFooter.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { AddAndRemoveBranches } from './commitsAndBranches/AddAndRemoveBranches'
+import styles from './styles.module.scss'
+
+export const TableFooter: React.FC = () => (
+  <tfoot className={styles.footer}>
+    <tr>
+      <td colSpan={99999}>
+        <AddAndRemoveBranches />
+      </td>
+    </tr>
+  </tfoot>
+)

--- a/webview/src/experiments/components/table/body/branchDivider/BranchDivider.tsx
+++ b/webview/src/experiments/components/table/body/branchDivider/BranchDivider.tsx
@@ -3,7 +3,7 @@ import styles from './styles.module.scss'
 import tablesStyles from '../../styles.module.scss'
 import { Icon } from '../../../../../shared/components/Icon'
 import { GitMerge } from '../../../../../shared/components/icons'
-import { CommitsAndBranchesNavigation } from '../commitsAndBranches/CommitsAndBranchesNavigation'
+import { CommitsAndBranchesNavigation } from '../../commitsAndBranches/CommitsAndBranchesNavigation'
 
 interface BranchDividerProps {
   branch: string

--- a/webview/src/experiments/components/table/commitsAndBranches/AddAndRemoveBranches.tsx
+++ b/webview/src/experiments/components/table/commitsAndBranches/AddAndRemoveBranches.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
 import styles from './styles.module.scss'
-import { ExperimentsState } from '../../../../store'
-import { selectBranches } from '../../../../util/messages'
+import { ExperimentsState } from '../../../store'
+import { selectBranches } from '../../../util/messages'
 
 export const AddAndRemoveBranches: React.FC = () => {
   const { hasBranchesToSelect } = useSelector(

--- a/webview/src/experiments/components/table/commitsAndBranches/CommitsAndBranchesNavigation.tsx
+++ b/webview/src/experiments/components/table/commitsAndBranches/CommitsAndBranchesNavigation.tsx
@@ -1,9 +1,8 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
-import { AddAndRemoveBranches } from './AddAndRemoveBranches'
 import styles from './styles.module.scss'
-import { showLessCommits, showMoreCommits } from '../../../../util/messages'
-import { ExperimentsState } from '../../../../store'
+import { showLessCommits, showMoreCommits } from '../../../util/messages'
+import { ExperimentsState } from '../../../store'
 
 interface CommitsAndBranchesNavigationProps {
   branch: string
@@ -34,8 +33,6 @@ export const CommitsAndBranchesNavigation: React.FC<
           Show Less Commits
         </button>
       )}
-
-      <AddAndRemoveBranches />
     </div>
   )
 }

--- a/webview/src/experiments/components/table/commitsAndBranches/styles.module.scss
+++ b/webview/src/experiments/components/table/commitsAndBranches/styles.module.scss
@@ -1,4 +1,4 @@
-@import '../../../../../shared/variables';
+@import '../../../../shared/variables';
 
 .commitsAndBranchesNav {
   text-align: left;

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -850,3 +850,13 @@ $badge-size: 0.85rem;
     font-family: var(--vscode-font-family);
   }
 }
+
+.footer {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  left: 0;
+  z-index: 10;
+  background: $bg-color;
+  padding: 10px 20px;
+}


### PR DESCRIPTION
Part of #1966 

Experimenting with a table footer for generic actions.

Demo

https://github.com/iterative/vscode-dvc/assets/3683420/b6e37404-ddeb-497e-a902-c8128ff5d1cc

IMO, the icon at the top for the action feels more appropriate. By not adding other generic actions anywhere else in the table, we educate the user that table actions can be performed by clicking one of these icons. I would even repeat the context menu when there is at least one row selected (like GMail does).