### PR TITLE
Bump min version of DVC to 2.58.1 (Enable live plots for experiments running outside of the workspace)

### DIFF
--- a/extension/src/cli/dvc/contract.ts
+++ b/extension/src/cli/dvc/contract.ts
@@ -1,6 +1,6 @@
 import { Plot } from '../../plots/webview/contract'
 
-export const MIN_CLI_VERSION = '2.57.0'
+export const MIN_CLI_VERSION = '2.58.1'
 export const LATEST_TESTED_CLI_VERSION = '2.58.1'
 export const MAX_CLI_VERSION = '3'
 

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -21,22 +21,13 @@ import {
   pickFiltersToRemove
 } from './model/filterBy/quickPick'
 import { Color } from './model/status/colors'
-import {
-  FetchedExperiment,
-  hasFinishedWorkspaceExperiment
-} from './model/status/collect'
 import { UNSELECTED } from './model/status'
 import { starredSort } from './model/sortBy/constants'
 import { pickSortsToRemove, pickSortToAdd } from './model/sortBy/quickPick'
 import { ColumnsModel } from './columns/model'
 import { ExperimentsData } from './data'
 import { stopWorkspaceExperiment } from './processExecution'
-import {
-  Experiment,
-  ColumnType,
-  TableData,
-  isRunning
-} from './webview/contract'
+import { Experiment, ColumnType, TableData } from './webview/contract'
 import { WebviewMessages } from './webview/messages'
 import { DecorationProvider } from './model/decorationProvider'
 import { starredFilter } from './model/filterBy/constants'
@@ -227,17 +218,6 @@ export class Experiments extends BaseRepository<TableData> {
     return status
   }
 
-  public checkForFinishedWorkspaceExperiment(
-    fetchedExperiments: FetchedExperiment[]
-  ) {
-    if (!hasFinishedWorkspaceExperiment(fetchedExperiments)) {
-      return
-    }
-
-    this.experiments.unselectWorkspace()
-    this.notifyChanged()
-  }
-
   public getSorts() {
     return this.experiments.getSorts()
   }
