### PR TITLE
Add default value for branch name when creating from experiment

### DIFF
--- a/extension/src/experiments/commands/register.ts
+++ b/extension/src/experiments/commands/register.ts
@@ -129,11 +129,7 @@ const registerExperimentInputCommands = (
 ): void => {
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.EXPERIMENT_BRANCH,
-    () =>
-      experiments.getCwdExpNameAndInputThenRun(
-        getBranchExperimentCommand(experiments),
-        Title.ENTER_BRANCH_NAME
-      )
+    () => experiments.createExperimentBranch()
   )
 
   internalCommands.registerExternalCliCommand(
@@ -142,6 +138,7 @@ const registerExperimentInputCommands = (
       experiments.getInputAndRun(
         getBranchExperimentCommand(experiments),
         Title.ENTER_BRANCH_NAME,
+        `${id}-branch`,
         dvcRoot,
         id
       )

--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -1,7 +1,10 @@
 import { EventEmitter, Memento } from 'vscode'
 import isEmpty from 'lodash.isempty'
 import { Experiments, ModifiedExperimentAndRunCommandId } from '.'
-import { getPushExperimentCommand } from './commands'
+import {
+  getBranchExperimentCommand,
+  getPushExperimentCommand
+} from './commands'
 import { TableData } from './webview/contract'
 import { Args } from '../cli/dvc/constants'
 import {
@@ -248,10 +251,7 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
     }
   }
 
-  public async getCwdExpNameAndInputThenRun(
-    runCommand: (cwd: string, ...args: Args) => Promise<void>,
-    title: Title
-  ) {
+  public async createExperimentBranch() {
     const cwd = await this.shouldRun()
     if (!cwd) {
       return
@@ -262,15 +262,22 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
     if (!experimentId) {
       return
     }
-    return this.getInputAndRun(runCommand, title, cwd, experimentId)
+    return this.getInputAndRun(
+      getBranchExperimentCommand(this),
+      Title.ENTER_BRANCH_NAME,
+      `${experimentId}-branch`,
+      cwd,
+      experimentId
+    )
   }
 
   public async getInputAndRun(
     runCommand: (...args: Args) => Promise<void> | void,
     title: Title,
+    defaultValue: string,
     ...args: Args
   ) {
-    const input = await getInput(title)
+    const input = await getInput(title, defaultValue)
     if (!input) {
       return
     }


### PR DESCRIPTION
Closes #4026.

> By default, dvc exp branch now generates a name like couth-bean-branch for an exp named couth-bean. Could we auto-fill a default name for the branch that matches that naming scheme?

### Demo

https://github.com/iterative/vscode-dvc/assets/37993418/5ea3ca35-bddb-474d-b979-aa9d136636d1

