### PR TITLE
Add DvcConfig class

### DIFF
--- a/extension/src/cli/dvc/config.test.ts
+++ b/extension/src/cli/dvc/config.test.ts
@@ -1,0 +1,107 @@
+import { EventEmitter } from 'vscode'
+import { Disposable, Disposer } from '@hediet/std/disposable'
+import { ConfigKey, Flag, SubCommand } from './constants'
+import { DvcConfig } from './config'
+import { CliResult, CliStarted } from '..'
+import { createProcess } from '../../process/execution'
+import { getMockedProcess } from '../../test/util/jest'
+import { getProcessEnv } from '../../env'
+import { Config } from '../../config'
+
+jest.mock('vscode')
+jest.mock('@hediet/std/disposable')
+jest.mock('../../env')
+jest.mock('../../process/execution')
+
+const mockedDisposable = jest.mocked(Disposable)
+
+const mockedCreateProcess = jest.mocked(createProcess)
+const mockedGetProcessEnv = jest.mocked(getProcessEnv)
+const mockedEnv = {
+  DVCLIVE_OPEN: 'false',
+  DVC_NO_ANALYTICS: 'true',
+  GIT_TERMINAL_PROMPT: '0',
+  PATH: '/some/special/path'
+}
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  mockedGetProcessEnv.mockReturnValueOnce(mockedEnv)
+})
+
+describe('DvcConfig', () => {
+  mockedDisposable.fn.mockReturnValueOnce({
+    track: function <T>(disposable: T): T {
+      return disposable
+    },
+    untrack: function <T>(disposable: T): T {
+      return disposable
+    }
+  } as unknown as (() => void) & Disposer)
+
+  const dvcConfig = new DvcConfig(
+    {
+      getCliPath: () => undefined,
+      getPythonBinPath: () => undefined
+    } as unknown as Config,
+    {
+      processCompleted: {
+        event: jest.fn(),
+        fire: jest.fn()
+      } as unknown as EventEmitter<CliResult>,
+      processStarted: {
+        event: jest.fn(),
+        fire: jest.fn()
+      } as unknown as EventEmitter<CliStarted>
+    }
+  )
+
+  describe('config', () => {
+    it('should call createProcess with the correct parameters to access the config', async () => {
+      const cwd = __dirname
+      const stdout = ''
+
+      mockedCreateProcess.mockReturnValueOnce(getMockedProcess(stdout))
+
+      const output = await dvcConfig.config(cwd, ConfigKey.STUDIO_OFFLINE)
+      expect(output).toStrictEqual(stdout)
+
+      expect(mockedCreateProcess).toHaveBeenCalledWith({
+        args: ['config', 'studio.offline'],
+        cwd,
+        env: mockedEnv,
+        executable: 'dvc'
+      })
+    })
+
+    it('should return undefined if the underlying process throws', async () => {
+      const cwd = __dirname
+
+      mockedCreateProcess.mockImplementationOnce(() => {
+        throw new Error('unable to access DVC')
+      })
+
+      const output = await dvcConfig.config(cwd, ConfigKey.STUDIO_OFFLINE)
+      expect(output).toStrictEqual(undefined)
+    })
+  })
+
+  describe('remote', () => {
+    it('should call createProcess with the correct parameters to access the remote section of the config', async () => {
+      const cwd = __dirname
+      const stdout = ''
+
+      mockedCreateProcess.mockReturnValueOnce(getMockedProcess(stdout))
+
+      const output = await dvcConfig.remote(cwd, SubCommand.LIST, Flag.LOCAL)
+      expect(output).toStrictEqual(stdout)
+
+      expect(mockedCreateProcess).toHaveBeenCalledWith({
+        args: ['remote', 'list', '--local'],
+        cwd,
+        env: mockedEnv,
+        executable: 'dvc'
+      })
+    })
+  })
+})

--- a/extension/src/cli/dvc/config.ts
+++ b/extension/src/cli/dvc/config.ts
@@ -1,0 +1,33 @@
+import { DvcCli } from '.'
+import { Args, Command } from './constants'
+import { typeCheckCommands } from '..'
+
+export const autoRegisteredCommands = {
+  CONFIG: 'config',
+  REMOTE: 'remote'
+} as const
+
+export class DvcConfig extends DvcCli {
+  public readonly autoRegisteredCommands = typeCheckCommands(
+    autoRegisteredCommands,
+    this
+  )
+
+  public config(cwd: string, ...args: Args) {
+    return this.executeSafeProcess(cwd, Command.CONFIG, ...args)
+  }
+
+  public remote(cwd: string, ...args: Args) {
+    return this.executeSafeProcess(cwd, Command.REMOTE, ...args)
+  }
+
+  private async executeSafeProcess(
+    cwd: string,
+    command: Command,
+    ...args: Args
+  ) {
+    try {
+      return await this.executeDvcProcess(cwd, command, ...args)
+    } catch {}
+  }
+}

