### PR TITLE
Have setup run different install commands depending on python environment

### DIFF
--- a/extension/src/setup/index.ts
+++ b/extension/src/setup/index.ts
@@ -345,6 +345,9 @@ export class Setup
     const commandArgs = args.length === 0 ? '' : ` ${args.join(' ')}`
     const command = executable + commandArgs
 
+    // add a type here
+    // will tell the frontend if they need default pip mentions
+    // or just "Install"
     return {
       command,
       version: this.cliVersion

--- a/webview/src/setup/components/dvc/CliUnavailable.tsx
+++ b/webview/src/setup/components/dvc/CliUnavailable.tsx
@@ -15,12 +15,10 @@ export const CliUnavailable: React.FC<PropsWithChildren> = ({ children }) => {
     <>
       The extension supports all{' '}
       <a href="https://dvc.org/doc/install">installation types</a> and can
-      auto-install recommended packages via{' '}
-      <a href="https://packaging.python.org/en/latest/key_projects/#pip">pip</a>
-      .
+      auto-install recommended packages.
     </>
   )
-
+  // the pip mentions will need to be conditional in the case of unknown environments
   const conditionalContents = canInstall ? (
     <>
       <p>
@@ -28,7 +26,7 @@ export const CliUnavailable: React.FC<PropsWithChildren> = ({ children }) => {
         {pythonBinPath}.
       </p>
       <div className={styles.sideBySideButtons}>
-        <Button onClick={installDvc} text="Install (pip)" />
+        <Button onClick={installDvc} text="Install" />
         <Button onClick={setupWorkspace} text="Configure" />
       </div>
     </>


### PR DESCRIPTION
* has setup run a different install command depending on the data given to us by the Python Extension API and defaults to `pip` if environment type is unknown

## Demo

Note: Cut the installation progress to make the demo shorter

https://github.com/iterative/vscode-dvc/assets/43496356/e35e9960-9563-432d-948b-053de77faffe

Part of #3935 