### PR TITLE
Reduce the number of calls to git log

### DIFF
--- a/extension/src/cli/git/reader.test.ts
+++ b/extension/src/cli/git/reader.test.ts
@@ -69,6 +69,48 @@ describe('GitReader', () => {
     })
   })
 
+  describe('getCommitMessages', () => {
+    it('should call git with the correct parameters', async () => {
+      const cwd = __dirname
+      const shas = [
+        'c921aaa025b7c09686937e58b3dc45b83ef5c732',
+        '3d702b23b17d2f0699295a0242b2c36511fb9865',
+        'aaba93ee11b8c7d254775769ad342072afdfbd81'
+      ]
+
+      const gitLog = `c921aaa025b7c09686937e58b3dc45b83ef5c732
+      Matt Seddon
+      19 minutes ago
+      refNames:branch-for-commits
+      message:make another commit
+      ^@3d702b23b17d2f0699295a0242b2c36511fb9865
+      Matt Seddon
+      19 minutes ago
+      refNames:
+      message:make a commit
+      ^@aaba93ee11b8c7d254775769ad342072afdfbd81
+      Matt Seddon
+      6 hours ago
+      refNames:HEAD -> main, origin/main, origin/HEAD, z-last-branch
+      message:Update dependency dvc to v2.58.1 (#88)`
+
+      mockedCreateProcess.mockReturnValueOnce(getMockedProcess(gitLog))
+
+      const cliOutput = await gitReader.getCommitMessages(cwd, ...shas)
+      expect(cliOutput).toStrictEqual(gitLog)
+      expect(mockedCreateProcess).toHaveBeenCalledWith({
+        args: [
+          'log',
+          ...shas,
+          '--pretty=format:%H%n%an%n%ar%nrefNames:%D%nmessage:%B',
+          '-z'
+        ],
+        cwd,
+        executable: 'git'
+      })
+    })
+  })
+
   describe('getCurrentBranch', () => {
     it('should match the expected output', async () => {
       const cwd = __dirname

--- a/extension/src/cli/git/reader.ts
+++ b/extension/src/cli/git/reader.ts
@@ -49,15 +49,16 @@ export class GitReader extends GitCli {
     return !output
   }
 
-  public async getCommitMessages(cwd: string, sha: string): Promise<string> {
+  public async getCommitMessages(
+    cwd: string,
+    ...shas: string[]
+  ): Promise<string> {
     const options = getOptions(
       cwd,
       Command.LOG,
-      sha,
+      ...shas,
       Flag.PRETTY_FORMAT_COMMIT_MESSAGE,
-      Flag.SEPARATE_WITH_NULL,
-      Flag.NUMBER,
-      '1'
+      Flag.SEPARATE_WITH_NULL
     )
     try {
       return await this.executeProcess(options)


### PR DESCRIPTION
Whilst debugging #3941 I noticed that we are making multiple calls to `git log` (each time that we call `exp show`) when we only need to make a single call.

### Demo

https://github.com/iterative/vscode-dvc/assets/37993418/e5f0bf35-36d0-4c66-8b6a-fbdfa9f327bb

