### PR TITLE
Fix custom plot tooltips

### DIFF
--- a/extension/src/plots/model/custom.ts
+++ b/extension/src/plots/model/custom.ts
@@ -97,8 +97,8 @@ export const createSpec = (title: string, metric: string, param: string) =>
         encoding: {
           tooltip: [
             {
-              field: 'expName',
-              title: 'name'
+              field: 'id',
+              title: 'id'
             },
             {
               field: 'metric',

--- a/extension/src/test/fixtures/expShow/base/customPlots.ts
+++ b/extension/src/test/fixtures/expShow/base/customPlots.ts
@@ -126,8 +126,8 @@ const data: CustomPlotsData = {
             encoding: {
               tooltip: [
                 {
-                  field: 'expName',
-                  title: 'name'
+                  field: 'id',
+                  title: 'id'
                 },
                 {
                   field: 'metric',
@@ -244,8 +244,8 @@ const data: CustomPlotsData = {
             encoding: {
               tooltip: [
                 {
-                  field: 'expName',
-                  title: 'name'
+                  field: 'id',
+                  title: 'id'
                 },
                 {
                   field: 'metric',


### PR DESCRIPTION
Closes #4097

Custom plot tooltips have been broken since we did the big `exp show` data update.

### Demo


https://github.com/iterative/vscode-dvc/assets/37993418/444f34db-13af-41bc-bf6f-602b62de028d

