### PR TITLE
Fix force SCM action regex

### DIFF
--- a/extension/src/cli/dvc/output.ts
+++ b/extension/src/cli/dvc/output.ts
@@ -1,3 +1,3 @@
 export const Prompt = {
-  TRY_FORCE: /Use\s['`]-f.*?['`]\sto\sforce\./
+  TRY_FORCE: /Use\s['`](-f|--force).*?['`]\sto\sforce\./
 } as const

--- a/extension/src/repository/commands/index.test.ts
+++ b/extension/src/repository/commands/index.test.ts
@@ -82,8 +82,28 @@ describe('getResourceCommand', () => {
     expect(mockedFunc).toHaveBeenCalledTimes(1)
   })
 
-  it('should return a function that calls warnOfConsequences if the first function fails with a force prompt', async () => {
-    const stderr = `I deed, but ${TRY_FORCE}`
+  it('should return a function that calls warnOfConsequences if the first function fails with a -f prompt', async () => {
+    const stderr = 'I deed. Use `-f` to force.'
+    const userCancelled = undefined
+    mockedFunc.mockRejectedValueOnce({ stderr })
+    mockedGetWarningResponse.mockResolvedValueOnce(userCancelled)
+
+    const commandToRegister = getResourceCommand(
+      mockedInternalCommands,
+      mockedCommandId
+    )
+
+    const undef = await commandToRegister({
+      dvcRoot: mockedDvcRoot,
+      resourceUri: { fsPath: mockedTarget } as Uri
+    })
+
+    expect(undef).toStrictEqual(userCancelled)
+    expect(mockedFunc).toHaveBeenCalledTimes(1)
+  })
+
+  it('should return a function that calls warnOfConsequences if the first function fails with a --force prompt', async () => {
+    const stderr = 'I deed, but Use `--force` to force.'
     const userCancelled = undefined
     mockedFunc.mockRejectedValueOnce({ stderr })
     mockedGetWarningResponse.mockResolvedValueOnce(userCancelled)


### PR DESCRIPTION
DVC updated the free text that we were relying on to trigger a "force" checkout. This PR fixes the regex test so that we trigger the user prompt.

### Demo


https://github.com/iterative/vscode-dvc/assets/37993418/bd9d4c20-b1cd-4c55-87d1-d28114efe938