--- a/extension/src/cli/dvc/executor.ts
+++ b/extension/src/cli/dvc/executor.ts
@@ -16,7 +16,6 @@ export const autoRegisteredCommands = {
   ADD: 'add',
   CHECKOUT: 'checkout',
   COMMIT: 'commit',
-  CONFIG: 'config',
   EXP_APPLY: 'expApply',
   EXP_BRANCH: 'expBranch',
   EXP_GARBAGE_COLLECT: 'expGarbageCollect',
@@ -32,7 +31,6 @@ export const autoRegisteredCommands = {
   QUEUE_KILL: 'queueKill',
   QUEUE_START: 'queueStart',
   QUEUE_STOP: 'queueStop',
-  REMOTE: 'remote',
   REMOVE: 'remove'
 } as const
 
@@ -54,10 +52,6 @@ export class DvcExecutor extends DvcCli {
 
   public commit(cwd: string, ...args: Args) {
     return this.blockAndExecuteProcess(cwd, Command.COMMIT, ...args, Flag.FORCE)
-  }
-
-  public config(cwd: string, ...args: Args) {
-    return this.executeDvcProcess(cwd, Command.CONFIG, ...args)
   }
 
   public expApply(cwd: string, experimentName: string) {
@@ -172,10 +166,6 @@ export class DvcExecutor extends DvcCli {
 
   public remove(cwd: string, ...args: Args) {
     return this.blockAndExecuteProcess(cwd, Command.REMOVE, ...args)
-  }
-
-  public remote(cwd: string, ...args: Args) {
-    return this.executeDvcProcess(cwd, Command.REMOTE, ...args)
   }
 
   private executeExperimentProcess(cwd: string, ...args: Args) {

--- a/extension/src/commands/internal.ts
+++ b/extension/src/commands/internal.ts
@@ -2,6 +2,7 @@ import { commands } from 'vscode'
 import { RegisteredCliCommands, RegisteredCommands } from './external'
 import { ICli } from '../cli'
 import { Args } from '../cli/constants'
+import { autoRegisteredCommands as DvcConfigCommands } from '../cli/dvc/config'
 import { autoRegisteredCommands as DvcExecutorCommands } from '../cli/dvc/executor'
 import { autoRegisteredCommands as DvcReaderCommands } from '../cli/dvc/reader'
 import { autoRegisteredCommands as DvcRunnerCommands } from '../cli/dvc/runner'
@@ -19,18 +20,21 @@ type Command = (...args: Args) => unknown | Promise<unknown>
 
 export const AvailableCommands = Object.assign(
   {},
+  DvcConfigCommands,
   DvcExecutorCommands,
   DvcReaderCommands,
   DvcRunnerCommands,
   DvcViewerCommands,
   GitExecutorCommands,
   GitReaderCommands
-) as typeof DvcExecutorCommands &
+) as typeof DvcConfigCommands &
+  typeof DvcExecutorCommands &
   typeof DvcReaderCommands &
   typeof DvcRunnerCommands &
   typeof DvcViewerCommands &
   typeof GitExecutorCommands &
   typeof GitReaderCommands
+
 export type CommandId =
   (typeof AvailableCommands)[keyof typeof AvailableCommands]
 

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -1,4 +1,5 @@
 import { commands, env, ExtensionContext, ViewColumn } from 'vscode'
+import { DvcConfig } from './cli/dvc/config'
 import { DvcExecutor } from './cli/dvc/executor'
 import { DvcRunner } from './cli/dvc/runner'
 import { DvcReader } from './cli/dvc/reader'
@@ -61,6 +62,7 @@ class Extension extends Disposable {
   private readonly plots: WorkspacePlots
   private readonly setup: Setup
   private readonly repositoriesTree: RepositoriesTree
+  private readonly dvcConfig: DvcConfig
   private readonly dvcExecutor: DvcExecutor
   private readonly dvcReader: DvcReader
   private readonly dvcRunner: DvcRunner
@@ -84,13 +86,14 @@ class Extension extends Disposable {
     this.gitExecutor = this.dispose.track(new GitExecutor())
     this.gitReader = this.dispose.track(new GitReader())
 
+    this.dvcConfig = this.dispose.track(new DvcConfig(config))
     this.dvcExecutor = this.dispose.track(new DvcExecutor(config))
-
     this.dvcReader = this.dispose.track(new DvcReader(config))
     this.dvcRunner = this.dispose.track(new DvcRunner(config))
     this.dvcViewer = this.dispose.track(new DvcViewer(config))
 
     const clis = [
+      this.dvcConfig,
       this.dvcExecutor,
       this.dvcReader,
       this.dvcRunner,

--- a/extension/src/setup/index.ts
+++ b/extension/src/setup/index.ts
@@ -714,22 +714,18 @@ export class Setup
   }
 
   private accessConfig(cwd: string, ...args: Args) {
-    return this.accessDvc(AvailableCommands.CONFIG, cwd, ...args)
+    return this.internalCommands.executeCommand(
+      AvailableCommands.CONFIG,
+      cwd,
+      ...args
+    )
   }
 
   private accessRemote(cwd: string, ...args: Args) {
-    return this.accessDvc(AvailableCommands.REMOTE, cwd, ...args)
-  }
-
-  private async accessDvc(
-    commandId:
-      | typeof AvailableCommands.CONFIG
-      | typeof AvailableCommands.REMOTE,
-    cwd: string,
-    ...args: Args
-  ) {
-    try {
-      return await this.internalCommands.executeCommand(commandId, cwd, ...args)
-    } catch {}
+    return this.internalCommands.executeCommand(
+      AvailableCommands.REMOTE,
+      cwd,
+      ...args
+    )
   }
 }

--- a/extension/src/test/suite/extension.test.ts
+++ b/extension/src/test/suite/extension.test.ts
@@ -22,6 +22,7 @@ import { DvcExecutor } from '../../cli/dvc/executor'
 import { dvcDemoPath } from '../util'
 import { Setup } from '../../setup'
 import { Flag } from '../../cli/dvc/constants'
+import { DvcConfig } from '../../cli/dvc/config'
 
 suite('Extension Test Suite', () => {
   const disposable = Disposable.fn()
@@ -94,7 +95,8 @@ suite('Extension Test Suite', () => {
       const mockExpShow = stub(DvcReader.prototype, 'expShow')
       const mockDataStatus = stub(DvcReader.prototype, 'dataStatus')
       const mockPlotsDiff = stub(DvcReader.prototype, 'plotsDiff')
-      stub(DvcExecutor.prototype, 'config').resolves('')
+      stub(DvcConfig.prototype, 'config').resolves('')
+      stub(DvcConfig.prototype, 'remote').resolves('')
 
       stub(DvcReader.prototype, 'root').resolves('.')
 

--- a/extension/src/test/suite/setup/index.test.ts
+++ b/extension/src/test/suite/setup/index.test.ts
@@ -45,9 +45,9 @@ import * as Python from '../../../extensions/python'
 import { ContextKey } from '../../../vscode/context'
 import { Setup } from '../../../setup'
 import { SetupSection } from '../../../setup/webview/contract'
-import { DvcExecutor } from '../../../cli/dvc/executor'
 import { getFirstWorkspaceFolder } from '../../../vscode/workspaceFolders'
 import { Response } from '../../../vscode/response'
+import { DvcConfig } from '../../../cli/dvc/config'
 
 suite('Setup Test Suite', () => {
   const disposable = Disposable.fn()
@@ -741,7 +741,7 @@ suite('Setup Test Suite', () => {
       const { setup, mockExecuteCommand, messageSpy } = buildSetup(disposable)
       mockExecuteCommand.restore()
 
-      const mockConfig = stub(DvcExecutor.prototype, 'config')
+      const mockConfig = stub(DvcConfig.prototype, 'config')
       mockConfig.resolves('')
 
       const executeCommandSpy = spy(commands, 'executeCommand')
@@ -829,7 +829,7 @@ suite('Setup Test Suite', () => {
     it('should be able to delete the Studio access token from the global dvc config', async () => {
       const mockConfig = stub(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        DvcExecutor.prototype,
+        DvcConfig.prototype,
         'config'
       ).resolves(undefined)
 
@@ -909,7 +909,7 @@ suite('Setup Test Suite', () => {
 
       const mockMessageReceived = getMessageReceivedEmitter(webview)
 
-      const mockRemote = stub(DvcExecutor.prototype, 'remote')
+      const mockRemote = stub(DvcConfig.prototype, 'remote')
 
       const remoteAdded = new Promise(resolve =>
         mockRemote.callsFake((_, ...args) => {
@@ -948,7 +948,7 @@ suite('Setup Test Suite', () => {
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should be able to add a remote', async () => {
-      const mockRemote = stub(DvcExecutor.prototype, 'remote')
+      const mockRemote = stub(DvcConfig.prototype, 'remote')
 
       const remoteAdded = new Promise(resolve =>
         mockRemote.callsFake((_, ...args) => {
@@ -998,7 +998,7 @@ suite('Setup Test Suite', () => {
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should be able to rename a remote', async () => {
-      const mockRemote = stub(DvcExecutor.prototype, 'remote')
+      const mockRemote = stub(DvcConfig.prototype, 'remote')
       const newName = 'better-name'
 
       const remoteRenamed = new Promise(resolve =>
@@ -1051,7 +1051,7 @@ suite('Setup Test Suite', () => {
 
       const mockMessageReceived = getMessageReceivedEmitter(webview)
 
-      const mockRemote = stub(DvcExecutor.prototype, 'remote')
+      const mockRemote = stub(DvcConfig.prototype, 'remote')
       const projectConfigUrl = 's3://different-url'
 
       const remoteModified = new Promise(resolve =>
@@ -1123,7 +1123,7 @@ suite('Setup Test Suite', () => {
 
       const mockMessageReceived = getMessageReceivedEmitter(webview)
 
-      const mockRemote = stub(DvcExecutor.prototype, 'remote')
+      const mockRemote = stub(DvcConfig.prototype, 'remote')
 
       let calls = 0
 

--- a/extension/src/test/suite/setup/util.ts
+++ b/extension/src/test/suite/setup/util.ts
@@ -33,7 +33,7 @@ export const buildSetup = (
     messageSpy,
     resourceLocator,
     internalCommands,
-    dvcExecutor,
+    dvcConfig,
     dvcReader,
     gitExecutor,
     gitReader
@@ -44,7 +44,7 @@ export const buildSetup = (
 
   const mockEmitter = disposer.track(new EventEmitter())
   stub(dvcReader, 'root').resolves(mockDvcRoot)
-  const mockRemote = stub(dvcExecutor, 'remote').resolves('')
+  const mockRemote = stub(dvcConfig, 'remote').resolves('')
   const mockVersion = stub(dvcReader, 'version').resolves(MIN_CLI_VERSION)
   const mockGlobalVersion = stub(dvcReader, 'globalVersion').resolves(
     MIN_CLI_VERSION
@@ -81,7 +81,7 @@ export const buildSetup = (
     })
   )
 
-  const mockConfig = stub(dvcExecutor, 'config').resolves('')
+  const mockConfig = stub(dvcConfig, 'config').resolves('')
 
   const setup = disposer.track(
     new Setup(

--- a/extension/src/test/suite/util.ts
+++ b/extension/src/test/suite/util.ts
@@ -36,6 +36,7 @@ import { SetupData } from '../../setup/webview/contract'
 import { DvcViewer } from '../../cli/dvc/viewer'
 import { Toast } from '../../vscode/toast'
 import { GitExecutor } from '../../cli/git/executor'
+import { DvcConfig } from '../../cli/dvc/config'
 
 export const mockDisposable = {
   dispose: stub()
@@ -140,6 +141,7 @@ export const bypassProcessManagerDebounce = (
 
 export const buildInternalCommands = (disposer: Disposer) => {
   const config = disposer.track(new Config())
+  const dvcConfig = disposer.track(new DvcConfig(config))
   const dvcReader = disposer.track(new DvcReader(config))
   const dvcRunner = disposer.track(new DvcRunner(config))
   const dvcExecutor = disposer.track(new DvcExecutor(config))
@@ -154,6 +156,7 @@ export const buildInternalCommands = (disposer: Disposer) => {
   const internalCommands = disposer.track(
     new InternalCommands(
       outputChannel,
+      dvcConfig,
       dvcExecutor,
       dvcReader,
       dvcRunner,
@@ -165,6 +168,7 @@ export const buildInternalCommands = (disposer: Disposer) => {
 
   return {
     config,
+    dvcConfig,
     dvcExecutor,
     dvcReader,
     dvcRunner,
@@ -197,6 +201,7 @@ export const buildDependencies = (
 ) => {
   const {
     config,
+    dvcConfig,
     dvcExecutor,
     dvcReader,
     dvcRunner,
@@ -231,6 +236,7 @@ export const buildDependencies = (
 
   return {
     config,
+    dvcConfig,
     dvcExecutor,
     dvcReader,
     dvcRunner,


### PR DESCRIPTION
# 2/2 `main` <- #3976 <- this

We need to access `dvc config` & `dvc remote` from `Setup`. There are a couple of issues with this 

1. both of these commands are read/write and don't really fit in with the `DvcExecutor`/`DvcReader` pattern
2. these commands can be run when there is no access to the CLI

Previously the commands were located in `DvcExecutor` and wrapped in `Setup` to avoid them breaking the rest of the app. I've now moved them to their own class (`DvcConfig`) and wrapped access to the CLI in that class (all errors will be caught). 