### PR TITLE
Fix overflowing message

### DIFF
--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -761,6 +761,8 @@ $badge-size: 0.85rem;
 .experimentCellSecondaryNameTooltip {
   white-space: normal;
   padding: 5px;
+  width: min-content;
+  width: 100%;
 
   &,
   p,
@@ -796,6 +798,9 @@ $badge-size: 0.85rem;
   .message {
     white-space: pre-wrap;
     margin: 0;
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }
 


### PR DESCRIPTION
Just stumbled upon this.

Before:
<img width="465" alt="Screenshot 2023-05-23 at 2 52 00 PM" src="https://github.com/iterative/vscode-dvc/assets/3683420/f0fa8bef-988b-4c40-bd42-07429e3de7ad">

Now:
<img width="361" alt="Screenshot 2023-05-24 at 9 17 10 AM" src="https://github.com/iterative/vscode-dvc/assets/3683420/5082b25a-9239-448d-856b-4f5d6e95bee3">

