### PR TITLE
Revert string quoting behaviour in modify and commands

### DIFF
--- a/extension/src/experiments/model/modify/collect.test.ts
+++ b/extension/src/experiments/model/modify/collect.test.ts
@@ -8,42 +8,34 @@ describe('collectFlatExperimentParams', () => {
     const params = collectFlatExperimentParams(rowsFixture[0].params)
     expect(params).toStrictEqual([
       {
-        isString: false,
         path: appendColumnToPath('params.yaml', 'code_names'),
         value: [0, 1]
       },
       {
-        isString: false,
         path: appendColumnToPath('params.yaml', 'epochs'),
         value: 5
       },
       {
-        isString: false,
         path: appendColumnToPath('params.yaml', 'learning_rate'),
         value: 2.1e-7
       },
       {
-        isString: true,
         path: appendColumnToPath('params.yaml', 'dvc_logs_dir'),
         value: 'dvc_logs'
       },
       {
-        isString: true,
         path: appendColumnToPath('params.yaml', 'log_file'),
         value: 'logs.csv'
       },
       {
-        isString: false,
         path: appendColumnToPath('params.yaml', 'dropout'),
         value: 0.124
       },
       {
-        isString: false,
         path: appendColumnToPath('params.yaml', 'process', 'threshold'),
         value: 0.85
       },
       {
-        isString: false,
         path: appendColumnToPath(join('nested', 'params.yaml'), 'test'),
         value: true
       }

--- a/extension/src/experiments/model/modify/collect.ts
+++ b/extension/src/experiments/model/modify/collect.ts
@@ -7,10 +7,8 @@ export type Param = {
   value: Value
 }
 
-export type ParamWithIsString = Param & { isString: boolean }
-
 const collectFromParamsFile = (
-  acc: ParamWithIsString[],
+  acc: Param[],
   key: string | undefined,
   value: Value | ValueTree,
   ancestors: string[] = []
@@ -26,13 +24,13 @@ const collectFromParamsFile = (
 
   const path = appendColumnToPath(...pathArray)
 
-  acc.push({ isString: typeof value === 'string', path, value })
+  acc.push({ path, value })
 }
 
 export const collectFlatExperimentParams = (
   params: MetricOrParamColumns = {}
 ) => {
-  const acc: ParamWithIsString[] = []
+  const acc: Param[] = []
   for (const file of Object.keys(params)) {
     collectFromParamsFile(acc, undefined, params[file], [file])
   }

--- a/extension/src/experiments/model/modify/quickPick.test.ts
+++ b/extension/src/experiments/model/modify/quickPick.test.ts
@@ -17,7 +17,7 @@ describe('pickAndModifyParams', () => {
     mockedQuickPickManyValues.mockResolvedValueOnce(undefined)
 
     const paramsToQueue = await pickAndModifyParams([
-      { isString: false, path: 'params.yaml:learning_rate', value: 2e-12 }
+      { path: 'params.yaml:learning_rate', value: 2e-12 }
     ])
 
     expect(paramsToQueue).toBeUndefined()
@@ -26,13 +26,12 @@ describe('pickAndModifyParams', () => {
 
   it('should return early if the user exits from the input box', async () => {
     const unchanged = {
-      isString: false,
       path: 'params.yaml:learning_rate',
       value: 2e-12
     }
     const initialUserResponse = [
-      { isString: false, path: 'params.yaml:dropout', value: 0.15 },
-      { isString: false, path: 'params.yaml:process.threshold', value: 0.86 }
+      { path: 'params.yaml:dropout', value: 0.15 },
+      { path: 'params.yaml:process.threshold', value: 0.86 }
     ]
     mockedQuickPickManyValues.mockResolvedValueOnce(initialUserResponse)
     const firstInput = '0.16'
@@ -50,37 +49,38 @@ describe('pickAndModifyParams', () => {
 
   it('should convert any selected params into the required format', async () => {
     const unchanged = {
-      isString: false,
       path: 'params.yaml:learning_rate',
       value: 2e-12
     }
 
     const initialUserResponse = [
-      { isString: false, path: 'params.yaml:dropout', value: 0.15 },
-      { isString: false, path: 'params.yaml:process.threshold', value: 0.86 },
-      { isString: false, path: 'params.yaml:code_names', value: [0, 1, 2] },
+      { path: 'params.yaml:dropout', value: 0.15 },
+      { path: 'params.yaml:process.threshold', value: 0.86 },
+      { path: 'params.yaml:code_names', value: [0, 1, 2] },
+      { path: 'params.yaml:arch', value: 'resnet18' },
       {
-        isString: true,
         path: 'params.yaml:transforms',
         value: '[Pipeline: PILBase.create, Pipeline: partial -> PILBase.create]'
       }
     ]
     mockedQuickPickManyValues.mockResolvedValueOnce(initialUserResponse)
-    const firstInput = '0.16'
-    const secondInput = '0.87'
-    const thirdInput = '[0,1,3]'
-    const fourthInput = '[Pipeline: PILBase.create]'
-    mockedGetInput.mockResolvedValueOnce(firstInput)
-    mockedGetInput.mockResolvedValueOnce(secondInput)
-    mockedGetInput.mockResolvedValueOnce(thirdInput)
-    mockedGetInput.mockResolvedValueOnce(fourthInput)
+    const input1 = '0.16'
+    const input2 = '0.87,0.88'
+    const input3 = '[0,1,3]'
+    const input4 = 'resnet18,shufflenet_v2_x2_0'
+    const input5 = "'[Pipeline: PILBase.create]'" // user needs to quote
+    mockedGetInput.mockResolvedValueOnce(input1)
+    mockedGetInput.mockResolvedValueOnce(input2)
+    mockedGetInput.mockResolvedValueOnce(input3)
+    mockedGetInput.mockResolvedValueOnce(input4)
+    mockedGetInput.mockResolvedValueOnce(input5)
 
     const paramsToQueue = await pickAndModifyParams([
       unchanged,
       ...initialUserResponse
     ])
 
-    expect(mockedGetInput).toHaveBeenCalledTimes(4)
+    expect(mockedGetInput).toHaveBeenCalledTimes(5)
     expect(mockedGetInput).toHaveBeenCalledWith(
       'Enter a Value for params.yaml:dropout',
       '0.15'
@@ -97,19 +97,26 @@ describe('pickAndModifyParams', () => {
     )
 
     expect(mockedGetInput).toHaveBeenCalledWith(
+      'Enter a Value for params.yaml:arch',
+      'resnet18'
+    )
+
+    expect(mockedGetInput).toHaveBeenCalledWith(
       'Enter a Value for params.yaml:transforms',
       '[Pipeline: PILBase.create, Pipeline: partial -> PILBase.create]'
     )
 
     expect(paramsToQueue).toStrictEqual([
       '-S',
-      `params.yaml:dropout=${firstInput}`,
+      `params.yaml:dropout=${input1}`,
       '-S',
-      `params.yaml:process.threshold=${secondInput}`,
+      `params.yaml:process.threshold=${input2}`,
       '-S',
-      `params.yaml:code_names=${thirdInput}`,
+      `params.yaml:code_names=${input3}`,
       '-S',
-      `params.yaml:transforms='${fourthInput}'`
+      `params.yaml:arch=${input4}`,
+      '-S',
+      `params.yaml:transforms=${input5}`
     ])
   })
 })

--- a/extension/src/experiments/model/modify/quickPick.ts
+++ b/extension/src/experiments/model/modify/quickPick.ts
@@ -1,4 +1,4 @@
-import { ParamWithIsString } from './collect'
+import { Param } from './collect'
 import { quickPickManyValues } from '../../../vscode/quickPick'
 import { getInput } from '../../../vscode/inputBox'
 import { Flag } from '../../../cli/dvc/constants'
@@ -6,20 +6,12 @@ import { definedAndNonEmpty } from '../../../util/array'
 import { getEnterValueTitle, Title } from '../../../vscode/title'
 import { Value } from '../../../cli/dvc/contract'
 
-const standardizeValue = (
-  value: Value,
-  wrapStringParamForCli = false
-): string => {
-  if (wrapStringParamForCli && typeof value === 'string') {
-    return `'${value}'`
-  }
+const standardizeValue = (value: Value): string => {
   return typeof value === 'object' ? JSON.stringify(value) : String(value)
 }
 
-const pickParamsToModify = (
-  params: ParamWithIsString[]
-): Thenable<ParamWithIsString[] | undefined> =>
-  quickPickManyValues<ParamWithIsString>(
+const pickParamsToModify = (params: Param[]): Thenable<Param[] | undefined> =>
+  quickPickManyValues<Param>(
     params.map(param => ({
       description: standardizeValue(param.value),
       label: param.path,
@@ -30,10 +22,10 @@ const pickParamsToModify = (
   )
 
 const pickNewParamValues = async (
-  paramsToModify: ParamWithIsString[]
+  paramsToModify: Param[]
 ): Promise<string[] | undefined> => {
   const args: string[] = []
-  for (const { path, value, isString } of paramsToModify) {
+  for (const { path, value } of paramsToModify) {
     const input = await getInput(
       getEnterValueTitle(path),
       standardizeValue(value)
@@ -41,16 +33,13 @@ const pickNewParamValues = async (
     if (input === undefined) {
       return
     }
-    args.push(
-      Flag.SET_PARAM,
-      [path, standardizeValue(input.trim(), isString)].join('=')
-    )
+    args.push(Flag.SET_PARAM, [path, standardizeValue(input.trim())].join('='))
   }
   return args
 }
 
 export const pickAndModifyParams = async (
-  params: ParamWithIsString[]
+  params: Param[]
 ): Promise<string[] | undefined> => {
   const paramsToModify = await pickParamsToModify(params)
 


### PR DESCRIPTION
Closes #4114

This PR reverts the recently added behaviour which quoted param values passed to DVC that use string parameters as a base.

The change broke grid search functionality for the modify and run/modify and queue commands. 

Reverting the change provides the user with more freedom to change parameters as they see fit. However, under certain circumstances, they will need to provide quotes for "strings that look like arrays/objects".

### Demo

https://github.com/iterative/vscode-dvc/assets/37993418/1f41ba16-ae53-40c6-99c3-2d20d7abe70e

### Edge case behaviour (requires the user to quote)

https://github.com/iterative/vscode-dvc/assets/37993418/9d73622c-117e-4456-937b-b9ec41d14e3b


