### PR TITLE
Do not drop experiment selection when an experiment is running and exp show errors

### DIFF
--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -145,6 +145,10 @@ export class ExperimentsModel extends ModelWithPersistence {
     this.experimentsByCommit = experimentsByCommit
     this.checkpoints = hasCheckpoints
 
+    const isTransientError = this.hasRunningExperiment() && workspace.error
+    if (isTransientError) {
+      return
+    }
     this.setColoredStatus(runningExperiments)
   }
 


### PR DESCRIPTION
This PR fixes a bug in that if `exp show` errored during an experiment run all experiments were de-selected. 

This meant that multiple experiments could be getting plotted (either live or as baselines) and the plots webview would jump to being empty after the error. Was confusing/unexpected/frustrating behaviour. 