### PR TITLE
Add Python Extension's "Create Env" command into DVC Setup

### DIFF
--- a/extension/src/extensions/python.ts
+++ b/extension/src/extensions/python.ts
@@ -49,6 +49,10 @@ export const getOnDidChangePythonExecutionDetails = async () => {
 
 export const isPythonExtensionInstalled = () => isInstalled(PYTHON_EXTENSION_ID)
 
+export const createPythonEnv = () => {
+  void commands.executeCommand('python.createEnvironment')
+}
+
 export const selectPythonInterpreter = () => {
   void commands.executeCommand('python.setInterpreter')
 }

--- a/extension/src/setup/quickPick.ts
+++ b/extension/src/setup/quickPick.ts
@@ -1,5 +1,6 @@
+import { createPythonEnv, selectPythonInterpreter } from '../extensions/python'
 import { sortCollectedArray } from '../util/array'
-import { quickPickManyValues } from '../vscode/quickPick'
+import { quickPickManyValues, quickPickValue } from '../vscode/quickPick'
 import { Title } from '../vscode/title'
 import { Toast } from '../vscode/toast'
 
@@ -25,4 +26,25 @@ export const pickFocusedProjects = async (
   }
 
   return sortCollectedArray(values)
+}
+
+export const pickPythonExtensionAction = async (): Promise<unknown> => {
+  const options = [
+    {
+      description: 'Create an environment',
+      label: 'Create',
+      value: 0
+    },
+    {
+      description: 'Choose from already created environments',
+      label: 'Select',
+      value: 1
+    }
+  ]
+  const value = await quickPickValue<number>(options, {
+    placeHolder: 'Select or Create a Python Environment',
+    title: Title.UPDATE_PYTHON_ENVIRONMENT
+  })
+
+  return value === 0 ? createPythonEnv() : selectPythonInterpreter()
 }

