### PR TITLE
Rename `firstThreeColumns`

### DIFF
--- a/extension/src/experiments/columns/model.test.ts
+++ b/extension/src/experiments/columns/model.test.ts
@@ -282,7 +282,7 @@ describe('ColumnsModel', () => {
       )
       await model.transformAndSet(outputFixture)
 
-      expect(model.getFirstThreeColumnOrder()).toStrictEqual([
+      expect(model.getSummaryColumnOrder()).toStrictEqual([
         'params:params.yaml:dvc_logs_dir',
         'params:params.yaml:process.threshold',
         'params:params.yaml:process.test_arg',
@@ -292,7 +292,7 @@ describe('ColumnsModel', () => {
 
       model.toggleStatus('params:params.yaml:dvc_logs_dir')
 
-      expect(model.getFirstThreeColumnOrder()).toStrictEqual([
+      expect(model.getSummaryColumnOrder()).toStrictEqual([
         'params:params.yaml:process.threshold',
         'params:params.yaml:process.test_arg',
         'params:params.yaml:dropout',
@@ -309,7 +309,7 @@ describe('ColumnsModel', () => {
       )
       await model.transformAndSet(outputFixture)
 
-      expect(model.getFirstThreeColumnOrder()).toStrictEqual([
+      expect(model.getSummaryColumnOrder()).toStrictEqual([
         'params:params.yaml:code_names',
         'params:params.yaml:epochs',
         'params:params.yaml:learning_rate',
@@ -320,7 +320,7 @@ describe('ColumnsModel', () => {
 
       model.toggleStatus('params:params.yaml:code_names')
 
-      expect(model.getFirstThreeColumnOrder()).toStrictEqual([
+      expect(model.getSummaryColumnOrder()).toStrictEqual([
         'params:params.yaml:epochs',
         'params:params.yaml:learning_rate',
         'params:params.yaml:dvc_logs_dir',

--- a/extension/src/experiments/columns/model.ts
+++ b/extension/src/experiments/columns/model.ts
@@ -44,7 +44,7 @@ export class ColumnsModel extends PathSelectionModel<Column> {
     return this.columnOrderState
   }
 
-  public getFirstThreeColumnOrder(): string[] {
+  public getSummaryColumnOrder(): string[] {
     const metrics: string[] = []
     const params: string[] = []
 

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -340,7 +340,7 @@ export class Experiments extends BaseRepository<TableData> {
 
     const selected = await pickExperimentsToPlot(
       experiments,
-      this.columns.getFirstThreeColumnOrder()
+      this.columns.getSummaryColumnOrder()
     )
     if (!selected) {
       return
@@ -365,14 +365,14 @@ export class Experiments extends BaseRepository<TableData> {
   public pickCommitOrExperiment() {
     return pickExperiment(
       this.experiments.getCommitsAndExperiments(),
-      this.getFirstThreeColumnOrder()
+      this.getSummaryColumnOrder()
     )
   }
 
   public pickRunningExperiments() {
     return pickExperiments(
       this.experiments.getRunningExperiments(),
-      this.getFirstThreeColumnOrder(),
+      this.getSummaryColumnOrder(),
       Title.SELECT_EXPERIMENTS_STOP
     )
   }
@@ -380,7 +380,7 @@ export class Experiments extends BaseRepository<TableData> {
   public pickExperimentsToRemove() {
     return pickExperiments(
       this.experiments.getExperimentsAndQueued(),
-      this.getFirstThreeColumnOrder(),
+      this.getSummaryColumnOrder(),
       Title.SELECT_EXPERIMENTS_REMOVE
     )
   }
@@ -388,7 +388,7 @@ export class Experiments extends BaseRepository<TableData> {
   public pickExperimentsToPush() {
     return pickExperiments(
       this.experiments.getExperiments(),
-      this.getFirstThreeColumnOrder(),
+      this.getSummaryColumnOrder(),
       Title.SELECT_EXPERIMENTS_PUSH
     )
   }
@@ -502,8 +502,8 @@ export class Experiments extends BaseRepository<TableData> {
     return this.experiments.getCliError()
   }
 
-  public getFirstThreeColumnOrder() {
-    return this.columns.getFirstThreeColumnOrder()
+  public getSummaryColumnOrder() {
+    return this.columns.getSummaryColumnOrder()
   }
 
   public getColumnTerminalNodes() {
@@ -584,7 +584,7 @@ export class Experiments extends BaseRepository<TableData> {
 
     return await pickExperiment(
       this.experiments.getCombinedList(),
-      this.getFirstThreeColumnOrder(),
+      this.getSummaryColumnOrder(),
       Title.SELECT_BASE_EXPERIMENT
     )
   }

--- a/extension/src/experiments/model/quickPick.ts
+++ b/extension/src/experiments/model/quickPick.ts
@@ -20,18 +20,18 @@ type QuickPickItemAccumulator = {
 
 const getItem = (
   experiment: Experiment,
-  firstThreeColumnOrder: string[]
+  summaryColumnOrder: string[]
 ): QuickPickItemWithValue<Experiment | undefined> => ({
-  detail: getColumnPathsQuickPickDetail(experiment, firstThreeColumnOrder),
+  detail: getColumnPathsQuickPickDetail(experiment, summaryColumnOrder),
   label: experiment.label,
   value: experiment
 })
 
 const getItemWithDescription = (
   experiment: Experiment,
-  firstThreeColumnOrder: string[]
+  summaryColumnOrder: string[]
 ) => {
-  const item = getItem(experiment, firstThreeColumnOrder)
+  const item = getItem(experiment, summaryColumnOrder)
   if (experiment.description) {
     item.description = `${experiment.commit ? '$(git-commit)' : ''}${
       experiment.description
@@ -43,10 +43,10 @@ const getItemWithDescription = (
 const collectItem = (
   acc: QuickPickItemAccumulator,
   experiment: Experiment,
-  firstThreeColumnOrder: string[],
+  summaryColumnOrder: string[],
   transformer = getItem
 ) => {
-  const item = transformer(experiment, firstThreeColumnOrder)
+  const item = transformer(experiment, summaryColumnOrder)
   acc.items.push(item)
   if (experiment.selected) {
     acc.selectedItems.push(item)
@@ -56,7 +56,7 @@ const collectItem = (
 
 const collectItems = (
   experiments: Experiment[],
-  firstThreeColumnOrder: string[]
+  summaryColumnOrder: string[]
 ) => {
   const acc: QuickPickItemAccumulator = {
     items: [],
@@ -64,7 +64,7 @@ const collectItems = (
   }
 
   for (const experiment of experiments) {
-    collectItem(acc, experiment, firstThreeColumnOrder, getItemWithDescription)
+    collectItem(acc, experiment, summaryColumnOrder, getItemWithDescription)
   }
 
   return acc
@@ -72,16 +72,13 @@ const collectItems = (
 
 export const pickExperimentsToPlot = (
   experiments: Experiment[],
-  firstThreeColumnOrder: string[]
+  summaryColumnOrder: string[]
 ): Promise<Experiment[] | undefined> => {
   if (!definedAndNonEmpty(experiments)) {
     return Toast.showError(noExperimentsToSelect)
   }
 
-  const { items, selectedItems } = collectItems(
-    experiments,
-    firstThreeColumnOrder
-  )
+  const { items, selectedItems } = collectItems(experiments, summaryColumnOrder)
 
   return quickPickLimitedValues<Experiment | undefined>(
     items,
@@ -101,14 +98,14 @@ type ExperimentItem = {
 
 const getExperimentItems = (
   experiments: Experiment[],
-  firstThreeColumnOrder: string[]
+  summaryColumnOrder: string[]
 ): ExperimentItem[] =>
   experiments.map(experiment => {
     const { label, id, description, commit } = experiment
     return {
       description:
         description && `${commit ? '$(git-commit)' : ''}${description}`,
-      detail: getColumnPathsQuickPickDetail(experiment, firstThreeColumnOrder),
+      detail: getColumnPathsQuickPickDetail(experiment, summaryColumnOrder),
       label,
       value: id
     }
@@ -121,7 +118,7 @@ const pickExperimentOrExperiments = <
   T extends QuickPickExperiment | QuickPickExperiments
 >(
   experiments: Experiment[],
-  firstThreeColumnOrder: string[],
+  summaryColumnOrder: string[],
   title: Title,
   quickPick: T
 ): ReturnType<T> | Promise<undefined> => {
@@ -129,7 +126,7 @@ const pickExperimentOrExperiments = <
     return Toast.showError(noExperimentsToSelect)
   }
 
-  const items = getExperimentItems(experiments, firstThreeColumnOrder)
+  const items = getExperimentItems(experiments, summaryColumnOrder)
 
   return quickPick(items, {
     matchOnDescription: true,
@@ -140,24 +137,24 @@ const pickExperimentOrExperiments = <
 
 export const pickExperiment = (
   experiments: Experiment[],
-  firstThreeColumnOrder: string[],
+  summaryColumnOrder: string[],
   title: Title = Title.SELECT_EXPERIMENT
 ): Thenable<string | undefined> =>
   pickExperimentOrExperiments<QuickPickExperiment>(
     experiments,
-    firstThreeColumnOrder,
+    summaryColumnOrder,
     title,
     quickPickValue
   )
 
 export const pickExperiments = (
   experiments: Experiment[],
-  firstThreeColumnOrder: string[],
+  summaryColumnOrder: string[],
   title: Title = Title.SELECT_EXPERIMENTS
 ): Thenable<string[] | undefined> =>
   pickExperimentOrExperiments<QuickPickExperiments>(
     experiments,
-    firstThreeColumnOrder,
+    summaryColumnOrder,
     title,
     quickPickManyValues
   )

--- a/extension/src/experiments/model/tree.test.ts
+++ b/extension/src/experiments/model/tree.test.ts
@@ -35,7 +35,7 @@ const {
   mockedGetCommitExperiments,
   mockedGetCliError,
   mockedGetDvcRoots,
-  mockedGetFirstThreeColumnOrder,
+  mockedGetSummaryColumnOrder,
   mockedGetWorkspaceAndCommits
 } = buildMockedExperiments()
 
@@ -179,7 +179,7 @@ describe('ExperimentsTree', () => {
         .mockReturnValueOnce(experiments)
 
       mockedGetDvcRoots.mockReturnValueOnce(['repo'])
-      mockedGetFirstThreeColumnOrder.mockReturnValue([])
+      mockedGetSummaryColumnOrder.mockReturnValue([])
 
       const children = await experimentsTree.getChildren()
 
@@ -294,7 +294,7 @@ describe('ExperimentsTree', () => {
         }
       ]
       mockedGetCommitExperiments.mockReturnValueOnce(experimentsByCommit)
-      mockedGetFirstThreeColumnOrder.mockReturnValue([])
+      mockedGetSummaryColumnOrder.mockReturnValue([])
 
       const children = await experimentsTree.getChildren(commit)
 
@@ -391,7 +391,7 @@ describe('ExperimentsTree', () => {
         .mockReturnValueOnce(experiments)
         .mockReturnValueOnce(experiments)
       mockedGetDvcRoots.mockReturnValueOnce(['repo'])
-      mockedGetFirstThreeColumnOrder.mockReturnValue([
+      mockedGetSummaryColumnOrder.mockReturnValue([
         'params:params.yaml:epochs',
         'params:params.yaml:featurize.random_value'
       ])
@@ -469,7 +469,7 @@ describe('ExperimentsTree', () => {
         .mockReturnValueOnce(experiments)
         .mockReturnValueOnce(experiments)
       mockedGetDvcRoots.mockReturnValueOnce(['repo'])
-      mockedGetFirstThreeColumnOrder.mockReturnValue([])
+      mockedGetSummaryColumnOrder.mockReturnValue([])
 
       const experimentsTree = new ExperimentsTree(
         mockedExperiments,

--- a/extension/src/experiments/model/tree.ts
+++ b/extension/src/experiments/model/tree.ts
@@ -236,7 +236,7 @@ export class ExperimentsTree
       tooltip: this.getTooltip(
         experiment.error,
         experiment,
-        this.experiments.getRepository(dvcRoot).getFirstThreeColumnOrder()
+        this.experiments.getRepository(dvcRoot).getSummaryColumnOrder()
       ),
       type: experiment.type
     }
@@ -343,8 +343,8 @@ export class ExperimentsTree
     return [...this.view.selection]
   }
 
-  private getTooltipTable(experiment: Experiment, firstThreeColumns: string[]) {
-    const data = getDataFromColumnPaths(experiment, firstThreeColumns)
+  private getTooltipTable(experiment: Experiment, summaryColumns: string[]) {
+    const data = getDataFromColumnPaths(experiment, summaryColumns)
       .map(
         ({ truncatedValue: value, columnPath }) =>
           `| ${truncateFromLeft(columnPath, 30)} | ${value} |\n`
@@ -356,14 +356,14 @@ export class ExperimentsTree
   private getTooltip(
     error: string | undefined,
     experiment: Experiment,
-    firstThreeColumns: string[]
+    summaryColumns: string[]
   ) {
     if (!error) {
-      if (firstThreeColumns.length === 0) {
+      if (summaryColumns.length === 0) {
         return
       }
 
-      return this.getTooltipTable(experiment, firstThreeColumns)
+      return this.getTooltipTable(experiment, summaryColumns)
     }
 
     return getErrorTooltip(error)

--- a/extension/src/plots/model/index.test.ts
+++ b/extension/src/plots/model/index.test.ts
@@ -34,15 +34,15 @@ describe('plotsModel', () => {
       DEFAULT_SECTION_NB_ITEMS_PER_ROW_OR_WIDTH
   })
   const mockedGetSelectedRevisions = jest.fn()
-  const mockedGetFirstThreeColumnOrder = jest.fn()
-  mockedGetFirstThreeColumnOrder.mockReturnValue([])
+  const mockedGetSummaryColumnOrder = jest.fn()
+  mockedGetSummaryColumnOrder.mockReturnValue([])
 
   beforeEach(() => {
     model = new PlotsModel(
       exampleDvcRoot,
       {
-        getFirstThreeColumnOrder: mockedGetFirstThreeColumnOrder,
         getSelectedRevisions: mockedGetSelectedRevisions,
+        getSummaryColumnOrder: mockedGetSummaryColumnOrder,
         isReady: () => Promise.resolve(undefined)
       } as unknown as Experiments,
       {
@@ -68,8 +68,8 @@ describe('plotsModel', () => {
     model = new PlotsModel(
       exampleDvcRoot,
       {
-        getFirstThreeColumnOrder: mockedGetFirstThreeColumnOrder,
         getSelectedRevisions: mockedGetSelectedRevisions,
+        getSummaryColumnOrder: mockedGetSummaryColumnOrder,
         isReady: () => Promise.resolve(undefined)
       } as unknown as Experiments,
       { getImageErrors: () => undefined } as unknown as ErrorsModel,

--- a/extension/src/plots/model/index.ts
+++ b/extension/src/plots/model/index.ts
@@ -12,7 +12,7 @@ import {
   collectImageUrl,
   collectIdShas
 } from './collect'
-import { getRevisionFirstThreeColumns } from './util'
+import { getRevisionSummaryColumns } from './util'
 import {
   checkForCustomPlotOptions,
   cleanupOldOrderValue,
@@ -206,12 +206,12 @@ export class PlotsModel extends ModelWithPersistence {
         displayColor,
         errors: this.errors.getRevisionErrors(id),
         fetched: this.fetchedRevs.has(id),
-        firstThreeColumns: getRevisionFirstThreeColumns(
-          this.experiments.getFirstThreeColumnOrder(),
-          experiment
-        ),
         id,
-        label
+        label,
+        summaryColumns: getRevisionSummaryColumns(
+          this.experiments.getSummaryColumnOrder(),
+          experiment
+        )
       }
 
       if (commit) {

--- a/extension/src/plots/model/util.ts
+++ b/extension/src/plots/model/util.ts
@@ -1,12 +1,12 @@
 import { getDataFromColumnPaths } from '../../experiments/model/util'
 import { Experiment } from '../../experiments/webview/contract'
-import { RevisionFirstThreeColumns } from '../webview/contract'
+import { RevisionSummaryColumns } from '../webview/contract'
 
-export const getRevisionFirstThreeColumns = (
-  firstThreeColumns: string[],
+export const getRevisionSummaryColumns = (
+  summaryColumns: string[],
   experiment: Experiment
-): RevisionFirstThreeColumns =>
-  getDataFromColumnPaths(experiment, firstThreeColumns).map(
+): RevisionSummaryColumns =>
+  getDataFromColumnPaths(experiment, summaryColumns).map(
     ({ columnPath: path, value, type }) => ({
       path,
       type,

--- a/extension/src/plots/webview/contract.ts
+++ b/extension/src/plots/webview/contract.ts
@@ -49,7 +49,7 @@ export type ComparisonPlots = {
   revisions: ComparisonRevisionData
 }[]
 
-export type RevisionFirstThreeColumns = Array<{
+export type RevisionSummaryColumns = Array<{
   path: string
   value: string | number
   type: string
@@ -60,7 +60,7 @@ export type Revision = {
   displayColor: Color
   errors?: string[]
   fetched: boolean
-  firstThreeColumns: RevisionFirstThreeColumns
+  summaryColumns: RevisionSummaryColumns
   description: string | undefined
   id: string
   label: string

--- a/extension/src/test/fixtures/plotsDiff/index.ts
+++ b/extension/src/test/fixtures/plotsDiff/index.ts
@@ -531,7 +531,7 @@ export const getRevisions = (): Revision[] => {
       displayColor: workspace,
       errors: undefined,
       fetched: true,
-      firstThreeColumns: [
+      summaryColumns: [
         {
           path: 'params.yaml:code_names',
           type: ColumnType.PARAMS,
@@ -568,7 +568,7 @@ export const getRevisions = (): Revision[] => {
       commit: 'Update version and CHANGELOG for release (#4022) ...',
       errors: undefined,
       fetched: true,
-      firstThreeColumns: [
+      summaryColumns: [
         {
           path: 'params.yaml:code_names',
           type: ColumnType.PARAMS,
@@ -608,7 +608,7 @@ export const getRevisions = (): Revision[] => {
     {
       errors: undefined,
       fetched: true,
-      firstThreeColumns: [
+      summaryColumns: [
         {
           path: 'params.yaml:code_names',
           type: ColumnType.PARAMS,
@@ -648,7 +648,7 @@ export const getRevisions = (): Revision[] => {
     {
       errors: undefined,
       fetched: true,
-      firstThreeColumns: [
+      summaryColumns: [
         {
           path: 'params.yaml:code_names',
           type: ColumnType.PARAMS,
@@ -688,7 +688,7 @@ export const getRevisions = (): Revision[] => {
     {
       errors: undefined,
       fetched: true,
-      firstThreeColumns: [
+      summaryColumns: [
         {
           path: 'params.yaml:code_names',
           type: ColumnType.PARAMS,

--- a/extension/src/test/util/jest/index.ts
+++ b/extension/src/test/util/jest/index.ts
@@ -39,7 +39,7 @@ export const buildMockedExperiments = () => {
   const mockedGetSorts = jest.fn()
   const mockedGetSelectedRevisions = jest.fn()
   const mockedGetCommitExperiments = jest.fn()
-  const mockedGetFirstThreeColumnOrder = jest.fn()
+  const mockedGetSummaryColumnOrder = jest.fn()
   const mockedExperiments = {
     columnsChanged: mockedColumnsChanged,
     experimentsChanged: mockedExperimentsChanged,
@@ -51,9 +51,9 @@ export const buildMockedExperiments = () => {
         getCommitExperiments: mockedGetCommitExperiments,
         getFilter: mockedGetFilter,
         getFilters: mockedGetFilters,
-        getFirstThreeColumnOrder: mockedGetFirstThreeColumnOrder,
         getSelectedRevisions: mockedGetSelectedRevisions,
         getSorts: mockedGetSorts,
+        getSummaryColumnOrder: mockedGetSummaryColumnOrder,
         getWorkspaceAndCommits: mockedGetWorkspaceAndCommits
       } as unknown as Experiments),
     isReady: () => true
@@ -70,9 +70,9 @@ export const buildMockedExperiments = () => {
     mockedGetDvcRoots,
     mockedGetFilter,
     mockedGetFilters,
-    mockedGetFirstThreeColumnOrder,
     mockedGetSelectedRevisions,
     mockedGetSorts,
+    mockedGetSummaryColumnOrder,
     mockedGetWorkspaceAndCommits
   }
 }

--- a/webview/src/plots/components/App.test.tsx
+++ b/webview/src/plots/components/App.test.tsx
@@ -243,9 +243,9 @@ describe('App', () => {
             description: '[exp-a270a]',
             displayColor: '#945dd6',
             fetched: false,
-            firstThreeColumns: [],
             id: 'ad2b5ec',
-            label: 'ad2b5ec'
+            label: 'ad2b5ec',
+            summaryColumns: []
           }
         ],
         width: DEFAULT_NB_ITEMS_PER_ROW
@@ -259,9 +259,9 @@ describe('App', () => {
           description: '[exp-a270a]',
           displayColor: '#945dd6',
           fetched: false,
-          firstThreeColumns: [],
           id: 'ad2b5ec',
-          label: 'ad2b5ec'
+          label: 'ad2b5ec',
+          summaryColumns: []
         }
       ],
       template: null

--- a/webview/src/plots/components/comparisonTable/ComparisonTable.test.tsx
+++ b/webview/src/plots/components/comparisonTable/ComparisonTable.test.tsx
@@ -289,9 +289,9 @@ describe('ComparisonTable', () => {
           description: undefined,
           displayColor: '#f56565',
           fetched: true,
-          firstThreeColumns: [],
           id: 'noData',
-          label: revisionWithNoData
+          label: revisionWithNoData,
+          summaryColumns: []
         }
       ]
     })
@@ -322,9 +322,9 @@ describe('ComparisonTable', () => {
           description: undefined,
           displayColor: '#f56565',
           fetched: true,
-          firstThreeColumns: [],
           id: revisionWithNoData,
-          label: 'noData'
+          label: 'noData',
+          summaryColumns: []
         }
       ]
     })

--- a/webview/src/plots/components/ribbon/RibbonBlock.tsx
+++ b/webview/src/plots/components/ribbon/RibbonBlock.tsx
@@ -36,7 +36,7 @@ export const RibbonBlock: React.FC<RibbonBlockProps> = ({
     displayColor,
     errors,
     fetched,
-    firstThreeColumns,
+    summaryColumns,
     id,
     label
   } = revision
@@ -78,7 +78,7 @@ export const RibbonBlock: React.FC<RibbonBlockProps> = ({
     </li>
   )
 
-  return firstThreeColumns.length === 0 && !commit ? (
+  return summaryColumns.length === 0 && !commit ? (
     mainContent
   ) : (
     <RibbonBlockTooltip revision={revision}>{mainContent}</RibbonBlockTooltip>

--- a/webview/src/plots/components/ribbon/RibbonBlockTooltip.tsx
+++ b/webview/src/plots/components/ribbon/RibbonBlockTooltip.tsx
@@ -13,7 +13,7 @@ export const RibbonBlockTooltip: React.FC<{
   revision: Revision
   children: ReactElement
 }> = ({ revision, children }) => {
-  const { firstThreeColumns, commit, errors } = revision
+  const { summaryColumns, commit, errors } = revision
 
   const tooltipContent = (
     <div>
@@ -24,7 +24,7 @@ export const RibbonBlockTooltip: React.FC<{
       )}
       <table>
         <tbody>
-          {firstThreeColumns.map(({ path, value, type }) => (
+          {summaryColumns.map(({ path, value, type }) => (
             <tr key={path}>
               <td className={cx(styles.tooltipColumn, styles[`${type}Key`])}>
                 <span className={styles.tooltipPathWrapper}>{path}</span>
@@ -50,7 +50,7 @@ export const RibbonBlockTooltip: React.FC<{
         <p
           className={cx(
             styles.commitMessage,
-            firstThreeColumns.length > 0 && styles.addTopBorder
+            summaryColumns.length > 0 && styles.addTopBorder
           )}
         >
           <Icon width={14} height={14} icon={GitCommit} />


### PR DESCRIPTION
# 2/2 `main` <= #4155 <= this

* renames `firstThreeColumns` (and related variables/keys) to `summaryColumns`

Followup to https://github.com/iterative/vscode-dvc/pull/4135#pullrequestreview-1487659893
