### PR TITLE
Bypass process manager debounce in refresh plot revisions tests

### DIFF
--- a/extension/src/test/suite/plots/index.test.ts
+++ b/extension/src/test/suite/plots/index.test.ts
@@ -582,6 +582,7 @@ suite('Plots Test Suite', () => {
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should handle a message to manually refresh plot revisions from the webview', async () => {
+      const mockNow = getMockNow()
       const { data, plots, mockPlotsDiff, messageSpy } = await buildPlots({
         disposer: disposable,
         plotsDiff: plotsDiffFixture
@@ -600,6 +601,8 @@ suite('Plots Test Suite', () => {
       const dataUpdateEvent = new Promise(resolve =>
         data.onDidUpdate(() => resolve(undefined))
       )
+
+      bypassProcessManagerDebounce(mockNow)
 
       mockMessageReceived.fire({
         type: MessageFromWebviewType.REFRESH_REVISIONS

--- a/extension/src/test/suite/plots/paths/tree.test.ts
+++ b/extension/src/test/suite/plots/paths/tree.test.ts
@@ -17,6 +17,7 @@ import {
 } from '../../../../vscode/quickPick'
 import { PlotPath } from '../../../../plots/paths/collect'
 import { REVISIONS } from '../../../fixtures/plotsDiff'
+import { bypassProcessManagerDebounce, getMockNow } from '../../util'
 
 suite('Plots Paths Tree Test Suite', () => {
   const disposable = Disposable.fn()
@@ -131,17 +132,21 @@ suite('Plots Paths Tree Test Suite', () => {
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should be able to refresh revision data for all plots using dvc.views.plots.refreshPlots', async () => {
+      const mockNow = getMockNow()
       const { data, mockPlotsDiff, plots } = await buildPlots({
         disposer: disposable,
         plotsDiff: plotsDiffFixture
       })
 
-      await plots.showWebview()
+      const webview = await plots.showWebview()
+      await webview.isReady()
 
       const dataUpdated = new Promise(resolve =>
         disposable.track(data.onDidUpdate(() => resolve(undefined)))
       )
       mockPlotsDiff.resetHistory()
+
+      bypassProcessManagerDebounce(mockNow)
 
       await commands.executeCommand(RegisteredCommands.PLOTS_REFRESH)
       await dataUpdated


### PR DESCRIPTION
# 1/2 `main` <- this <- #4165

These two tests started failing locally for me. 