### PR TITLE
Move "new to DVC" text from setup to welcome view

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1473,7 +1473,7 @@
       },
       {
         "view": "dvc.views.welcome",
-        "contents": "The extension is currently unable to initialize.\n[Show Setup](command:dvc.showDvcSetup)",
+        "contents": "The extension is currently unable to initialize.\n[Show Setup](command:dvc.showDvcSetup)\nNew to DVC? Check out [dvc.org](https://dvc.org/) to learn more or quickly try the extension with our [demo](https://github.com/iterative/vscode-dvc-demo).",
         "when": "true"
       },
       {

--- a/extension/package.json
+++ b/extension/package.json
@@ -1473,7 +1473,7 @@
       },
       {
         "view": "dvc.views.welcome",
-        "contents": "The extension is currently unable to initialize.\n[Show Setup](command:dvc.showDvcSetup)\nNew to DVC? Check out [dvc.org](https://dvc.org/) to learn more or quickly try the extension with our [demo](https://github.com/iterative/vscode-dvc-demo).",
+        "contents": "The extension is currently unable to initialize.\n[Show Setup](command:dvc.showDvcSetup)\nNew to the extension? Watch a [demo of the extension](https://youtu.be/E26IaD7bNXg?t=1177) in action or quickly try the extension yourself with our [example project](https://github.com/iterative/example-dvc-experiments.git). Dive deeper into DVC at [dvc.org](https://dvc.org/).",
         "when": "true"
       },
       {

--- a/webview/src/setup/components/dvc/CliUnavailable.tsx
+++ b/webview/src/setup/components/dvc/CliUnavailable.tsx
@@ -14,8 +14,8 @@ export const CliUnavailable: React.FC<PropsWithChildren> = ({ children }) => {
   const installationSentence = (
     <>
       The extension supports all{' '}
-      <a href="https://dvc.org/doc/install">installation types</a> and can
-      auto-install recommended packages via{' '}
+      <a href="https://dvc.org/doc/install">installation types</a>. It can also
+      help to install needed packages via{' '}
       <a href="https://packaging.python.org/en/latest/key_projects/#pip">pip</a>
       .
     </>

--- a/webview/src/setup/components/dvc/CliUnavailable.tsx
+++ b/webview/src/setup/components/dvc/CliUnavailable.tsx
@@ -46,11 +46,6 @@ export const CliUnavailable: React.FC<PropsWithChildren> = ({ children }) => {
     <EmptyState isFullScreen={false}>
       <h1>DVC is currently unavailable</h1>
       {children}
-      <p>
-        New to DVC? Check out <a href="https://dvc.org/">dvc.org</a> to learn
-        more or quickly try the extension with our{' '}
-        <a href="https://github.com/iterative/vscode-dvc-demo">demo</a>.
-      </p>
       {conditionalContents}
     </EmptyState>
   )

--- a/webview/src/setup/components/dvc/DvcUnitialized.tsx
+++ b/webview/src/setup/components/dvc/DvcUnitialized.tsx
@@ -9,9 +9,7 @@ export const DvcUninitialized: React.FC<PropsWithChildren> = ({ children }) => (
     {children}
     <p>
       The current workspace does not contain a DVC project, which is needed to
-      enable DVC-powered features. Interested in trying a demo project? Check
-      out our{' '}
-      <a href="https://github.com/iterative/vscode-dvc-demo">extension demo</a>.
+      enable DVC-powered features.
     </p>
     <Button onClick={initializeDvc} text="Initialize Project"></Button>
   </EmptyState>


### PR DESCRIPTION
Simplifies setup "DVC is Incompatible" and "DVC is unavailable" text content by moving welcome-related text to the welcome view. This also would help with the setup "welcome" text possibly be misleading.

## `main`

<img width="408" alt="image" src="https://github.com/iterative/vscode-dvc/assets/43496356/427863e4-5793-4c53-a80b-fe94aceeca2c">

<img width="806" alt="image" src="https://github.com/iterative/vscode-dvc/assets/43496356/9340e784-4d9c-4215-b20f-ff14c430578d">

<img width="813" alt="image" src="https://github.com/iterative/vscode-dvc/assets/43496356/4d503c32-9400-4d9e-97e0-eea2ea58fbaa">


## PR

~https://github.com/iterative/vscode-dvc/assets/43496356/9b75d2fd-84f8-4140-aa56-66058ddccd8d~

~https://github.com/iterative/vscode-dvc/assets/43496356/a96da2f4-c1ea-431d-91b6-84f824d3671e~

<img width="437" alt="image" src="https://github.com/iterative/vscode-dvc/assets/43496356/92a5855c-6d3d-434c-bd35-2cbfa510f2de">

<img width="781" alt="image" src="https://github.com/iterative/vscode-dvc/assets/43496356/f0dcdfb9-eef9-48ab-b20d-1006776fbcc0">

<img width="777" alt="image" src="https://github.com/iterative/vscode-dvc/assets/43496356/bb9fc365-f13d-48e3-9899-81067c297f86">

Resolves https://github.com/iterative/vscode-dvc/pull/3993#issuecomment-1569254205