### PR TITLE
Update the logic to identify a failed process

### DIFF
--- a/extension/src/cli/index.ts
+++ b/extension/src/cli/index.ts
@@ -193,7 +193,7 @@ export class Cli extends Disposable implements ICli {
       {
         ...baseEvent,
         duration,
-        errorOutput: all || cliError.stderr,
+        errorOutput: all || cliError.stderr || error.message,
         exitCode: cliError.exitCode
       },
       this.processCompleted

--- a/extension/src/cli/util.ts
+++ b/extension/src/cli/util.ts
@@ -23,14 +23,14 @@ export const notifyOutput = (
 }
 
 export const notifyCompleted = (
-  { command, pid, cwd, duration, exitCode, errorOutput: stderr }: CliResult,
+  { command, pid, cwd, duration, exitCode, errorOutput }: CliResult,
   processCompleted: EventEmitter<CliResult>
 ): void =>
   processCompleted.fire({
     command,
     cwd,
     duration,
-    errorOutput: stderr?.replace(/\n+/g, '\n'),
+    errorOutput: errorOutput?.replace(/\n+/g, '\n'),
     exitCode,
     pid
   })

--- a/extension/src/vscode/outputChannel.ts
+++ b/extension/src/vscode/outputChannel.ts
@@ -42,10 +42,9 @@ export class OutputChannel extends Disposable {
     this.dispose.track(
       cli.onDidCompleteProcess(
         ({ command, duration, exitCode, pid, errorOutput }) => {
-          const processStatus =
-            exitCode && errorOutput
-              ? ProcessStatus.FAILED
-              : ProcessStatus.COMPLETED
+          const processStatus = this.assumeFailed(exitCode, errorOutput)
+            ? ProcessStatus.FAILED
+            : ProcessStatus.COMPLETED
 
           const baseOutput = this.getBaseOutput(pid, command, processStatus)
           const completionOutput = this.getCompletionOutput(
@@ -86,10 +85,17 @@ export class OutputChannel extends Disposable {
 
     completionOutput += ` (${duration}ms)`
 
-    if (exitCode && errorOutput) {
+    if (this.assumeFailed(exitCode, errorOutput)) {
       completionOutput += `\n${errorOutput}`
     }
 
     return completionOutput
+  }
+
+  private assumeFailed(
+    exitCode: number | null,
+    errorOutput: string | undefined
+  ): errorOutput is string {
+    return exitCode !== 0 && !!errorOutput
   }
 }


### PR DESCRIPTION
I discovered while digging into #4129. It appears that if a process fails to spawn on a UNIX system an exit code is not provided which meant that we logged the process as completed instead of failed. This PR updates the logic.

### Demo


https://github.com/iterative/vscode-dvc/assets/37993418/635e50eb-7d45-40c2-ae46-f33763e39112

