### PR TITLE
Only use selected params for modify and commands

### DIFF
--- a/extension/src/experiments/model/modify/quickPick.test.ts
+++ b/extension/src/experiments/model/modify/quickPick.test.ts
@@ -109,57 +109,7 @@ describe('pickAndModifyParams', () => {
       '-S',
       `params.yaml:code_names=${thirdInput}`,
       '-S',
-      `params.yaml:transforms='${fourthInput}'`,
-      '-S',
-      [unchanged.path, unchanged.value].join('=')
-    ])
-  })
-
-  it('should convert any unselected params into the required format', async () => {
-    const numericValue = {
-      isString: false,
-      path: 'params.yaml:learning_rate',
-      value: 2e-12
-    }
-    const stringArrayValue = {
-      isString: true,
-      path: 'params.yaml:transforms',
-      value: '[Pipeline: PILBase.create, Pipeline: partial -> PILBase.create]'
-    }
-
-    const actualArrayValue = {
-      isString: false,
-      path: 'params.yaml:code_names',
-      value: [0, 1, 2]
-    }
-
-    const unchanged = [numericValue, stringArrayValue, actualArrayValue]
-    const initialUserResponse = {
-      isString: false,
-      path: 'params.yaml:dropout',
-      value: 0.15
-    }
-
-    mockedQuickPickManyValues.mockResolvedValueOnce([initialUserResponse])
-    const firstInput = '0.16'
-    mockedGetInput.mockResolvedValueOnce(firstInput)
-
-    const paramsToQueue = await pickAndModifyParams([
-      ...unchanged,
-      initialUserResponse
-    ])
-
-    expect(mockedGetInput).toHaveBeenCalledTimes(1)
-
-    expect(paramsToQueue).toStrictEqual([
-      '-S',
-      `params.yaml:dropout=${firstInput}`,
-      '-S',
-      [numericValue.path, numericValue.value].join('='),
-      '-S',
-      [stringArrayValue.path, `'${stringArrayValue.value}'`].join('='),
-      '-S',
-      [actualArrayValue.path, JSON.stringify(actualArrayValue.value)].join('=')
+      `params.yaml:transforms='${fourthInput}'`
     ])
   })
 })


### PR DESCRIPTION
# 3/3 `main` <- #4092 <- #4094 <- this

Closes #4088 

This PR stops the extension from sending unchanged params to DVC for the "modify and... " commands. This is no longer needed as we are only letting the user use the workspace as a base now.

### Demo


https://github.com/iterative/vscode-dvc/assets/37993418/e3d7ebec-5cd7-4e98-8213-fa8067239824

