### PR TITLE
Improve "Get Started" walkthrough and welcome section

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1473,7 +1473,7 @@
       },
       {
         "view": "dvc.views.welcome",
-        "contents": "New to the extension?\n[Show Walkthrough](command:dvc.getStarted)\n\nThe extension is currently unable to initialize.\n[Show Setup](command:dvc.showDvcSetup)",
+        "contents": "The extension is currently unable to initialize.\n[Show Setup](command:dvc.showDvcSetup)",
         "when": "true"
       },
       {

--- a/extension/resources/walkthrough/command-palette.md
+++ b/extension/resources/walkthrough/command-palette.md
@@ -1,8 +1,8 @@
+# Command Palette
+
 > ℹ️ The extension's features cannot be accessed until DVC is installed and a
 > DVC project is available in the workspace. Please refer to the
 > [setup page](command:dvc.dvc.showDvcSetup) if you have not setup DVC yet.
-
-# Command Palette
 
 This extension makes extensive use of the
 [Command Palette](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette).


### PR DESCRIPTION
* don't show walkthrough in sidebar welcome section 
* moves admonition to be below title in command palette walkthrough step

## Demo

<img width="750" alt="image" src="https://github.com/iterative/vscode-dvc/assets/43496356/7f07661e-a1b3-43e7-8aab-7f9c1d15abc1">

<img width="372" alt="image" src="https://github.com/iterative/vscode-dvc/assets/43496356/e6cb4164-f3b0-4fa4-9b36-89430d068f75">


Leftovers that were missed in #3993 