### PR TITLE
Switch experiment table radio buttons to plot icons

### DIFF
--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -668,10 +668,10 @@ describe('App', () => {
 
       expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
 
-      const radioButton = within(getRow(EXPERIMENT_WORKSPACE_ID)).getByTestId(
+      const plotIcon = within(getRow(EXPERIMENT_WORKSPACE_ID)).getByTestId(
         'row-action-plot'
       )
-      fireEvent.mouseEnter(radioButton)
+      fireEvent.mouseEnter(plotIcon)
 
       advanceTimersByTime(NORMAL_TOOLTIP_DELAY[0])
       const tooltip = screen.queryByRole('tooltip')
@@ -692,8 +692,8 @@ describe('App', () => {
 
       expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
 
-      const radioButton = within(getRow('main')).getByTestId('row-action-star')
-      fireEvent.mouseEnter(radioButton)
+      const starIcon = within(getRow('main')).getByTestId('row-action-star')
+      fireEvent.mouseEnter(starIcon)
 
       advanceTimersByTime(NORMAL_TOOLTIP_DELAY[0])
       const tooltip = screen.queryByRole('tooltip')

--- a/webview/src/experiments/components/table/body/Cell.tsx
+++ b/webview/src/experiments/components/table/body/Cell.tsx
@@ -1,6 +1,8 @@
 import { flexRender } from '@tanstack/react-table'
 import React, { ReactNode } from 'react'
+import { VSCodeProgressRing } from '@vscode/webview-ui-toolkit/react'
 import cx from 'classnames'
+import { isRunning } from 'dvc/src/experiments/webview/contract'
 import { CellRowActionsProps, CellRowActions } from './CellRowActions'
 import styles from '../styles.module.scss'
 import { CellValue, isValueWithChanges } from '../content/Cell'
@@ -59,6 +61,12 @@ export const FirstCell: React.FC<
       <div className={styles.innerCell} style={{ width: getSize() }}>
         <CellRowActions status={status} {...rowActionsProps} />
         <RowExpansionButton row={row} />
+        {isRunning(status) && (
+          <VSCodeProgressRing
+            className={cx(styles.running, 'chromatic-ignore')}
+          />
+        )}
+
         {getIsPlaceholder() ? null : (
           <ErrorTooltip error={error}>
             <div

--- a/webview/src/experiments/components/table/body/CellRowActions.tsx
+++ b/webview/src/experiments/components/table/body/CellRowActions.tsx
@@ -131,10 +131,15 @@ export const CellRowActions: React.FC<CellRowActionsProps> = ({
           onClick={toggleExperiment}
         >
           <Icon
-            style={{ backgroundColor: plotColor }}
             className={styles.plotBox}
-            height={18}
-            width={18}
+            style={
+              plotColor
+                ? {
+                    backgroundColor: plotColor,
+                    fill: 'var(--vscode-editor-foreground)'
+                  }
+                : {}
+            }
             icon={GraphScatter}
           />
         </CellRowAction>

--- a/webview/src/experiments/components/table/body/CellRowActions.tsx
+++ b/webview/src/experiments/components/table/body/CellRowActions.tsx
@@ -1,6 +1,5 @@
 import React, { MouseEventHandler, ReactElement } from 'react'
 import { VSCodeCheckbox } from '@vscode/webview-ui-toolkit/react'
-import cx from 'classnames'
 import {
   ExperimentStatus,
   isQueued
@@ -35,18 +34,16 @@ export type CellRowActionsProps = {
 }
 
 type CellRowActionProps = {
-  className?: string
   showSubRowStates: boolean
   subRowsAffected: number
   children: ReactElement
   testId: string
-  tooltipContent: string | ReactElement | null
+  tooltipContent: string | ReactElement
   onClick?: MouseEventHandler
 }
 
 const CellRowAction: React.FC<CellRowActionProps> = ({
   children,
-  className,
   onClick,
   showSubRowStates,
   subRowsAffected,
@@ -55,18 +52,14 @@ const CellRowAction: React.FC<CellRowActionProps> = ({
 }) => {
   const count = (showSubRowStates && subRowsAffected) || 0
 
-  const action = (
-    <div className={cx(styles.rowActions, className)} data-testid={testId}>
-      <Indicator onClick={onClick} count={count}>
-        {children}
-      </Indicator>
-    </div>
-  )
-
-  return tooltipContent ? (
-    <CellHintTooltip tooltipContent={tooltipContent}>{action}</CellHintTooltip>
-  ) : (
-    action
+  return (
+    <CellHintTooltip tooltipContent={tooltipContent}>
+      <div className={styles.rowActions} data-testid={testId}>
+        <Indicator onClick={onClick} count={count}>
+          {children}
+        </Indicator>
+      </div>
+    </CellHintTooltip>
   )
 }
 
@@ -168,7 +161,7 @@ export const CellRowActions: React.FC<CellRowActionsProps> = ({
         >
           {starred ? <StarFull /> : <StarEmpty />}
         </div>
-      </CellRowAction>{' '}
+      </CellRowAction>
     </>
   )
 }

--- a/webview/src/experiments/components/table/body/CellRowActions.tsx
+++ b/webview/src/experiments/components/table/body/CellRowActions.tsx
@@ -131,7 +131,7 @@ export const CellRowActions: React.FC<CellRowActionsProps> = ({
           onClick={toggleExperiment}
         >
           <Icon
-            style={{ fill: plotColor }}
+            style={{ backgroundColor: plotColor }}
             className={styles.plotBox}
             height={18}
             width={18}

--- a/webview/src/experiments/components/table/body/Row.tsx
+++ b/webview/src/experiments/components/table/body/Row.tsx
@@ -2,7 +2,6 @@ import cx from 'classnames'
 import React, { useCallback, useContext, useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { EXPERIMENT_WORKSPACE_ID } from 'dvc/src/cli/dvc/contract'
-import { isRunning } from 'dvc/src/experiments/webview/contract'
 import { FirstCell, CellWrapper } from './Cell'
 import { RowContextMenu } from './RowContextMenu'
 import styles from '../styles.module.scss'
@@ -52,9 +51,6 @@ export const RowContent: React.FC<
     const plotSelections =
       subRows?.filter(subRow => subRow.original.selected).length ?? 0
 
-    const running =
-      subRows?.filter(subRow => isRunning(subRow.original.status)).length ?? 0
-
     const selections =
       subRows?.filter(
         subRow =>
@@ -65,7 +61,6 @@ export const RowContent: React.FC<
 
     return {
       plotSelections,
-      running,
       selections,
       stars
     }

--- a/webview/src/experiments/components/table/body/Row.tsx
+++ b/webview/src/experiments/components/table/body/Row.tsx
@@ -2,7 +2,7 @@ import cx from 'classnames'
 import React, { useCallback, useContext, useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { EXPERIMENT_WORKSPACE_ID } from 'dvc/src/cli/dvc/contract'
-import { isQueued, isRunning } from 'dvc/src/experiments/webview/contract'
+import { isRunning } from 'dvc/src/experiments/webview/contract'
 import { FirstCell, CellWrapper } from './Cell'
 import { RowContextMenu } from './RowContextMenu'
 import styles from '../styles.module.scss'
@@ -24,9 +24,8 @@ export const RowContent: React.FC<
   const changes = useSelector(
     (state: ExperimentsState) => state.tableData.changes
   )
-  const { getVisibleCells, original, index, getIsExpanded, subRows } = row
-  const { branch, displayColor, error, starred, id, status, selected } =
-    original
+  const { getVisibleCells, original, getIsExpanded, subRows } = row
+  const { branch, displayColor, error, starred, id } = original
   const [firstCell, ...cells] = getVisibleCells()
   const isWorkspace = id === EXPERIMENT_WORKSPACE_ID
   const changesIfWorkspace = isWorkspace ? changes : undefined
@@ -53,6 +52,9 @@ export const RowContent: React.FC<
     const plotSelections =
       subRows?.filter(subRow => subRow.original.selected).length ?? 0
 
+    const running =
+      subRows?.filter(subRow => isRunning(subRow.original.status)).length ?? 0
+
     const selections =
       subRows?.filter(
         subRow =>
@@ -63,15 +65,11 @@ export const RowContent: React.FC<
 
     return {
       plotSelections,
+      running,
       selections,
       stars
     }
   }, [subRows, selectedRows])
-
-  const running = isRunning(status)
-  const queued = isQueued(status)
-  const unselected = selected === false
-  const isOdd = index % 2 !== 0 && !isRowSelected
 
   return (
     <ContextMenu content={<RowContextMenu row={row} />}>
@@ -82,14 +80,6 @@ export const RowContent: React.FC<
           styles.bodyRow,
           styles.row,
           {
-            [styles.runningExperiment]: running,
-            [styles.queuedExperiment]: queued,
-            [styles.unselectedExperiment]: !running && !queued && unselected,
-            [styles.normalExperiment]: !running && !queued && !unselected,
-            [styles.oddRow]: isOdd,
-            [styles.evenRow]: !isOdd,
-            [styles.workspaceRow]: isWorkspace,
-            [styles.normalRow]: !isWorkspace,
             [styles.rowSelected]: isRowSelected
           }
         )}
@@ -100,7 +90,7 @@ export const RowContent: React.FC<
         <FirstCell
           cell={firstCell}
           changesIfWorkspace={!!changesIfWorkspace?.length}
-          bulletColor={displayColor}
+          plotColor={displayColor}
           starred={starred}
           isRowSelected={isRowSelected}
           showSubRowStates={!getIsExpanded() && !isWorkspace}

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -451,11 +451,7 @@ $badge-size: 0.85rem;
     visibility: hidden;
   }
 
-  .running {
-    visibility: visible;
-  }
-
-  .plotIcon {
+  .plotBox {
     visibility: visible;
   }
 
@@ -634,14 +630,21 @@ $badge-size: 0.85rem;
   font-size: 0.65rem;
 }
 
-.plotIcon {
-  margin-top: 4px;
+.plotBox {
+  height: $checkbox-size;
+  width: $checkbox-size;
+  background-color: $checkbox-background;
+  border-radius: $checkbox-border-radius;
+  border: $checkbox-border-width solid $checkbox-border;
+  cursor: pointer;
 }
 
 .running {
-  position: relative;
-  height: 16px;
-  width: 16px;
+  display: inline-flex;
+  height: 12px;
+  width: 12px;
+  margin-right: 8px;
+  margin-left: -20px;
 }
 
 .queued {

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -635,6 +635,10 @@ $badge-size: 0.85rem;
   background-color: $checkbox-background;
   border-radius: $checkbox-border-radius;
   border: $checkbox-border-width solid $checkbox-border;
+  svg: {
+    fill: $icon-color;
+  }
+
   cursor: pointer;
 }
 

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -10,7 +10,6 @@ $row-border: 1px solid $border-color;
 $edge-padding: 0.8rem;
 $cell-padding: 0.5rem;
 $workspace-row-edge-margin: $edge-padding - $cell-padding;
-$bullet-size: calc(var(--design-unit) * 8px);
 $badge-size: 0.85rem;
 
 // Extendable Silent Rules

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -10,7 +10,7 @@ $row-border: 1px solid $border-color;
 $edge-padding: 0.8rem;
 $cell-padding: 0.5rem;
 $workspace-row-edge-margin: $edge-padding - $cell-padding;
-$bullet-size: calc(var(--design-unit) * 4px);
+$bullet-size: calc(var(--design-unit) * 8px);
 $badge-size: 0.85rem;
 
 // Extendable Silent Rules
@@ -451,6 +451,14 @@ $badge-size: 0.85rem;
     visibility: hidden;
   }
 
+  .running {
+    visibility: visible;
+  }
+
+  .plotIcon {
+    visibility: visible;
+  }
+
   .timestampInnerCell {
     height: 42px;
   }
@@ -576,7 +584,7 @@ $badge-size: 0.85rem;
   height: 100%;
 
   &:first-child {
-    margin-right: 20px;
+    margin-right: 4px;
   }
 
   .nestedRow & {
@@ -626,57 +634,14 @@ $badge-size: 0.85rem;
   font-size: 0.65rem;
 }
 
-.bullet {
-  visibility: visible;
-  align-items: center;
-  background: $checkbox-background;
-  border-radius: $bullet-size;
-  border: calc(var(--border-width) * 1px) solid $checkbox-border;
-  color: $icon-color;
-  cursor: pointer;
-  display: flex;
-  height: $bullet-size;
-  justify-content: center;
-  outline: none;
-  padding: 0;
+.plotIcon {
+  margin-top: 4px;
+}
+
+.running {
   position: relative;
-  width: $bullet-size;
-
-  &::before {
-    display: inline-block;
-    position: relative;
-    content: '';
-    border-radius: 99px;
-    width: 6px;
-    height: 6px;
-    z-index: 2;
-
-    .normalExperiment & {
-      line-height: 0;
-      background: currentcolor;
-      border-radius: 100%;
-    }
-
-    .unselectedExperiment & {
-      width: 4px;
-      height: 4px;
-      vertical-align: middle;
-      border: 1px solid $icon-color;
-      background-color: $checkbox-background;
-    }
-
-    .runningExperiment & {
-      width: 4px;
-      height: 4px;
-      vertical-align: middle;
-      border: 1.5px solid $checkbox-background;
-      border-radius: 100%;
-      border-right: 1.5px solid currentcolor;
-      border-top: 1.5px solid currentcolor;
-      animation: spin 1s cubic-bezier(0.53, 0.21, 0.29, 0.67) infinite;
-      background-color: $checkbox-background;
-    }
-  }
+  height: 16px;
+  width: 16px;
 }
 
 .queued {

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -630,16 +630,14 @@ $badge-size: 0.85rem;
 }
 
 .plotBox {
-  height: $checkbox-size;
-  width: $checkbox-size;
   background-color: $checkbox-background;
   border-radius: $checkbox-border-radius;
   border: $checkbox-border-width solid $checkbox-border;
-  svg: {
-    fill: $icon-color;
-  }
-
   cursor: pointer;
+  display: flex;
+  height: $checkbox-size;
+  width: $checkbox-size;
+  padding: 2px;
 }
 
 .running {

--- a/webview/src/plots/components/ribbon/RibbonBlock.tsx
+++ b/webview/src/plots/components/ribbon/RibbonBlock.tsx
@@ -1,5 +1,6 @@
 import { Revision } from 'dvc/src/plots/webview/contract'
 import React from 'react'
+import cx from 'classnames'
 import { VSCodeProgressRing } from '@vscode/webview-ui-toolkit/react'
 import styles from './styles.module.scss'
 import { RibbonBlockTooltip } from './RibbonBlockTooltip'
@@ -19,7 +20,9 @@ const RevisionIcon: React.FC<{ fetched: boolean; errors?: string[] }> = ({
 }) => (
   <div className={styles.iconPlaceholder}>
     {fetched && errors && '!'}
-    {!fetched && <VSCodeProgressRing className={styles.fetching} />}
+    {!fetched && (
+      <VSCodeProgressRing className={cx(styles.fetching, 'chromatic-ignore')} />
+    )}
   </div>
 )
 

--- a/webview/src/shared/components/Icon.tsx
+++ b/webview/src/shared/components/Icon.tsx
@@ -4,6 +4,7 @@ export type IconValue = (props: SVGProps<SVGSVGElement>) => JSX.Element
 interface IconProps {
   icon: IconValue
   className?: string
+  style?: { [key: string]: string | undefined }
   width?: number
   height?: number
 }

--- a/webview/src/shared/variables.scss
+++ b/webview/src/shared/variables.scss
@@ -42,6 +42,9 @@ $selected-icon-color: var(
 $row-action-star-checked: var(--vscode-editorLightBulb-foreground);
 $checkbox-background: var(--checkbox-background);
 $checkbox-border: var(--checkbox-border);
+$checkbox-border-radius: calc(var(--checkbox-corner-radius) * 1px);
+$checkbox-border-width: calc(var(--border-width) * 1px);
+$checkbox-size: calc(var(--design-unit) * 4px + 2px);
 $indicator-badge-background: var(--vscode-activityBarBadge-background);
 $indicator-badge-foreground: var(--vscode-activityBarBadge-foreground);
 $disabled-opacity: var(--disabled-opacity);


### PR DESCRIPTION
Related to #3430

This PR swaps the old radio button for a plot icon and separates an experiment's running indicator from the icon. This brings us closer to the new Studio UI for plotting.

### Demo 

#### Final Icons

<img width="1728" alt="image" src="https://github.com/iterative/vscode-dvc/assets/37993418/9e2cd6f0-5e1c-4306-9b17-e8c5bac2b9a1">

#### Layout (outdated icons)

https://github.com/iterative/vscode-dvc/assets/37993418/81c16dab-f511-400b-897a-3014ceb39c7f

#### Studio UI (for reference)

<img width="422" alt="image" src="https://github.com/iterative/vscode-dvc/assets/37993418/a20fe1b9-d05d-485d-9f7d-8620cceb1f7f">



**Note:** As you can see in the original demo (below) I have left the tree untouched. I have taken this approach because the user will lose information if we move to the plot icon there (a user cannot tell if an experiment is running from the tree).

-----

#### Demo (outdated)


https://github.com/iterative/vscode-dvc/assets/37993418/53e87737-f151-4990-b330-53199effde28
