### PR TITLE
Add PYTHONPATH to environment variables if the Python extension makes it available

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,6 +38,7 @@
     "MNIST",
     "nfiles",
     "pseudoterminal",
+    "PYTHONPATH",
     "rwlock",
     "sonarjs",
     "spyable",

--- a/README.md
+++ b/README.md
@@ -160,6 +160,13 @@ These are the VS Code [settings] available for the Extension:
 > **Note** that the `Setup The Workspace` command helps you set up the basic
 > ones at the [Workspace level] (saved to `.vscode/setting.json`).
 
+### Python
+
+This extension is integrated with Microsoft's [Python extension]. When possible,
+the Python extension's selected interpreter will be used to locate DVC. The
+`PYTHONPATH` environment variable identified via the [python.envFile] config
+setting is also respected.
+
 [python extension]:
   https://marketplace.visualstudio.com/items?itemName=ms-python.python
 [studio.token]:
@@ -167,6 +174,8 @@ These are the VS Code [settings] available for the Extension:
 [Studio]: https://studio.iterative.ai
 [workspace level]:
   https://code.visualstudio.com/docs/getstarted/settings#_workspace-settings
+[python.envFile]:
+  https://code.visualstudio.com/docs/python/environments#_use-of-the-pythonpath-variable
 
 ## Debugging
 