@@ -345,9 +325,7 @@ export class Experiments extends BaseRepository<TableData> {
   }
 
   public async selectExperimentsToPlot() {
-    const experiments = this.experiments
-      .getWorkspaceCommitsAndExperiments()
-      .filter(({ status }) => !isRunning(status))
+    const experiments = this.experiments.getWorkspaceCommitsAndExperiments()
 
     const selected = await pickExperimentsToPlot(
       experiments,

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -417,14 +417,6 @@ export class Experiments extends BaseRepository<TableData> {
     return this.experiments.getSelectedRevisions()
   }
 
-  public setRevisionCollected(revisions: string[]) {
-    this.experiments.setRevisionCollected(revisions)
-  }
-
-  public getFinishedExperiments() {
-    return this.experiments.getFinishedExperiments()
-  }
-
   public getExperiments() {
     return this.experiments.getExperiments()
   }

--- a/extension/src/experiments/model/collect.ts
+++ b/extension/src/experiments/model/collect.ts
@@ -300,6 +300,9 @@ const setWorkspaceAsRunning = (
   ) {
     acc.workspace.executor = Executor.WORKSPACE
     acc.workspace.status = ExperimentStatus.RUNNING
+  }
+
+  if (dvcLiveOnly) {
     acc.runningExperiments.unshift({
       executor: Executor.WORKSPACE,
       id: EXPERIMENT_WORKSPACE_ID

--- a/extension/src/experiments/model/index.test.ts
+++ b/extension/src/experiments/model/index.test.ts
@@ -221,7 +221,7 @@ describe('ExperimentsModel', () => {
     expect(experimentsModel.getSelectedRevisions()).toHaveLength(7)
   })
 
-  it('should swap an experiment running in the workspace for the workspace and not select an experiment running in the queue', () => {
+  it('should not swap an experiment running in the workspace for the workspace and not prevent selection of an experiment running in the queue', () => {
     const params = {
       params: {
         'params.yaml': {
@@ -231,6 +231,9 @@ describe('ExperimentsModel', () => {
         }
       }
     }
+    const runningExpName = 'selectable-nuffy'
+    const runningTaskName = 'selectable-task'
+
     const data = generateTestExpShowOutput(
       {},
       {
@@ -242,7 +245,7 @@ describe('ExperimentsModel', () => {
               name: Executor.WORKSPACE,
               state: ExperimentStatus.RUNNING
             },
-            name: 'unselectable-nuffy',
+            name: runningExpName,
             rev: EXPERIMENT_WORKSPACE_ID
           },
           {},
@@ -255,7 +258,7 @@ describe('ExperimentsModel', () => {
               name: Executor.DVC_TASK,
               state: ExperimentStatus.RUNNING
             },
-            name: 'unselectable-task',
+            name: runningTaskName,
             rev: EXPERIMENT_WORKSPACE_ID
           }
         ],
@@ -267,7 +270,7 @@ describe('ExperimentsModel', () => {
     model.transformAndSet(data, false, '')
 
     expect(model.getSelectedRevisions().map(({ id }) => id)).toStrictEqual([
-      EXPERIMENT_WORKSPACE_ID
+      runningExpName
     ])
 
     model.setSelected([])
@@ -277,9 +280,11 @@ describe('ExperimentsModel', () => {
     expect(model.getSelectedRevisions().map(({ id }) => id)).toStrictEqual([
       EXPERIMENT_WORKSPACE_ID,
       'testBranch',
+      runningExpName,
       'exp-2',
       'exp-3',
-      'exp-4'
+      'exp-4',
+      runningTaskName
     ])
   })
 

--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -24,7 +24,6 @@ import {
 } from '../webview/contract'
 import { definedAndNonEmpty, reorderListSubset } from '../../util/array'
 import {
-  EXPERIMENT_WORKSPACE_ID,
   Executor,
   ExpShowOutput,
   ExperimentStatus
@@ -66,7 +65,6 @@ export class ExperimentsModel extends ModelWithPersistence {
 
   private currentSorts: SortDefinition[]
   private running: RunningExperiment[] = []
-  private finishedRunning: { [id: string]: string } = {}
   private startedRunning: Set<string> = new Set()
 
   constructor(dvcRoot: string, workspaceState: Memento) {
@@ -160,10 +158,6 @@ export class ExperimentsModel extends ModelWithPersistence {
     return this.coloredStatus[id]
   }
 
-  public unselectWorkspace() {
-    this.coloredStatus[EXPERIMENT_WORKSPACE_ID] = UNSELECTED
-  }
-
   public hasRunningExperiment() {
     return this.running.length > 0
   }
@@ -174,16 +168,6 @@ export class ExperimentsModel extends ModelWithPersistence {
 
   public hasCheckpoints() {
     return this.checkpoints
-  }
-
-  public setRevisionCollected(revisions: string[]) {
-    for (const { id } of this.getExperimentsAndQueued().filter(({ label }) =>
-      revisions.includes(label)
-    )) {
-      if (this.finishedRunning[id]) {
-        delete this.finishedRunning[id]
-      }
-    }
   }
 
   public canSelect() {
@@ -422,10 +406,6 @@ export class ExperimentsModel extends ModelWithPersistence {
       hasChildren: false,
       type: this.getExperimentType(experiment.status)
     }))
-  }
-
-  public getFinishedExperiments() {
-    return this.finishedRunning
   }
 
   public setNbfCommitsToShow(numberOfCommitsToShow: number, branch: string) {

--- a/extension/src/plots/model/index.ts
+++ b/extension/src/plots/model/index.ts
@@ -113,8 +113,6 @@ export class PlotsModel extends ModelWithPersistence {
 
     this.fetchedRevs = new Set(revs)
 
-    this.experiments.setRevisionCollected(revs)
-
     this.deferred.resolve()
   }
 

--- a/extension/src/plots/webview/messages.ts
+++ b/extension/src/plots/webview/messages.ts
@@ -69,10 +69,6 @@ export class WebviewMessages {
       selectedRevisions,
       template: this.getTemplatePlots(selectedRevisions)
     })
-
-    this.experiments.checkForFinishedWorkspaceExperiment(
-      selectedRevisions.filter(({ fetched }) => fetched)
-    )
   }
 
   public handleMessageFromWebview(message: MessageFromWebview) {

--- a/extension/src/test/fixtures/expShow/base/rows.ts
+++ b/extension/src/test/fixtures/expShow/base/rows.ts
@@ -42,7 +42,7 @@ const rowsFixture: Commit[] = [
         'c3961d777cfbd7727f9fde4851896006'
       )
     },
-    displayColor: colorsList[0],
+    displayColor: undefined,
     executor: Executor.WORKSPACE,
     id: EXPERIMENT_WORKSPACE_ID,
     label: EXPERIMENT_WORKSPACE_ID,
@@ -69,7 +69,7 @@ const rowsFixture: Commit[] = [
       }
     },
     status: ExperimentStatus.RUNNING,
-    selected: true,
+    selected: false,
     starred: false
   },
   {
@@ -269,7 +269,7 @@ const rowsFixture: Commit[] = [
             'c3961d777cfbd7727f9fde4851896006'
           )
         },
-        displayColor: undefined,
+        displayColor: colorsList[0],
         description: '[exp-83425]',
         executor: Executor.WORKSPACE,
         id: 'exp-83425',
@@ -296,7 +296,7 @@ const rowsFixture: Commit[] = [
             test: true
           }
         },
-        selected: false,
+        selected: true,
         starred: false,
         status: ExperimentStatus.RUNNING,
         Created: '2020-12-29T15:27:02'

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -71,11 +71,7 @@ import {
   RegisteredCommands
 } from '../../../commands/external'
 import { ConfigKey } from '../../../vscode/config'
-import {
-  EXPERIMENT_WORKSPACE_ID,
-  Executor,
-  ExperimentStatus
-} from '../../../cli/dvc/contract'
+import { EXPERIMENT_WORKSPACE_ID } from '../../../cli/dvc/contract'
 import * as Time from '../../../util/time'
 import { AvailableCommands } from '../../../commands/internal'
 import { Setup } from '../../../setup'
@@ -931,8 +927,8 @@ suite('Experiments Test Suite', () => {
 
       expect(
         isExperimentSelected(runningInQueueId),
-        'experiment running the queue cannot be selected'
-      ).to.be.false
+        'experiment running in the queue can be selected'
+      ).to.be.true
 
       mockMessageReceived.fire({
         payload: queuedId,
@@ -1159,8 +1155,8 @@ suite('Experiments Test Suite', () => {
       const mockMessageReceived = getMessageReceivedEmitter(webview)
       const queuedId = '90aea7f'
       const runningInQueueId = 'exp-e7a67'
-      const expectedIds = ['main', 'test-branch']
-      const mockExperimentIds = [...expectedIds, queuedId, runningInQueueId]
+      const expectedIds = ['main', 'test-branch', runningInQueueId]
+      const mockExperimentIds = [...expectedIds, queuedId]
 
       stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
@@ -1177,7 +1173,7 @@ suite('Experiments Test Suite', () => {
         .getSelectedRevisions()
         .map(({ id }) => id)
         .sort()
-      mockExperimentIds.sort()
+      expectedIds.sort()
       expect(
         selectExperimentIds,
         'should exclude queued experiments and experiments running in the queue from selection'
@@ -1204,14 +1200,14 @@ suite('Experiments Test Suite', () => {
       const webview = await experiments.showWebview()
       const mockMessageReceived = getMessageReceivedEmitter(webview)
       const runningInQueueId = 'exp-e7a67'
-      const mockExperimentIds = ['main', 'test-branch']
+      const mockExperimentIds = ['main', 'test-branch', runningInQueueId]
 
       stubWorkspaceExperimentsGetters(dvcDemoPath, experiments)
 
       const tableChangePromise = experimentsUpdatedEvent(experiments)
 
       mockMessageReceived.fire({
-        payload: [...mockExperimentIds, runningInQueueId],
+        payload: mockExperimentIds,
         type: MessageFromWebviewType.SET_EXPERIMENTS_AND_OPEN_PLOTS
       })
 
@@ -1692,11 +1688,12 @@ suite('Experiments Test Suite', () => {
       ).to.deep.equal({
         '489fd8b': 0,
         '55d492c': 0,
+        'exp-83425': colors[0],
         'exp-e7a67': 0,
         'exp-f13bca': 0,
         main: 0,
         'test-branch': 0,
-        [EXPERIMENT_WORKSPACE_ID]: colors[0]
+        [EXPERIMENT_WORKSPACE_ID]: 0
       })
 
       expect(
@@ -1787,11 +1784,12 @@ suite('Experiments Test Suite', () => {
       ).to.deep.equal({
         '489fd8b': 0,
         '55d492c': 0,
+        'exp-83425': colors[0],
         'exp-e7a67': 0,
         'exp-f13bca': colors[1],
         main: 0,
         'test-branch': 0,
-        [EXPERIMENT_WORKSPACE_ID]: colors[0]
+        [EXPERIMENT_WORKSPACE_ID]: 0
       })
     })
 
@@ -1802,7 +1800,7 @@ suite('Experiments Test Suite', () => {
         'experimentsFilterBy:test': filterMapEntries,
         'experimentsSortBy:test': sortDefinitions,
         'experimentsStatus:test': {
-          [EXPERIMENT_WORKSPACE_ID]: colors[0],
+          'exp-83425': colors[0],
           'exp-e7a67': colors[5],
           'exp-f13bca': 0,
           'test-branch': colors[1]
@@ -1841,7 +1839,7 @@ suite('Experiments Test Suite', () => {
       ).to.deep.equal([
         {
           displayColor: colors[0],
-          id: EXPERIMENT_WORKSPACE_ID
+          id: 'exp-83425'
         },
         {
           displayColor: colors[1],
@@ -2005,123 +2003,6 @@ suite('Experiments Test Suite', () => {
       expect(mockCheckSignalFile).to.be.called
       expect(mockDelay).to.be.called
       expect(mockUpdateExperimentsData).to.be.calledOnce
-    })
-  })
-
-  describe('checkForFinishedWorkspaceExperiment', () => {
-    it('should unselect the workspace record if it has the same color as an experiment', async () => {
-      const colors = copyOriginalColors()
-      const [color] = colors
-      const commit = 'df3f8647a47e403c9c4aa6562cad0b74afbe900b'
-      const name = 'fizzy-dilemma'
-      const params = { 'params.yaml': { data: { lr: 1 } } }
-      const runningOutput = generateTestExpShowOutput(
-        { params },
-        {
-          rev: commit,
-          experiments: [
-            {
-              rev: EXPERIMENT_WORKSPACE_ID,
-              data: { params },
-              name,
-              executor: {
-                local: null,
-                state: ExperimentStatus.RUNNING,
-                name: Executor.WORKSPACE
-              }
-            }
-          ]
-        }
-      )
-
-      const getSelectedIdsWithColor = (
-        experiments: Experiments
-      ): { id: string; displayColor: string }[] =>
-        experiments
-          .getSelectedRevisions()
-          .map(({ id, displayColor }) => ({ id, displayColor }))
-
-      const selectedWorkspace = {
-        id: EXPERIMENT_WORKSPACE_ID,
-        displayColor: color
-      }
-      const selectedExperiment = {
-        id: name,
-        displayColor: color
-      }
-      const bothSelected = [selectedWorkspace, selectedExperiment]
-
-      const { experiments, experimentsModel } = buildExperiments(
-        disposable,
-        runningOutput
-      )
-
-      await experiments.isReady()
-
-      expect(
-        experimentsModel.hasRunningWorkspaceExperiment(),
-        'should have a running experiment'
-      ).to.be.true
-
-      expect(
-        getSelectedIdsWithColor(experiments),
-        'should automatically select the running experiment'
-      ).to.deep.equal([selectedWorkspace])
-
-      const experimentsChanged = new Promise(resolve =>
-        experiments.onDidChangeExperiments(() => resolve(undefined))
-      )
-
-      await experiments.setState(
-        generateTestExpShowOutput(
-          { params },
-          {
-            rev: commit,
-            experiments: [
-              {
-                rev: '679c7ce7469020332154717126f88ce157ebc612',
-                data: { params },
-                name,
-                executor: null
-              }
-            ]
-          }
-        )
-      )
-
-      await experimentsChanged
-
-      expect(
-        getSelectedIdsWithColor(experiments),
-        "should apply the workspace's color to a newly created experiment"
-      ).to.deep.equal(bothSelected)
-
-      experiments.checkForFinishedWorkspaceExperiment([selectedWorkspace])
-
-      expect(
-        getSelectedIdsWithColor(experiments),
-        "should not remove the workspace's color if the experiment's data has not been fetched"
-      ).to.deep.equal(bothSelected)
-
-      experiments.checkForFinishedWorkspaceExperiment([
-        selectedExperiment,
-        selectedWorkspace
-      ])
-
-      expect(
-        getSelectedIdsWithColor(experiments),
-        "should remove the workspace's color once the experiment's data has been shown to be fetched"
-      ).to.deep.equal([selectedExperiment])
-
-      experiments.toggleExperimentStatus(EXPERIMENT_WORKSPACE_ID)
-
-      expect(
-        getSelectedIdsWithColor(experiments),
-        'should not duplicate the color when toggling another experiment'
-      ).to.deep.equal([
-        selectedExperiment,
-        { id: EXPERIMENT_WORKSPACE_ID, displayColor: colors[1] }
-      ])
     })
   })
 })

--- a/webview/src/experiments/components/table/body/RowContextMenu.tsx
+++ b/webview/src/experiments/components/table/body/RowContextMenu.tsx
@@ -56,7 +56,6 @@ const collectDisabledOptions = (
   const starredExperimentIds: string[] = []
   const unstarredExperimentIds: string[] = []
   let disableExperimentOnlyOption = false
-  let disablePlotOption = false
   let disableStopOption = false
 
   for (const { row } of selectedRowsList) {
@@ -78,16 +77,13 @@ const collectDisabledOptions = (
       disableExperimentOnlyOption = true
     }
 
-    if (isRunning(status)) {
-      disablePlotOption = true
-      continue
+    if (!isRunning(status)) {
+      disableStopOption = true
     }
-    disableStopOption = true
   }
 
   return {
     disableExperimentOnlyOption,
-    disablePlotOption,
     disableStopOption,
     selectedIds,
     starredExperimentIds,
@@ -101,7 +97,6 @@ const getMultiSelectMenuOptions = (
 ) => {
   const {
     disableExperimentOnlyOption,
-    disablePlotOption,
     disableStopOption,
     selectedIds,
     starredExperimentIds,
@@ -126,14 +121,14 @@ const getMultiSelectMenuOptions = (
       ids,
       'Plot',
       MessageFromWebviewType.SET_EXPERIMENTS_FOR_PLOTS,
-      disablePlotOption,
+      false,
       true
     ),
     experimentMenuOption(
       ids,
       'Plot and Show',
       MessageFromWebviewType.SET_EXPERIMENTS_AND_OPEN_PLOTS,
-      disablePlotOption,
+      false,
       false
     ),
     experimentMenuOption(


### PR DESCRIPTION
Closes #3436 & closes #3178 (I will open a new issue for the final remaining item).

Things to note:

- Experiments running in the queue are not selected by default.
- Experiments running in the workspace are selected by default.
- No more selecting the workspace for an experiment running in the workspace and then moving the selection across to the experiment once it finishes.
- Experiments running in the DVCLive-only context are not selected once the workspace run finishes (selection remains on workspace).

### Demos 

#### 2 queue workers + workspace experiment

https://github.com/iterative/vscode-dvc/assets/37993418/2e507ff4-b5f3-4333-b7b1-634eedfaf79a

#### DVCLive only

https://github.com/iterative/vscode-dvc/assets/37993418/030f9d91-8010-41cb-b4f8-50dec377d29b

