### PR TITLE
Use shields.io for marketplace badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 # DVC Extension for Visual Studio Code
 
-[![Version](https://vsmarketplacebadges.dev/version-short/iterative.dvc.svg)](https://marketplace.visualstudio.com/items?itemName=Iterative.dvc)
-[![Installs](https://vsmarketplacebadges.dev/installs/iterative.dvc.svg)](https://marketplace.visualstudio.com/items?itemName=Iterative.dvc)
-[![Downloads](https://vsmarketplacebadges.dev/downloads/iterative.dvc.svg)](https://marketplace.visualstudio.com/items?itemName=Iterative.dvc)
-[![Ratings](https://vsmarketplacebadges.dev/rating-short/iterative.dvc.svg)](https://marketplace.visualstudio.com/items?itemName=Iterative.dvc)
+![Version](https://img.shields.io/visual-studio-marketplace/v/iterative.dvc)
+![Installs](https://img.shields.io/visual-studio-marketplace/i/iterative.dvc)
+![Downloads](https://img.shields.io/visual-studio-marketplace/d/iterative.dvc)
+![Rating](https://img.shields.io/visual-studio-marketplace/r/iterative.dvc)
 
 [![Continuous Integration](https://github.com/iterative/vscode-dvc/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/iterative/vscode-dvc/actions/workflows/continuous-integration.yml)
 [![Maintainability](https://api.codeclimate.com/v1/badges/fb243c31ea059c0038b2/maintainability)](https://codeclimate.com/repos/608b5886f52398018b00264c/maintainability)


### PR DESCRIPTION
Related to https://github.com/cssho/VSMarketplaceBadge/issues/18

Unbreaks the marketplace badges in the README:

![image](https://github.com/iterative/vscode-dvc/assets/37993418/0d07898c-3759-490c-8411-632e1e72541c)

