### PR TITLE
Point users to Python extension in DVC Setup

### DIFF
--- a/webview/src/setup/components/App.test.tsx
+++ b/webview/src/setup/components/App.test.tsx
@@ -133,7 +133,7 @@ describe('App', () => {
       })
     })
 
-    it('should tell the user they cannot install DVC without a Python interpreter', () => {
+    it('should tell the user they cannot install DVC without a Python env', () => {
       renderApp({
         cliCompatible: undefined,
         dvcCliDetails: {
@@ -147,7 +147,6 @@ describe('App', () => {
           /DVC & DVCLive cannot be auto-installed as Python was not located./
         )
       ).toBeInTheDocument()
-      expect(screen.queryByText('Install')).not.toBeInTheDocument()
     })
 
     it('should tell the user they can auto-install DVC with a Python interpreter', () => {
@@ -169,7 +168,7 @@ describe('App', () => {
       expect(screen.getByText('Install (pip)')).toBeInTheDocument()
     })
 
-    it('should let the user find another Python interpreter to install DVC when the Python extension is not installed', () => {
+    it('should let the user locate DVC when the Python extension is not installed', () => {
       renderApp({
         cliCompatible: undefined,
         dvcCliDetails: {
@@ -185,6 +184,28 @@ describe('App', () => {
       expect(mockPostMessage).toHaveBeenCalledWith({
         type: MessageFromWebviewType.SETUP_WORKSPACE
       })
+    })
+
+    it('should show "Set Env" and "Install (pip)" button tooltips when dvc is unavailable and Python extension is not installed', () => {
+      renderApp({
+        cliCompatible: undefined,
+        dvcCliDetails: {
+          command: 'python -m dvc',
+          version: undefined
+        }
+      })
+
+      const installButton = screen.getByText('Install (pip)')
+
+      fireEvent.mouseEnter(installButton, { bubbles: true })
+
+      expect(screen.getByTestId('install-tooltip')).toBeVisible()
+
+      const setEnvButton = screen.getByText('Set Env')
+
+      fireEvent.mouseEnter(setEnvButton, { bubbles: true })
+
+      expect(screen.getByTestId('set-env-tooltip')).toBeVisible()
     })
 
     it('should let the user find or create another Python interpreter to install DVC when the Python extension is installed', () => {

--- a/webview/src/setup/components/App.test.tsx
+++ b/webview/src/setup/components/App.test.tsx
@@ -133,7 +133,7 @@ describe('App', () => {
       })
     })
 
-    it('should tell the user they cannot install DVC without a Python env', () => {
+    it('should tell the user they cannot install DVC without a Python interpreter', () => {
       renderApp({
         cliCompatible: undefined,
         dvcCliDetails: {

--- a/webview/src/setup/components/App.test.tsx
+++ b/webview/src/setup/components/App.test.tsx
@@ -186,7 +186,7 @@ describe('App', () => {
       })
     })
 
-    it('should show "Set Env" and "Install (pip)" button tooltips when dvc is unavailable and Python extension is not installed', () => {
+    it('should show python extension info when dvc is unavailable and Python extension is not installed', () => {
       renderApp({
         cliCompatible: undefined,
         dvcCliDetails: {
@@ -195,17 +195,13 @@ describe('App', () => {
         }
       })
 
-      const installButton = screen.getByText('Install (pip)')
+      const infoText = screen.getByText(/detect or create python environments/)
 
-      fireEvent.mouseEnter(installButton, { bubbles: true })
+      expect(infoText).toBeInTheDocument()
 
-      expect(screen.getByTestId('install-tooltip')).toBeVisible()
+      sendSetDataMessage({ ...DEFAULT_DATA, isPythonExtensionUsed: true })
 
-      const setEnvButton = screen.getByText('Set Env')
-
-      fireEvent.mouseEnter(setEnvButton, { bubbles: true })
-
-      expect(screen.getByTestId('set-env-tooltip')).toBeVisible()
+      expect(infoText).not.toBeInTheDocument()
     })
 
     it('should let the user find or create another Python interpreter to install DVC when the Python extension is installed', () => {

--- a/webview/src/setup/components/dvc/CliIncompatible.tsx
+++ b/webview/src/setup/components/dvc/CliIncompatible.tsx
@@ -15,12 +15,8 @@ export const CliIncompatible: React.FC<PropsWithChildren> = ({ children }) => {
   const conditionalContents = canUpgrade ? (
     <>
       <div className={styles.sideBySideButtons}>
-        <span className={styles.buttonWrapper}>
-          <Button onClick={upgradeDvc} text="Upgrade (pip)" />
-        </span>
-        <span className={styles.buttonWrapper}>
-          <Button text="Check Compatibility" onClick={checkCompatibility} />
-        </span>
+        <Button onClick={upgradeDvc} text="Upgrade (pip)" />
+        <Button text="Check Compatibility" onClick={checkCompatibility} />
       </div>
     </>
   ) : (

--- a/webview/src/setup/components/dvc/CliIncompatible.tsx
+++ b/webview/src/setup/components/dvc/CliIncompatible.tsx
@@ -15,8 +15,12 @@ export const CliIncompatible: React.FC<PropsWithChildren> = ({ children }) => {
   const conditionalContents = canUpgrade ? (
     <>
       <div className={styles.sideBySideButtons}>
-        <Button onClick={upgradeDvc} text="Upgrade (pip)" />
-        <Button text="Check Compatibility" onClick={checkCompatibility} />
+        <span className={styles.buttonWrapper}>
+          <Button onClick={upgradeDvc} text="Upgrade (pip)" />
+        </span>
+        <span className={styles.buttonWrapper}>
+          <Button text="Check Compatibility" onClick={checkCompatibility} />
+        </span>
       </div>
     </>
   ) : (

--- a/webview/src/setup/components/dvc/CliUnavailable.tsx
+++ b/webview/src/setup/components/dvc/CliUnavailable.tsx
@@ -10,6 +10,28 @@ import {
   updatePythonEnvironment
 } from '../../util/messages'
 import { Warning } from '../../../shared/components/icons'
+import { ExtensionLink } from '../shared/ExtensionLink'
+import Tooltip from '../../../shared/components/tooltip/Tooltip'
+
+const PythonExtensionTooltip: React.FC<
+  PropsWithChildren<{ disabled: boolean }>
+> = ({ disabled, children }) => (
+  <Tooltip
+    content={
+      <span>
+        Install the{' '}
+        <ExtensionLink extensionId="ms-python.python">
+          Python extension
+        </ExtensionLink>
+        .
+      </span>
+    }
+    interactive={true}
+    disabled={disabled}
+  >
+    <span>{children}</span>
+  </Tooltip>
+)
 
 export const CliUnavailable: React.FC<PropsWithChildren> = ({ children }) => {
   const { pythonBinPath, isPythonExtensionUsed, isPythonEnvironmentGlobal } =
@@ -35,21 +57,17 @@ export const CliUnavailable: React.FC<PropsWithChildren> = ({ children }) => {
         )}
         .
       </p>
-      <div className={styles.sideBySideButtons}>
-        <Button onClick={installDvc} text="Install (pip)" />
-        {isPythonExtensionUsed && (
-          <Button onClick={updatePythonEnvironment} text="Set Env" />
-        )}
-        <Button onClick={setupWorkspace} text="Locate DVC" />
-      </div>
     </>
   ) : (
     <>
       <p>
         {installationSentence} DVC & DVCLive cannot be auto-installed as Python
-        was not located.
+        was not located. Install the{' '}
+        <ExtensionLink extensionId="ms-python.python">
+          Python extension
+        </ExtensionLink>{' '}
+        to detect or create python environments.
       </p>
-      <Button onClick={setupWorkspace} text="Locate DVC" />
     </>
   )
 
@@ -58,6 +76,23 @@ export const CliUnavailable: React.FC<PropsWithChildren> = ({ children }) => {
       <h1>DVC is currently unavailable</h1>
       {children}
       {conditionalContents}
+      <div className={styles.sideBySideButtons}>
+        <PythonExtensionTooltip disabled={canInstall}>
+          <Button
+            disabled={!canInstall}
+            onClick={installDvc}
+            text="Install (pip)"
+          />
+        </PythonExtensionTooltip>
+        <PythonExtensionTooltip disabled={isPythonExtensionUsed}>
+          <Button
+            disabled={!isPythonExtensionUsed}
+            onClick={updatePythonEnvironment}
+            text="Set Env"
+          />
+        </PythonExtensionTooltip>
+        <Button onClick={setupWorkspace} text="Locate DVC" />
+      </div>
     </EmptyState>
   )
 }

--- a/webview/src/setup/components/dvc/CliUnavailable.tsx
+++ b/webview/src/setup/components/dvc/CliUnavailable.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, ReactElement } from 'react'
+import React, { PropsWithChildren } from 'react'
 import { useSelector } from 'react-redux'
 import styles from './styles.module.scss'
 import { Button } from '../../../shared/components/button/Button'
@@ -10,30 +10,7 @@ import {
   updatePythonEnvironment
 } from '../../util/messages'
 import { Warning } from '../../../shared/components/icons'
-import { ExtensionLink } from '../shared/ExtensionLink'
-import Tooltip from '../../../shared/components/tooltip/Tooltip'
-
-const PythonExtensionTooltip: React.FC<{
-  dataTestId: string
-  disabled: boolean
-  children: ReactElement
-}> = ({ dataTestId, disabled, children }) => (
-  <Tooltip
-    content={
-      <span data-testid={dataTestId}>
-        Install the{' '}
-        <ExtensionLink extensionId="ms-python.python">
-          Python extension
-        </ExtensionLink>
-        .
-      </span>
-    }
-    interactive={true}
-    disabled={disabled}
-  >
-    <span>{children}</span>
-  </Tooltip>
-)
+import { ShowExtension } from '../remotes/ShowExtension'
 
 export const CliUnavailable: React.FC<PropsWithChildren> = ({ children }) => {
   const { pythonBinPath, isPythonExtensionUsed, isPythonEnvironmentGlobal } =
@@ -64,11 +41,7 @@ export const CliUnavailable: React.FC<PropsWithChildren> = ({ children }) => {
     <>
       <p>
         {installationSentence} DVC & DVCLive cannot be auto-installed as Python
-        was not located. Install the{' '}
-        <ExtensionLink extensionId="ms-python.python">
-          Python extension
-        </ExtensionLink>{' '}
-        to detect or create python environments.
+        was not located.
       </p>
     </>
   )
@@ -79,34 +52,26 @@ export const CliUnavailable: React.FC<PropsWithChildren> = ({ children }) => {
       {children}
       {conditionalContents}
       <div className={styles.sideBySideButtons}>
-        <span className={styles.buttonWrapper}>
-          <PythonExtensionTooltip
-            dataTestId="install-tooltip"
-            disabled={canInstall}
-          >
-            <Button
-              disabled={!canInstall}
-              onClick={installDvc}
-              text="Install (pip)"
-            />
-          </PythonExtensionTooltip>
-        </span>
-        <span className={styles.buttonWrapper}>
-          <PythonExtensionTooltip
-            dataTestId="set-env-tooltip"
-            disabled={isPythonExtensionUsed}
-          >
-            <Button
-              disabled={!isPythonExtensionUsed}
-              onClick={updatePythonEnvironment}
-              text="Set Env"
-            />
-          </PythonExtensionTooltip>
-        </span>
-        <span className={styles.buttonWrapper}>
-          <Button onClick={setupWorkspace} text="Locate DVC" />
-        </span>
+        <Button
+          disabled={!canInstall}
+          onClick={installDvc}
+          text="Install (pip)"
+        />
+        <Button
+          disabled={!isPythonExtensionUsed}
+          onClick={updatePythonEnvironment}
+          text="Set Env"
+        />
+        <Button onClick={setupWorkspace} text="Locate DVC" />
       </div>
+      {isPythonExtensionUsed || (
+        <ShowExtension
+          className={styles.pythonExtInfo}
+          id="ms-python.python"
+          name="Python"
+          capabilities="detect or create python environments"
+        />
+      )}
     </EmptyState>
   )
 }

--- a/webview/src/setup/components/dvc/CliUnavailable.tsx
+++ b/webview/src/setup/components/dvc/CliUnavailable.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react'
+import React, { PropsWithChildren, ReactElement } from 'react'
 import { useSelector } from 'react-redux'
 import styles from './styles.module.scss'
 import { Button } from '../../../shared/components/button/Button'
@@ -13,12 +13,14 @@ import { Warning } from '../../../shared/components/icons'
 import { ExtensionLink } from '../shared/ExtensionLink'
 import Tooltip from '../../../shared/components/tooltip/Tooltip'
 
-const PythonExtensionTooltip: React.FC<
-  PropsWithChildren<{ disabled: boolean }>
-> = ({ disabled, children }) => (
+const PythonExtensionTooltip: React.FC<{
+  dataTestId: string
+  disabled: boolean
+  children: ReactElement
+}> = ({ dataTestId, disabled, children }) => (
   <Tooltip
     content={
-      <span>
+      <span data-testid={dataTestId}>
         Install the{' '}
         <ExtensionLink extensionId="ms-python.python">
           Python extension
@@ -77,21 +79,33 @@ export const CliUnavailable: React.FC<PropsWithChildren> = ({ children }) => {
       {children}
       {conditionalContents}
       <div className={styles.sideBySideButtons}>
-        <PythonExtensionTooltip disabled={canInstall}>
-          <Button
-            disabled={!canInstall}
-            onClick={installDvc}
-            text="Install (pip)"
-          />
-        </PythonExtensionTooltip>
-        <PythonExtensionTooltip disabled={isPythonExtensionUsed}>
-          <Button
-            disabled={!isPythonExtensionUsed}
-            onClick={updatePythonEnvironment}
-            text="Set Env"
-          />
-        </PythonExtensionTooltip>
-        <Button onClick={setupWorkspace} text="Locate DVC" />
+        <span className={styles.buttonWrapper}>
+          <PythonExtensionTooltip
+            dataTestId="install-tooltip"
+            disabled={canInstall}
+          >
+            <Button
+              disabled={!canInstall}
+              onClick={installDvc}
+              text="Install (pip)"
+            />
+          </PythonExtensionTooltip>
+        </span>
+        <span className={styles.buttonWrapper}>
+          <PythonExtensionTooltip
+            dataTestId="set-env-tooltip"
+            disabled={isPythonExtensionUsed}
+          >
+            <Button
+              disabled={!isPythonExtensionUsed}
+              onClick={updatePythonEnvironment}
+              text="Set Env"
+            />
+          </PythonExtensionTooltip>
+        </span>
+        <span className={styles.buttonWrapper}>
+          <Button onClick={setupWorkspace} text="Locate DVC" />
+        </span>
       </div>
     </EmptyState>
   )

--- a/webview/src/setup/components/dvc/styles.module.scss
+++ b/webview/src/setup/components/dvc/styles.module.scss
@@ -52,5 +52,4 @@
 .pythonExtInfo {
   max-width: 350px;
   margin: 8px auto;
-  font-size: 0.75rem;
 }

--- a/webview/src/setup/components/dvc/styles.module.scss
+++ b/webview/src/setup/components/dvc/styles.module.scss
@@ -45,6 +45,10 @@
   font-size: inherit;
 }
 
-.sideBySideButtons > *:not(:first-child) {
+.buttonWrapper {
+  display: inline-block;
+}
+
+.sideBySideButtons .buttonWrapper:not(:first-child) {
   margin-left: 15px;
 }

--- a/webview/src/setup/components/dvc/styles.module.scss
+++ b/webview/src/setup/components/dvc/styles.module.scss
@@ -45,10 +45,12 @@
   font-size: inherit;
 }
 
-.buttonWrapper {
-  display: inline-block;
+.sideBySideButtons *:not(:first-child) {
+  margin-left: 15px;
 }
 
-.sideBySideButtons .buttonWrapper:not(:first-child) {
-  margin-left: 15px;
+.pythonExtInfo {
+  max-width: 350px;
+  margin: 8px auto;
+  font-size: 0.75rem;
 }

--- a/webview/src/setup/components/remotes/ShowExtension.tsx
+++ b/webview/src/setup/components/remotes/ShowExtension.tsx
@@ -2,14 +2,13 @@ import React from 'react'
 import styles from './styles.module.scss'
 import { Icon } from '../../../shared/components/Icon'
 import { Extensions } from '../../../shared/components/icons'
+import { ExtensionLink } from '../shared/ExtensionLink'
 
 export const ShowExtension: React.FC<{
   capabilities: string
   id: string
   name: string
 }> = ({ capabilities, id, name }) => {
-  const idQuery = `"@id:${id}"`
-
   return (
     <p>
       <Icon
@@ -18,15 +17,8 @@ export const ShowExtension: React.FC<{
         height={16}
         className={styles.infoIcon}
       />{' '}
-      The{' '}
-      <a
-        href={`command:workbench.extensions.search?${encodeURIComponent(
-          idQuery
-        )}`}
-      >
-        {name}
-      </a>{' '}
-      extension can be used to <span>{capabilities}</span>.
+      The <ExtensionLink extensionId={id}>{name}</ExtensionLink> extension can
+      be used to <span>{capabilities}</span>.
     </p>
   )
 }

--- a/webview/src/setup/components/remotes/ShowExtension.tsx
+++ b/webview/src/setup/components/remotes/ShowExtension.tsx
@@ -8,9 +8,10 @@ export const ShowExtension: React.FC<{
   capabilities: string
   id: string
   name: string
-}> = ({ capabilities, id, name }) => {
+  className?: string
+}> = ({ capabilities, id, name, className }) => {
   return (
-    <p>
+    <p className={className}>
       <Icon
         icon={Extensions}
         width={16}

--- a/webview/src/setup/components/shared/ExtensionLink.tsx
+++ b/webview/src/setup/components/shared/ExtensionLink.tsx
@@ -1,0 +1,24 @@
+import React, { PropsWithChildren } from 'react'
+import type { HTMLAttributes } from 'react'
+
+interface ExtensionLinkProps extends HTMLAttributes<HTMLAnchorElement> {
+  extensionId: string
+}
+
+export const ExtensionLink: React.FC<PropsWithChildren<ExtensionLinkProps>> = ({
+  extensionId,
+  children,
+  ...props
+}) => {
+  const idQuery = `"@id:${extensionId}"`
+  return (
+    <a
+      href={`command:workbench.extensions.search?${encodeURIComponent(
+        idQuery
+      )}`}
+      {...props}
+    >
+      {children}
+    </a>
+  )
+}

--- a/webview/src/shared/components/button/Button.tsx
+++ b/webview/src/shared/components/button/Button.tsx
@@ -9,6 +9,7 @@ export type ButtonProps = {
   isNested?: boolean
   children?: React.ReactNode
   disabled?: boolean
+  className?: string
 }
 
 export const Button: React.FC<ButtonProps> = ({


### PR DESCRIPTION
* add link to python extension if users don't use it and disable buttons instead of removing completely

## Demo

~https://github.com/iterative/vscode-dvc/assets/43496356/aec5ac6e-d39b-4799-aa52-3468a0fd8e03~

https://github.com/iterative/vscode-dvc/assets/43496356/63d0546c-35cc-408c-bdab-a55b7e4eaac7

<img width="678" alt="Screenshot 2023-06-19 at 11 01 48 AM" src="https://github.com/iterative/vscode-dvc/assets/43496356/794a8add-f9b5-44c1-b61c-f0189996c397">


Part of #3935 

