### PR TITLE
Exclude codicons.mjs from eslint

### DIFF
--- a/webview/.eslintrc.js
+++ b/webview/.eslintrc.js
@@ -3,7 +3,7 @@ const config = require('../.eslintrc')
 
 module.exports = {
   ...config,
-  ignorePatterns: [...config.ignorePatterns, 'storybook-static/**'],
+  ignorePatterns: [...config.ignorePatterns, 'storybook-static/**', '**/*.mjs'],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     tsconfigRootDir: __dirname,


### PR DESCRIPTION
Suppresses this error:

<img width="924" alt="image" src="https://github.com/iterative/vscode-dvc/assets/37993418/58232bda-5f2f-4b71-afd5-1b0eece4a298">
