### PR TITLE
Fix table webview stuck on error page

### DIFF
--- a/extension/src/experiments/webview/contract.ts
+++ b/extension/src/experiments/webview/contract.ts
@@ -93,7 +93,7 @@ export interface Column extends ColumnAggregateData {
 
 export type TableData = {
   changes: string[]
-  cliError: string | undefined
+  cliError: string | null
   columnOrder: string[]
   columns: Column[]
   columnWidths: Record<string, number>

--- a/extension/src/experiments/webview/messages.ts
+++ b/extension/src/experiments/webview/messages.ts
@@ -255,10 +255,10 @@ export class WebviewMessages {
     return this.update()
   }
 
-  private getWebviewData() {
+  private getWebviewData(): TableData {
     return {
       changes: this.columns.getChanges(),
-      cliError: this.experiments.getCliError(),
+      cliError: this.experiments.getCliError() || null,
       columnOrder: this.columns.getColumnOrder(),
       columnWidths: this.columns.getColumnWidths(),
       columns: this.columns.getSelected(),

--- a/extension/src/test/fixtures/expShow/base/tableData.ts
+++ b/extension/src/test/fixtures/expShow/base/tableData.ts
@@ -3,7 +3,7 @@ import rowsFixture from './rows'
 import columnsFixture from './columns'
 
 const tableDataFixture: TableData = {
-  cliError: undefined,
+  cliError: null,
   changes: [],
   columnOrder: [],
   columns: columnsFixture,

--- a/webview/src/experiments/state/tableDataSlice.ts
+++ b/webview/src/experiments/state/tableDataSlice.ts
@@ -16,7 +16,7 @@ export interface TableDataState extends TableData {
 export const tableDataInitialState: TableDataState = {
   branches: ['current'],
   changes: [],
-  cliError: undefined,
+  cliError: null,
   columnOrder: [],
   columnWidths: {},
   columns: [],
@@ -49,7 +49,7 @@ export const tableDataSlice = createSlice({
     updateChanges: (state, action: PayloadAction<string[]>) => {
       state.changes = action.payload
     },
-    updateCliError: (state, action: PayloadAction<string | undefined>) => {
+    updateCliError: (state, action: PayloadAction<string | null>) => {
       state.cliError = action.payload
     },
     updateColumnOrder: (state, action: PayloadAction<string[]>) => {

--- a/webview/src/stories/Table.stories.tsx
+++ b/webview/src/stories/Table.stories.tsx
@@ -33,7 +33,7 @@ import {
 const tableData: TableDataState = {
   branches: [undefined, 'main'],
   changes: workspaceChangesFixture,
-  cliError: undefined,
+  cliError: null,
   columnOrder: [],
   columnWidths: {
     'params:params.yaml:dvc_logs_dir': 300


### PR DESCRIPTION
* Keeps the table updating correctly when `cliError` is undefined

## Demo

https://github.com/iterative/vscode-dvc/assets/43496356/b31e0de4-f087-4d83-b7e1-7a5dff9cce70

Fixes #4176 