### PR TITLE
Show all branches when selecting

### DIFF
--- a/extension/src/cli/git/constants.ts
+++ b/extension/src/cli/git/constants.ts
@@ -35,7 +35,6 @@ export enum Flag {
   HARD = '--hard',
   NAME_ONLY = '--name-only',
   NO_EMPTY_DIRECTORY = '--no-empty-directory',
-  NO_MERGE = '--no-merge',
   NUMBER = '-n',
   PRETTY_FORMAT_COMMIT_MESSAGE = '--pretty=format:%H%n%an%n%ar%nrefNames:%D%nmessage:%B',
   OTHERS = '--others',

--- a/extension/src/cli/git/reader.test.ts
+++ b/extension/src/cli/git/reader.test.ts
@@ -52,7 +52,7 @@ describe('GitReader', () => {
       const cliOutput = await gitReader.getBranches(cwd)
       expect(cliOutput).toStrictEqual(branches)
       expect(mockedCreateProcess).toHaveBeenCalledWith({
-        args: ['branch', '--no-merge'],
+        args: ['branch'],
         cwd,
         executable: 'git'
       })

--- a/extension/src/cli/git/reader.ts
+++ b/extension/src/cli/git/reader.ts
@@ -94,7 +94,7 @@ export class GitReader extends GitCli {
   }
 
   public async getBranches(cwd: string): Promise<string[]> {
-    const options = getOptions(cwd, Command.BRANCH, Flag.NO_MERGE)
+    const options = getOptions(cwd, Command.BRANCH)
     try {
       const branches = await this.executeProcess(options)
       return trimAndSplit(branches).map(cleanUpBranchName)

--- a/extension/src/experiments/workspace.test.ts
+++ b/extension/src/experiments/workspace.test.ts
@@ -42,6 +42,7 @@ const mockedFindOrCreateDvcYamlFile = jest.mocked(findOrCreateDvcYamlFile)
 const mockedGetFileExtension = jest.mocked(getFileExtension)
 const mockedHasDvcYamlFile = jest.mocked(hasDvcYamlFile)
 const mockedGetBranches = jest.fn()
+const mockedGetCurrentBranch = jest.fn()
 const mockedPickFile = jest.mocked(pickFile)
 
 jest.mock('vscode')
@@ -83,6 +84,11 @@ describe('Experiments', () => {
   mockedInternalCommands.registerCommand(
     AvailableCommands.GIT_GET_BRANCHES,
     () => mockedGetBranches()
+  )
+
+  mockedInternalCommands.registerCommand(
+    AvailableCommands.GIT_GET_CURRENT_BRANCH,
+    () => mockedGetCurrentBranch()
   )
 
   const workspaceExperiments = new WorkspaceExperiments(
@@ -743,7 +749,7 @@ describe('Experiments', () => {
       )
     })
 
-    it('should display the current branch in the quick pick', async () => {
+    it('should not display the current branch in the quick pick', async () => {
       const allBranches = [
         '* (HEAD detached at XXXX)',
         'main',
@@ -756,7 +762,7 @@ describe('Experiments', () => {
 
       await workspaceExperiments.selectBranches([])
 
-      expect(mockedQuickPickManyValues).toHaveBeenCalledWith(
+      expect(mockedQuickPickManyValues).not.toHaveBeenCalledWith(
         [
           expect.objectContaining({
             label: 'HEAD detached at XXXX',
@@ -784,7 +790,7 @@ describe('Experiments', () => {
 
       await workspaceExperiments.selectBranches([])
 
-      expect(mockedQuickPickManyValues).toHaveBeenCalledWith(
+      expect(mockedQuickPickManyValues).not.toHaveBeenCalledWith(
         [
           ...updatedAllBranches.slice(0, 1),
           'special-branch',

--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -394,15 +394,20 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
       AvailableCommands.GIT_GET_BRANCHES,
       cwd
     )
+    const currentBranch = await this.internalCommands.executeCommand<string>(
+      AvailableCommands.GIT_GET_CURRENT_BRANCH,
+      cwd
+    )
     return await quickPickManyValues(
-      allBranches.map(branch => {
-        const branchName = branch.replace('* (', '').replace(')', '')
-        return {
-          label: branchName,
-          picked: branchesSelected.includes(branchName),
-          value: branchName
-        }
-      }),
+      allBranches
+        .filter(branch => branch !== currentBranch)
+        .map(branch => {
+          return {
+            label: branch,
+            picked: branchesSelected.includes(branch),
+            value: branch
+          }
+        }),
       {
         title: Title.SELECT_BRANCHES
       }


### PR DESCRIPTION
Removed the `--no-merge` flag when getting the branches.

Now:
<img width="1628" alt="Screenshot 2023-05-24 at 9 30 59 AM" src="https://github.com/iterative/vscode-dvc/assets/3683420/ea1ccb9e-a256-4566-b5d2-2dc4fbf61b7e">