--- a/extension/src/cli/dvc/config.test.ts
+++ b/extension/src/cli/dvc/config.test.ts
@@ -42,6 +42,7 @@ describe('DvcConfig', () => {
   const dvcConfig = new DvcConfig(
     {
       getCliPath: () => undefined,
+      getPYTHONPATH: () => undefined,
       getPythonBinPath: () => undefined
     } as unknown as Config,
     {

--- a/extension/src/cli/dvc/executor.test.ts
+++ b/extension/src/cli/dvc/executor.test.ts
@@ -48,6 +48,7 @@ describe('CliExecutor', () => {
   const dvcExecutor = new DvcExecutor(
     {
       getCliPath: () => undefined,
+      getPYTHONPATH: () => undefined,
       getPythonBinPath: () => undefined
     } as unknown as Config,
     {

--- a/extension/src/cli/dvc/index.test.ts
+++ b/extension/src/cli/dvc/index.test.ts
@@ -66,6 +66,7 @@ describe('executeDvcProcess', () => {
     const cli = new DvcCli(
       {
         getCliPath: () => undefined,
+        getPYTHONPATH: () => undefined,
         getPythonBinPath: () => undefined
       } as unknown as Config,
       {
@@ -111,6 +112,7 @@ describe('executeDvcProcess', () => {
     const cli = new DvcCli(
       {
         getCliPath: () => '/some/path/to/dvc',
+        getPYTHONPATH: () => undefined,
         getPythonBinPath: () => pythonBinPath
       } as unknown as Config,
       {

--- a/extension/src/cli/dvc/index.ts
+++ b/extension/src/cli/dvc/index.ts
@@ -35,11 +35,12 @@ export class DvcCli extends Cli {
   }
 
   protected getOptions(cwd: string, ...args: Args) {
-    return getOptions(
-      this.extensionConfig.getPythonBinPath(),
-      this.extensionConfig.getCliPath(),
+    return getOptions({
+      PYTHONPATH: this.extensionConfig.getPYTHONPATH(),
+      args: [...args],
+      cliPath: this.extensionConfig.getCliPath(),
       cwd,
-      ...args
-    )
+      pythonBinPath: this.extensionConfig.getPythonBinPath()
+    })
   }
 }

--- a/extension/src/cli/dvc/options.test.ts
+++ b/extension/src/cli/dvc/options.test.ts
@@ -25,7 +25,13 @@ describe('getOptions', () => {
   const cwd = join('path', 'to', 'work', 'dir')
 
   it('should give the correct options given a basic environment', () => {
-    const options = getOptions(undefined, '', cwd, Command.CHECKOUT, Flag.FORCE)
+    const options = getOptions({
+      PYTHONPATH: undefined,
+      args: [Command.CHECKOUT, Flag.FORCE],
+      cliPath: '',
+      cwd,
+      pythonBinPath: undefined
+    })
     expect(options).toStrictEqual({
       args: ['checkout', '-f'],
       cwd,
@@ -36,7 +42,13 @@ describe('getOptions', () => {
 
   it('should append -m dvc to the args and use the python as the executable if only an isolated python env is in use', () => {
     const pythonBinPath = join('path', 'to', 'python', '.venv', 'python')
-    const options = getOptions(pythonBinPath, '', cwd, Command.PULL)
+    const options = getOptions({
+      PYTHONPATH: undefined,
+      args: [Command.PULL],
+      cliPath: '',
+      cwd,
+      pythonBinPath
+    })
     expect(options).toStrictEqual({
       args: ['-m', 'dvc', 'pull'],
       cwd,
@@ -53,7 +65,13 @@ describe('getOptions', () => {
   it('should append to the PATH but only use the path to the cli if both an isolated python env and path to dvc are in use', () => {
     const pythonBinPath = join('path', 'to', 'python', '.venv', 'python')
     const cliPath = join('custom', 'path', 'to', 'dvc')
-    const options = getOptions(pythonBinPath, cliPath, cwd, Command.PULL)
+    const options = getOptions({
+      PYTHONPATH: undefined,
+      args: [Command.PULL],
+      cliPath,
+      cwd,
+      pythonBinPath
+    })
     expect(options).toStrictEqual({
       args: ['pull'],
       cwd,
@@ -64,6 +82,32 @@ describe('getOptions', () => {
         PATH: joinEnvPath(join('path', 'to', 'python', '.venv'), mockedPATH)
       },
       executable: cliPath
+    })
+  })
+
+  it('should add PYTHONPATH to the environment variables if it is provided', () => {
+    const PYTHONPATH = join('path', 'to', 'project')
+    const venvPath = join(PYTHONPATH, '.venv')
+    const pythonBinPath = join(venvPath, 'python')
+    const cliPath = ''
+    const options = getOptions({
+      PYTHONPATH,
+      args: [Command.PULL],
+      cliPath,
+      cwd,
+      pythonBinPath
+    })
+    expect(options).toStrictEqual({
+      args: ['-m', 'dvc', 'pull'],
+      cwd,
+      env: {
+        DVCLIVE_OPEN: 'false',
+        DVC_NO_ANALYTICS: 'true',
+        GIT_TERMINAL_PROMPT: '0',
+        PATH: joinEnvPath(venvPath, mockedPATH),
+        PYTHONPATH
+      },
+      executable: pythonBinPath
     })
   })
 })

--- a/extension/src/cli/dvc/reader.ts
+++ b/extension/src/cli/dvc/reader.ts
@@ -124,12 +124,13 @@ export class DvcReader extends DvcCli {
   }
 
   public globalVersion(cwd: string): Promise<string> {
-    const options = getOptions(
-      undefined,
-      this.extensionConfig.getCliPath(),
+    const options = getOptions({
+      PYTHONPATH: undefined,
+      args: [Flag.VERSION],
+      cliPath: this.extensionConfig.getCliPath(),
       cwd,
-      Flag.VERSION
-    )
+      pythonBinPath: undefined
+    })
 
     return this.executeProcess(options)
   }

--- a/extension/src/cli/dvc/runner.ts
+++ b/extension/src/cli/dvc/runner.ts
@@ -141,12 +141,13 @@ export class DvcRunner extends Disposable implements ICli {
   }
 
   private createProcess({ cwd, args }: { cwd: string; args: Args }): Process {
-    const options = getOptions(
-      this.config.getPythonBinPath(),
-      this.config.getCliPath(),
+    const options = getOptions({
+      PYTHONPATH: this.config.getPYTHONPATH(),
+      args: [...args],
+      cliPath: this.config.getCliPath(),
       cwd,
-      ...args
-    )
+      pythonBinPath: this.config.getPythonBinPath()
+    })
     const command = getCommandString(options)
     const stopWatch = new StopWatch()
     const process = this.dispose.track(createProcess(options))

--- a/extension/src/cli/dvc/viewer.ts
+++ b/extension/src/cli/dvc/viewer.ts
@@ -77,22 +77,21 @@ export class DvcViewer extends Disposable implements ICli {
   }
 
   private viewProcess(name: string, cwd: string, args: Args) {
+    const options = getOptions({
+      PYTHONPATH: this.config.getPYTHONPATH(),
+      args: [...args],
+      cliPath: this.config.getCliPath(),
+      cwd,
+      pythonBinPath: this.config.getPythonBinPath()
+    })
+
     return this.dispose.track(
       new ViewableCliProcess(
         `DVC: ${name}`,
-        this.getOptions(cwd, args),
+        options,
         this.processStarted,
         this.processCompleted
       )
-    )
-  }
-
-  private getOptions(cwd: string, args: Args) {
-    return getOptions(
-      this.config.getPythonBinPath(),
-      this.config.getCliPath(),
-      cwd,
-      ...args
     )
   }
 

--- a/extension/src/extensions/python.ts
+++ b/extension/src/extensions/python.ts
@@ -11,12 +11,21 @@ interface Settings {
   }
 }
 
+type EnvironmentVariables = { readonly [key: string]: string | undefined }
+type EnvironmentVariablesChangeEvent = {
+  readonly env: EnvironmentVariables
+}
+
 export interface VscodePython {
   ready: Thenable<void>
   settings: Settings
+  environments: {
+    onDidEnvironmentVariablesChange: Event<EnvironmentVariablesChangeEvent>
+    getEnvironmentVariables(): EnvironmentVariables
+  }
 }
 
-const getPythonExtensionSettings = async (): Promise<Settings | undefined> => {
+const getPythonExtensionAPI = async (): Promise<VscodePython | undefined> => {
   const api = await getExtensionAPI<VscodePython>(PYTHON_EXTENSION_ID)
   if (!api) {
     return
@@ -24,14 +33,14 @@ const getPythonExtensionSettings = async (): Promise<Settings | undefined> => {
   try {
     await api.ready
   } catch {}
-  return api.settings
+  return api
 }
 
 export const getPythonExecutionDetails = async (): Promise<
   string[] | undefined
 > => {
-  const settings = await getPythonExtensionSettings()
-  return settings?.getExecutionDetails().execCommand
+  const api = await getPythonExtensionAPI()
+  return api?.settings?.getExecutionDetails().execCommand
 }
 
 export const getPythonBinPath = async (): Promise<string | undefined> => {
@@ -42,9 +51,19 @@ export const getPythonBinPath = async (): Promise<string | undefined> => {
   }
 }
 
+export const getPYTHONPATH = async (): Promise<string | undefined> => {
+  const api = await getPythonExtensionAPI()
+  return api?.environments?.getEnvironmentVariables().PYTHONPATH
+}
+
 export const getOnDidChangePythonExecutionDetails = async () => {
-  const settings = await getPythonExtensionSettings()
-  return settings?.onDidChangeExecutionDetails
+  const api = await getPythonExtensionAPI()
+  return api?.settings?.onDidChangeExecutionDetails
+}
+
+export const getOnDidChangePythonEnvironmentVariables = async () => {
+  const api = await getPythonExtensionAPI()
+  return api?.environments?.onDidEnvironmentVariablesChange
 }
 
 export const isPythonExtensionInstalled = () => isInstalled(PYTHON_EXTENSION_ID)

--- a/extension/src/setup/index.ts
+++ b/extension/src/setup/index.ts
@@ -341,7 +341,12 @@ export class Setup
     const pythonBinPath = this.config.getPythonBinPath()
     const cwd = getFirstWorkspaceFolder()
 
-    const { args, executable } = getOptions(pythonBinPath, dvcPath, cwd || '')
+    const { args, executable } = getOptions({
+      PYTHONPATH: this.config.getPYTHONPATH(),
+      cliPath: dvcPath,
+      cwd: cwd || '',
+      pythonBinPath
+    })
     const commandArgs = args.length === 0 ? '' : ` ${args.join(' ')}`
     const command = executable + commandArgs
 

--- a/extension/src/test/suite/cli/dvc/runner.test.ts
+++ b/extension/src/test/suite/cli/dvc/runner.test.ts
@@ -24,6 +24,7 @@ suite('DVC Runner Test Suite', () => {
     it('should only be able to run a single command at a time', async () => {
       const mockConfig = {
         getCliPath: () => 'sleep',
+        getPYTHONPATH: () => undefined,
         getPythonBinPath: () => undefined
       } as Config
 
@@ -41,6 +42,7 @@ suite('DVC Runner Test Suite', () => {
     it('should be able to stop a started command', async () => {
       const mockConfig = {
         getCliPath: () => 'sleep',
+        getPYTHONPATH: () => undefined,
         getPythonBinPath: () => undefined
       } as Config
 
@@ -106,6 +108,7 @@ suite('DVC Runner Test Suite', () => {
 
       const mockConfig = {
         getCliPath: () => 'echo',
+        getPYTHONPATH: () => undefined,
         getPythonBinPath: () => undefined
       } as Config
 

--- a/extension/src/test/suite/cli/dvc/viewer.test.ts
+++ b/extension/src/test/suite/cli/dvc/viewer.test.ts
@@ -22,6 +22,7 @@ suite('DVC Viewer Test Suite', () => {
     it('should only be able to run a command once', async () => {
       const mockConfig = {
         getCliPath: () => 'sleep',
+        getPYTHONPATH: () => undefined,
         getPythonBinPath: () => undefined
       } as Config
       const dvcViewer = disposable.track(new DvcViewer(mockConfig))

--- a/extension/src/test/suite/config.test.ts
+++ b/extension/src/test/suite/config.test.ts
@@ -32,7 +32,7 @@ suite('Config Test Suite', () => {
       const extensionsChanged = disposable.track(new EventEmitter<void>())
 
       const config = disposable.track(new Config(extensionsChanged.event))
-      expect(mockGetExtensionAPI).to.be.calledTwice
+      expect(mockGetExtensionAPI).to.be.called
       expect(config.getPythonBinPath()).to.be.undefined
 
       const pythonBinPath = join('some', 'magic', 'python', 'path')

--- a/extension/src/test/suite/status.test.ts
+++ b/extension/src/test/suite/status.test.ts
@@ -62,6 +62,7 @@ suite('Status Test Suite', () => {
         new Status(
           {
             getCliPath: () => undefined,
+            getPYTHONPATH: () => undefined,
             getPythonBinPath: () => undefined,
             isPythonExtensionUsed: () => false,
             isReady: () => Promise.resolve()
@@ -149,6 +150,7 @@ suite('Status Test Suite', () => {
         new Status(
           {
             getCliPath: () => undefined,
+            getPYTHONPATH: () => undefined,
             getPythonBinPath: () => undefined,
             isPythonExtensionUsed: () => false,
             isReady: () => Promise.resolve()
@@ -199,6 +201,7 @@ suite('Status Test Suite', () => {
       const status = disposable.track(
         new Status({
           getCliPath: mockGetCliPath,
+          getPYTHONPATH: () => undefined,
           getPythonBinPath: mockGetPythonBinPath,
           isPythonExtensionUsed: mockedIsPythonExtensionUsed,
           isReady: () => Promise.resolve()


### PR DESCRIPTION
Closes #1791

This PR uses the `ms-python.python` extension's new API to grab their `PYTHONPATH` variable and add it to the environment variables used to create DVC processes. In order for users to set this up they need to add a file containing `PYTHONPATH=`. This can be a `.env` file at the root of the workspace (default for the extension) or they need to set the `python.envFile` configuration option.

### Demo (fixes issue in [magnetic-tiles-defect](https://github.com/iterative/magnetic-tiles-defect))

https://github.com/iterative/vscode-dvc/assets/37993418/c4166c36-5a41-4d73-bc63-3acefc89965c

