### PR TITLE
Move git call into experiments data

### DIFF
--- a/extension/src/data/index.ts
+++ b/extension/src/data/index.ts
@@ -10,9 +10,10 @@ import { DeferredDisposable } from '../class/deferred'
 import { isSameOrChild } from '../fileSystem'
 
 export type ExperimentsOutput = {
+  availableNbCommits: { [branch: string]: number }
   expShow: ExpShowOutput
-  rowOrder: { branch: string; sha: string }[]
   gitLog: string
+  rowOrder: { branch: string; sha: string }[]
 }
 
 export abstract class BaseData<

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -168,12 +168,23 @@ export class Experiments extends BaseRepository<TableData> {
     return this.data.managedUpdate()
   }
 
-  public async setState({ expShow, gitLog, rowOrder }: ExperimentsOutput) {
+  public async setState({
+    availableNbCommits,
+    expShow,
+    gitLog,
+    rowOrder
+  }: ExperimentsOutput) {
     const hadCheckpoints = this.hasCheckpoints()
     const dvcLiveOnly = await this.checkSignalFile()
     await Promise.all([
       this.columns.transformAndSet(expShow),
-      this.experiments.transformAndSet(expShow, gitLog, dvcLiveOnly, rowOrder)
+      this.experiments.transformAndSet(
+        expShow,
+        gitLog,
+        dvcLiveOnly,
+        rowOrder,
+        availableNbCommits
+      )
     ])
 
     if (hadCheckpoints !== this.hasCheckpoints()) {
@@ -551,12 +562,6 @@ export class Experiments extends BaseRepository<TableData> {
         ),
       () => this.addStage(),
       (branchesSelected: string[]) => this.selectBranches(branchesSelected),
-      (branch: string) =>
-        this.internalCommands.executeCommand<number>(
-          AvailableCommands.GIT_GET_NUM_COMMITS,
-          this.dvcRoot,
-          branch
-        ),
       () => this.data.update()
     )
 

--- a/extension/src/experiments/model/collect.ts
+++ b/extension/src/experiments/model/collect.ts
@@ -186,6 +186,28 @@ const collectExpState = (
   return baseline
 }
 
+export const collectAddRemoveCommitsDetails = (
+  availableNbCommits: {
+    [branch: string]: number
+  },
+  getNbOfCommitsToShow: (branch: string) => number
+): {
+  hasMoreCommits: { [branch: string]: boolean }
+  isShowingMoreCommits: { [branch: string]: boolean }
+} => {
+  const hasMoreCommits: { [branch: string]: boolean } = {}
+  const isShowingMoreCommits: { [branch: string]: boolean } = {}
+
+  for (const [branch, availableCommits] of Object.entries(availableNbCommits)) {
+    const nbOfCommitsToShow = getNbOfCommitsToShow(branch)
+    hasMoreCommits[branch] = availableCommits > nbOfCommitsToShow
+    isShowingMoreCommits[branch] =
+      Math.min(nbOfCommitsToShow, availableCommits) > 1
+  }
+
+  return { hasMoreCommits, isShowingMoreCommits }
+}
+
 const getExecutor = (experiment: Experiment): Executor => {
   if ([experiment.executor, experiment.id].includes(EXPERIMENT_WORKSPACE_ID)) {
     return Executor.WORKSPACE

--- a/extension/src/experiments/model/index.test.ts
+++ b/extension/src/experiments/model/index.test.ts
@@ -33,26 +33,39 @@ beforeEach(() => {
   jest.resetAllMocks()
 })
 
-const DEFAULT_DATA: [string, boolean, { branch: string; sha: string }[]] = [
-  '',
-  false,
-  []
-]
+const DEFAULT_DATA: [
+  string,
+  boolean,
+  { branch: string; sha: string }[],
+  { [branch: string]: number }
+] = ['', false, [], { main: 2000 }]
 
 describe('ExperimentsModel', () => {
   it('should return the expected rows when given the base fixture', () => {
     const model = new ExperimentsModel('', buildMockMemento())
-    model.transformAndSet(outputFixture, gitLogFixture, false, rowOrderFixture)
+    model.transformAndSet(
+      outputFixture,
+      gitLogFixture,
+      false,
+      rowOrderFixture,
+      { main: 6 }
+    )
     expect(model.getRowData()).toStrictEqual(rowsFixture)
   })
 
   it('should return the expected rows when given the survival fixture', () => {
     const model = new ExperimentsModel('', buildMockMemento())
-    model.transformAndSet(survivalOutputFixture, '', false, [
-      { branch: 'main', sha: '3d5adcb974bb2c85917a5d61a489b933adaa2b7f' },
-      { branch: 'main', sha: 'a49e03966a1f9f1299ec222ebc4bed8625d2c54d' },
-      { branch: 'main', sha: '4f7b50c3d171a11b6cfcd04416a16fc80b61018d' }
-    ])
+    model.transformAndSet(
+      survivalOutputFixture,
+      '',
+      false,
+      [
+        { branch: 'main', sha: '3d5adcb974bb2c85917a5d61a489b933adaa2b7f' },
+        { branch: 'main', sha: 'a49e03966a1f9f1299ec222ebc4bed8625d2c54d' },
+        { branch: 'main', sha: '4f7b50c3d171a11b6cfcd04416a16fc80b61018d' }
+      ],
+      { main: 700 }
+    )
     expect(model.getRowData()).toStrictEqual(
       expect.objectContaining(survivalRowsFixture)
     )
@@ -87,7 +100,7 @@ describe('ExperimentsModel', () => {
       }
     )
 
-    model.transformAndSet(dvcLiveOnly, '', true, [])
+    model.transformAndSet(dvcLiveOnly, '', true, [], { main: 2000 })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const runningWorkspace = (model as any).workspace
     expect(runningWorkspace?.executor).toStrictEqual(EXPERIMENT_WORKSPACE_ID)
@@ -178,9 +191,13 @@ describe('ExperimentsModel', () => {
 
   it('should return the expected rows when given the deeply nested output fixture', () => {
     const model = new ExperimentsModel('', buildMockMemento())
-    model.transformAndSet(deeplyNestedOutputFixture, '', false, [
-      { branch: 'main', sha: '53c3851f46955fa3e2b8f6e1c52999acc8c9ea77' }
-    ])
+    model.transformAndSet(
+      deeplyNestedOutputFixture,
+      '',
+      false,
+      [{ branch: 'main', sha: '53c3851f46955fa3e2b8f6e1c52999acc8c9ea77' }],
+      { main: 10 }
+    )
     expect(model.getRowData()).toStrictEqual(
       expect.objectContaining(deeplyNestedRowsFixture)
     )
@@ -188,9 +205,13 @@ describe('ExperimentsModel', () => {
 
   it('should return the expected rows when given the data types output fixture', () => {
     const model = new ExperimentsModel('', buildMockMemento())
-    model.transformAndSet(dataTypesOutputFixture, '', false, [
-      { branch: 'main', sha: '53c3851f46955fa3e2b8f6e1c52999acc8c9ea77' }
-    ])
+    model.transformAndSet(
+      dataTypesOutputFixture,
+      '',
+      false,
+      [{ branch: 'main', sha: '53c3851f46955fa3e2b8f6e1c52999acc8c9ea77' }],
+      { main: 10 }
+    )
     expect(model.getRowData()).toStrictEqual(
       expect.objectContaining(dataTypesRowsFixture)
     )

--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -2,6 +2,7 @@ import { Memento } from 'vscode'
 import { SortDefinition, sortExperiments } from './sortBy'
 import { FilterDefinition, filterExperiment, getFilterId } from './filterBy'
 import {
+  collectAddRemoveCommitsDetails,
   collectExperiments,
   collectOrderedCommitsAndExperiments,
   collectRunningInQueue,
@@ -128,17 +129,13 @@ export class ExperimentsModel extends ModelWithPersistence {
       hasCheckpoints
     } = collectExperiments(expShow, gitLog, dvcLiveOnly)
 
-    this.hasMoreCommits = {}
-    this.isShowingMoreCommits = {}
+    const { hasMoreCommits, isShowingMoreCommits } =
+      collectAddRemoveCommitsDetails(availableNbCommits, (branch: string) =>
+        this.getNbOfCommitsToShow(branch)
+      )
 
-    for (const [branch, availableCommits] of Object.entries(
-      availableNbCommits
-    )) {
-      const nbOfCommitsToShow = this.getNbOfCommitsToShow(branch)
-      this.hasMoreCommits[branch] = availableCommits > nbOfCommitsToShow
-      this.isShowingMoreCommits[branch] =
-        Math.min(nbOfCommitsToShow, availableCommits) > 1
-    }
+    this.hasMoreCommits = hasMoreCommits
+    this.isShowingMoreCommits = isShowingMoreCommits
 
     commits.sort((a, b) => (b.Created || '').localeCompare(a.Created || ''))
 

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -249,8 +249,8 @@ suite('Experiments Test Suite', () => {
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should set hasMoreCommits to true if there are more commits to show', async () => {
-      stub(GitReader.prototype, 'getNumCommits').resolves(100)
       const { experiments, messageSpy } = buildExperiments({
+        availableNbCommits: { main: 404 },
         disposer: disposable
       })
 
@@ -262,8 +262,8 @@ suite('Experiments Test Suite', () => {
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should set hasMoreCommits to false if there are more commits to show', async () => {
-      stub(GitReader.prototype, 'getNumCommits').resolves(1)
       const { experiments, messageSpy } = buildExperiments({
+        availableNbCommits: { main: 1 },
         disposer: disposable
       })
 
@@ -275,8 +275,8 @@ suite('Experiments Test Suite', () => {
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should set isShowingMoreCommits to true if it is showing more than the current commit', async () => {
-      stub(GitReader.prototype, 'getNumCommits').resolves(100)
       const { experiments, messageSpy } = buildExperiments({
+        availableNbCommits: { main: 40000 },
         disposer: disposable
       })
 
@@ -289,8 +289,8 @@ suite('Experiments Test Suite', () => {
 
     it('should set isShowingMoreCommits to false it is showing only the current commit', async () => {
       stub(GitReader.prototype, 'getCurrentBranch').resolves('current')
-      stub(GitReader.prototype, 'getNumCommits').resolves(1)
       const { experiments, messageSpy } = buildExperiments({
+        availableNbCommits: { main: 1 },
         disposer: disposable
       })
 
@@ -1498,6 +1498,7 @@ suite('Experiments Test Suite', () => {
       )
 
       void experiments.setState({
+        availableNbCommits: { main: 20 },
         gitLog: '',
         expShow: data,
         rowOrder: [
@@ -1975,6 +1976,7 @@ suite('Experiments Test Suite', () => {
       )
 
       void experiments.setState({
+        availableNbCommits: { main: 20 },
         gitLog: '',
         expShow: defaultExperimentsData,
         rowOrder: []

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -85,7 +85,6 @@ import * as ProcessExecution from '../../../process/execution'
 import { DvcReader } from '../../../cli/dvc/reader'
 import { DvcViewer } from '../../../cli/dvc/viewer'
 import { DEFAULT_NB_ITEMS_PER_ROW } from '../../../plots/webview/contract'
-import { GitReader } from '../../../cli/git/reader'
 import { Toast } from '../../../vscode/toast'
 import { Response } from '../../../vscode/response'
 
@@ -288,11 +287,12 @@ suite('Experiments Test Suite', () => {
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should set isShowingMoreCommits to false it is showing only the current commit', async () => {
-      stub(GitReader.prototype, 'getCurrentBranch').resolves('current')
-      const { experiments, messageSpy } = buildExperiments({
-        availableNbCommits: { main: 1 },
+      const { experiments, experimentsModel, messageSpy } = buildExperiments({
+        expShow: expShowFixture.slice(0, 2),
         disposer: disposable
       })
+
+      stub(experimentsModel, 'getNbOfCommitsToShow').returns(1)
 
       await experiments.showWebview()
 

--- a/extension/src/test/suite/experiments/util.ts
+++ b/extension/src/test/suite/experiments/util.ts
@@ -21,18 +21,21 @@ import { PersistenceKey } from '../../../persistence/constants'
 import { ExpShowOutput } from '../../../cli/dvc/contract'
 
 export const DEFAULT_EXPERIMENTS_OUTPUT = {
+  availableNbCommits: { main: 5 },
   expShow: expShowFixture,
   gitLog: gitLogFixture,
   rowOrder: rowOrderFixture
 }
 
 export const buildExperiments = ({
+  availableNbCommits = { main: 5 },
   disposer,
   dvcRoot = dvcDemoPath,
   expShow = expShowFixture,
   gitLog = gitLogFixture,
   rowOrder = rowOrderFixture
 }: {
+  availableNbCommits?: { [branch: string]: number }
   disposer: Disposer
   dvcRoot?: string
   expShow?: ExpShowOutput
@@ -79,6 +82,7 @@ export const buildExperiments = ({
   )
 
   void experiments.setState({
+    availableNbCommits,
     expShow,
     gitLog,
     rowOrder
@@ -192,6 +196,7 @@ export const buildExperimentsData = (
   stub(gitReader, 'getBranches').resolves(['one'])
   stub(gitReader, 'getCurrentBranch').resolves(currentBranch)
   stub(gitReader, 'getCommitMessages').resolves(commitOutput)
+  stub(gitReader, 'getNumCommits').resolves(404)
 
   const mockGetBranchesToShow = stub().returns(['main'])
   const mockPruneBranchesToShow = stub()

--- a/extension/src/test/suite/plots/index.test.ts
+++ b/extension/src/test/suite/plots/index.test.ts
@@ -138,6 +138,7 @@ suite('Plots Test Suite', () => {
 
       bypassProcessManagerDebounce(mockNow)
       void experiments.setState({
+        availableNbCommits: { main: 6 },
         expShow: updatedExpShowFixture,
         gitLog: newCommit + COMMITS_SEPARATOR + gitLogFixture,
         rowOrder: [{ branch: 'main', sha: newCommit }, ...rowOrderFixture]

--- a/extension/src/test/suite/plots/util.ts
+++ b/extension/src/test/suite/plots/util.ts
@@ -28,12 +28,14 @@ import { ErrorsModel } from '../../../plots/errors/model'
 import { PersistenceKey } from '../../../persistence/constants'
 
 export const buildPlots = async ({
+  availableNbCommits = { main: 5 },
   disposer,
   plotsDiff = undefined,
   expShow = expShowFixtureWithoutErrors,
   gitLog = gitLogFixture,
   rowOrder = rowOrderFixture
 }: {
+  availableNbCommits?: { [branch: string]: number }
   disposer: Disposer
   plotsDiff?: PlotsOutput | undefined
   expShow?: ExpShowOutput
@@ -86,6 +88,7 @@ export const buildPlots = async ({
   ] as Experiment[])
 
   void experiments.setState({
+    availableNbCommits,
     expShow,
     gitLog,
     rowOrder


### PR DESCRIPTION
# 2/2 `main` <- #3980 <- this

This is a follow-up from #3980 ([this comment](https://github.com/iterative/vscode-dvc/pull/3980/files#r1214163024)).

The main motivation behind doing this is to make it easier to follow data being updated in a linear fashion from the watcher, through the model and into the webview.