--- a/extension/src/setup/webview/messages.ts
+++ b/extension/src/setup/webview/messages.ts
@@ -8,13 +8,13 @@ import {
 import { BaseWebview } from '../../webview'
 import { sendTelemetryEvent } from '../../telemetry'
 import { EventName } from '../../telemetry/constants'
-import { selectPythonInterpreter } from '../../extensions/python'
 import { autoInstallDvc, autoUpgradeDvc } from '../autoInstall'
 import {
   RegisteredCliCommands,
   RegisteredCommands
 } from '../../commands/external'
 import { openUrl } from '../../vscode/external'
+import { pickPythonExtensionAction } from '../quickPick'
 
 export class WebviewMessages {
   private readonly getWebview: () => BaseWebview<TSetupData> | undefined
@@ -79,8 +79,8 @@ export class WebviewMessages {
         return commands.executeCommand(RegisteredCommands.EXTENSION_GET_STARTED)
       case MessageFromWebviewType.SHOW_SCM_PANEL:
         return this.showScmForCommit()
-      case MessageFromWebviewType.SELECT_PYTHON_INTERPRETER:
-        return this.selectPythonInterpreter()
+      case MessageFromWebviewType.UPDATE_PYTHON_ENVIRONMENT:
+        return this.updatePythonEnvironment()
       case MessageFromWebviewType.INSTALL_DVC:
         return this.installDvc()
       case MessageFromWebviewType.UPGRADE_DVC:
@@ -131,13 +131,13 @@ export class WebviewMessages {
     return commands.executeCommand('workbench.view.scm')
   }
 
-  private selectPythonInterpreter() {
+  private updatePythonEnvironment() {
     sendTelemetryEvent(
-      EventName.VIEWS_SETUP_SELECT_PYTHON_INTERPRETER,
+      EventName.VIEWS_SETUP_UPDATE_PYTHON_ENVIRONMENT,
       undefined,
       undefined
     )
-    return selectPythonInterpreter()
+    return pickPythonExtensionAction()
   }
 
   private upgradeDvc() {

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -85,9 +85,9 @@ export const EventName = Object.assign(
     VIEWS_SETUP_FOCUS_CHANGED: 'views.setup.focusChanged',
     VIEWS_SETUP_INIT_GIT: 'views.setup.initializeGit',
     VIEWS_SETUP_INSTALL_DVC: 'views.setup.installDvc',
-    VIEWS_SETUP_SELECT_PYTHON_INTERPRETER:
-      'views.setup.selectPythonInterpreter',
     VIEWS_SETUP_SHOW_SCM_FOR_COMMIT: 'views.setup.showScmForCommit',
+    VIEWS_SETUP_UPDATE_PYTHON_ENVIRONMENT:
+      'views.setup.updatePythonEnvironment',
     VIEWS_SETUP_UPGRADE_DVC: 'view.setup.upgradeDvc',
 
     VIEWS_TERMINAL_CLOSED: 'views.terminal.closed',
@@ -277,7 +277,7 @@ export interface IEventNamePropertyMapping {
   [EventName.VIEWS_SETUP_CLOSE]: undefined
   [EventName.VIEWS_SETUP_CREATED]: undefined
   [EventName.VIEWS_SETUP_FOCUS_CHANGED]: undefined
-  [EventName.VIEWS_SETUP_SELECT_PYTHON_INTERPRETER]: undefined
+  [EventName.VIEWS_SETUP_UPDATE_PYTHON_ENVIRONMENT]: undefined
   [EventName.VIEWS_SETUP_SHOW_SCM_FOR_COMMIT]: undefined
   [EventName.VIEWS_SETUP_INIT_GIT]: undefined
   [EventName.VIEWS_SETUP_INSTALL_DVC]: undefined

--- a/extension/src/test/suite/setup/index.test.ts
+++ b/extension/src/test/suite/setup/index.test.ts
@@ -156,9 +156,9 @@ suite('Setup Test Suite', () => {
       expect(mockAutoUpgradeDvc).to.be.calledOnce
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
-    it('should handle a select Python interpreter message from the webview', async () => {
-      const { messageSpy, mockExecuteCommand, setup } = buildSetup(disposable)
-      const setInterpreterCommand = 'python.setInterpreter'
+    it('should handle a update Python environment message from the webview', async () => {
+      const { messageSpy, setup } = buildSetup(disposable)
+      const mockShowQuickPick = stub(window, 'showQuickPick')
 
       const webview = await setup.showWebview()
       await webview.isReady()
@@ -167,10 +167,10 @@ suite('Setup Test Suite', () => {
 
       messageSpy.resetHistory()
       mockMessageReceived.fire({
-        type: MessageFromWebviewType.SELECT_PYTHON_INTERPRETER
+        type: MessageFromWebviewType.UPDATE_PYTHON_ENVIRONMENT
       })
 
-      expect(mockExecuteCommand).to.be.calledWithExactly(setInterpreterCommand)
+      expect(mockShowQuickPick).to.be.called
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should handle a show source control panel message from the webview', async () => {

--- a/extension/src/vscode/title.ts
+++ b/extension/src/vscode/title.ts
@@ -41,7 +41,8 @@ export enum Title {
   SELECT_TRAINING_SCRIPT = 'Select your Training Script',
   SETUP_WORKSPACE = 'Setup the Workspace',
   SET_EXPERIMENTS_HEADER_HEIGHT = 'Set the Maximum Experiment Table Header Height',
-  SET_REMOTE_AS_DEFAULT = 'Set Default Remote'
+  SET_REMOTE_AS_DEFAULT = 'Set Default Remote',
+  UPDATE_PYTHON_ENVIRONMENT = 'Update Python Environment (selected with the Python Extension)'
 }
 
 export const getEnterValueTitle = (path: string): Title =>

--- a/extension/src/webview/contract.ts
+++ b/extension/src/webview/contract.ts
@@ -47,7 +47,6 @@ export enum MessageFromWebviewType {
   SELECT_EXPERIMENTS = 'select-experiments',
   SELECT_COLUMNS = 'select-columns',
   SELECT_PLOTS = 'select-plots',
-  SELECT_PYTHON_INTERPRETER = 'select-python-interpreter',
   SET_EXPERIMENTS_FOR_PLOTS = 'set-experiments-for-plots',
   SET_EXPERIMENTS_AND_OPEN_PLOTS = 'set-experiments-and-open-plots',
   SET_STUDIO_SHARE_EXPERIMENTS_LIVE = 'set-studio-share-experiments-live',
@@ -66,6 +65,7 @@ export enum MessageFromWebviewType {
   INITIALIZE_GIT = 'initialize-git',
   SHOW_SCM_PANEL = 'show-scm-panel',
   INSTALL_DVC = 'install-dvc',
+  UPDATE_PYTHON_ENVIRONMENT = 'update-python-environment',
   UPGRADE_DVC = 'upgrade-dvc',
   SETUP_WORKSPACE = 'setup-workspace',
   ZOOM_PLOT = 'zoom-plot',
@@ -197,7 +197,7 @@ export type MessageFromWebview =
     }
   | { type: MessageFromWebviewType.INITIALIZED }
   | { type: MessageFromWebviewType.SELECT_EXPERIMENTS }
-  | { type: MessageFromWebviewType.SELECT_PYTHON_INTERPRETER }
+  | { type: MessageFromWebviewType.UPDATE_PYTHON_ENVIRONMENT }
   | { type: MessageFromWebviewType.SELECT_PLOTS }
   | { type: MessageFromWebviewType.REFRESH_REVISIONS }
   | { type: MessageFromWebviewType.SELECT_COLUMNS }

--- a/webview/src/setup/components/App.test.tsx
+++ b/webview/src/setup/components/App.test.tsx
@@ -376,7 +376,7 @@ describe('App', () => {
       })
     })
 
-    it('should show the user the command used to run DVC with "Configure" and "Select Python Interpreter" buttons if dvc is installed with the python extension', () => {
+    it('should show the user the command used to run DVC with "Configure" and "Update Python Environment" buttons if dvc is installed with the python extension', () => {
       renderApp({
         isPythonExtensionUsed: true
       })
@@ -387,7 +387,7 @@ describe('App', () => {
 
       const configureButton = within(envDetails).getByText('Configure')
       const selectButton = within(envDetails).getByText(
-        'Select Python Interpreter'
+        'Update Python Environment'
       )
 
       expect(configureButton).toBeInTheDocument()
@@ -398,7 +398,7 @@ describe('App', () => {
       fireEvent.click(selectButton)
 
       expect(mockPostMessage).toHaveBeenCalledWith({
-        type: MessageFromWebviewType.SELECT_PYTHON_INTERPRETER
+        type: MessageFromWebviewType.UPDATE_PYTHON_ENVIRONMENT
       })
     })
 

--- a/webview/src/setup/components/dvc/CliUnavailable.tsx
+++ b/webview/src/setup/components/dvc/CliUnavailable.tsx
@@ -4,11 +4,15 @@ import styles from './styles.module.scss'
 import { Button } from '../../../shared/components/button/Button'
 import { EmptyState } from '../../../shared/components/emptyState/EmptyState'
 import { SetupState } from '../../store'
-import { installDvc, setupWorkspace } from '../messages'
+import {
+  installDvc,
+  updatePythonEnvironment,
+  setupWorkspace
+} from '../messages'
 
 export const CliUnavailable: React.FC<PropsWithChildren> = ({ children }) => {
-  const pythonBinPath = useSelector(
-    (state: SetupState) => state.dvc.pythonBinPath
+  const { pythonBinPath, isPythonExtensionUsed } = useSelector(
+    (state: SetupState) => state.dvc
   )
   const canInstall = !!pythonBinPath
   const installationSentence = (
@@ -30,6 +34,12 @@ export const CliUnavailable: React.FC<PropsWithChildren> = ({ children }) => {
       <div className={styles.sideBySideButtons}>
         <Button onClick={installDvc} text="Install (pip)" />
         <Button onClick={setupWorkspace} text="Configure" />
+        {isPythonExtensionUsed && (
+          <Button
+            onClick={updatePythonEnvironment}
+            text="Update Python Environment"
+          />
+        )}
       </div>
     </>
   ) : (

--- a/webview/src/setup/components/dvc/DvcEnvCommandRow.tsx
+++ b/webview/src/setup/components/dvc/DvcEnvCommandRow.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useSelector } from 'react-redux'
 import { DvcEnvInfoRow } from './DvcEnvInfoRow'
 import styles from './styles.module.scss'
-import { selectPythonInterpreter, setupWorkspace } from '../messages'
+import { updatePythonEnvironment, setupWorkspace } from '../messages'
 import { SetupState } from '../../store'
 
 interface DvcEnvCommandRowProps {
@@ -28,9 +28,9 @@ export const DvcEnvCommandRow: React.FC<DvcEnvCommandRowProps> = ({
             <span className={styles.separator} />
             <button
               className={styles.buttonAsLink}
-              onClick={selectPythonInterpreter}
+              onClick={updatePythonEnvironment}
             >
-              Select Python Interpreter
+              Update Python Environment
             </button>
           </>
         )}

--- a/webview/src/setup/components/messages.ts
+++ b/webview/src/setup/components/messages.ts
@@ -33,8 +33,8 @@ export const upgradeDvc = () => {
   sendMessage({ type: MessageFromWebviewType.UPGRADE_DVC })
 }
 
-export const selectPythonInterpreter = () => {
-  sendMessage({ type: MessageFromWebviewType.SELECT_PYTHON_INTERPRETER })
+export const updatePythonEnvironment = () => {
+  sendMessage({ type: MessageFromWebviewType.UPDATE_PYTHON_ENVIRONMENT })
 }
 
 export const setupWorkspace = () => {


### PR DESCRIPTION
* adds a "Update Python Extension" button that gives the user a choice between creating a new environment or selected from already created ones

## Demo

wip

## To Do

- [ ] Add more tests

Part of #3935 