### PR TITLE
Correctly handle string arrays in modify and commands

### DIFF
--- a/extension/src/experiments/model/modify/collect.test.ts
+++ b/extension/src/experiments/model/modify/collect.test.ts
@@ -7,29 +7,43 @@ describe('collectFlatExperimentParams', () => {
   it('should flatten the params into an array', () => {
     const params = collectFlatExperimentParams(rowsFixture[0].params)
     expect(params).toStrictEqual([
-      { path: appendColumnToPath('params.yaml', 'code_names'), value: [0, 1] },
-      { path: appendColumnToPath('params.yaml', 'epochs'), value: 5 },
       {
+        isString: false,
+        path: appendColumnToPath('params.yaml', 'code_names'),
+        value: [0, 1]
+      },
+      {
+        isString: false,
+        path: appendColumnToPath('params.yaml', 'epochs'),
+        value: 5
+      },
+      {
+        isString: false,
         path: appendColumnToPath('params.yaml', 'learning_rate'),
         value: 2.1e-7
       },
       {
+        isString: true,
         path: appendColumnToPath('params.yaml', 'dvc_logs_dir'),
         value: 'dvc_logs'
       },
       {
+        isString: true,
         path: appendColumnToPath('params.yaml', 'log_file'),
         value: 'logs.csv'
       },
       {
+        isString: false,
         path: appendColumnToPath('params.yaml', 'dropout'),
         value: 0.124
       },
       {
+        isString: false,
         path: appendColumnToPath('params.yaml', 'process', 'threshold'),
         value: 0.85
       },
       {
+        isString: false,
         path: appendColumnToPath(join('nested', 'params.yaml'), 'test'),
         value: true
       }

--- a/extension/src/experiments/model/modify/collect.ts
+++ b/extension/src/experiments/model/modify/collect.ts
@@ -7,8 +7,10 @@ export type Param = {
   value: Value
 }
 
+export type ParamWithIsString = Param & { isString: boolean }
+
 const collectFromParamsFile = (
-  acc: { path: string; value: Value }[],
+  acc: ParamWithIsString[],
   key: string | undefined,
   value: Value | ValueTree,
   ancestors: string[] = []
@@ -24,13 +26,13 @@ const collectFromParamsFile = (
 
   const path = appendColumnToPath(...pathArray)
 
-  acc.push({ path, value })
+  acc.push({ isString: typeof value === 'string', path, value })
 }
 
 export const collectFlatExperimentParams = (
   params: MetricOrParamColumns = {}
 ) => {
-  const acc: { path: string; value: string | number | boolean }[] = []
+  const acc: ParamWithIsString[] = []
   for (const file of Object.keys(params)) {
     collectFromParamsFile(acc, undefined, params[file], [file])
   }


### PR DESCRIPTION
# 1/3 `main` <- this <- #4094 <- #4095

Part of #4088 

This PR adds support for strings that contain an array being passed around inside the "modify and" commands.

### Demo (can now modify and run in `example-get-started-experiments`)

https://github.com/iterative/vscode-dvc/assets/37993418/38dcbf38-0520-4874-b07d-b7b8cdd49ca1


