### PR TITLE
Add dvc.yaml pipeline snippets

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -31,7 +31,8 @@
     "Machine Learning",
     "Data Science",
     "Visualization",
-    "SCM Providers"
+    "SCM Providers",
+    "Snippets"
   ],
   "galleryBanner": {
     "color": "#333",
@@ -1380,6 +1381,12 @@
         }
       ]
     },
+    "snippets": [
+      {
+        "language": "yaml",
+        "path": "./snippets/dvc-yaml.code-snippets"
+      }
+    ],
     "viewsContainers": {
       "activitybar": [
         {

--- a/extension/snippets/dvc-yaml.code-snippets
+++ b/extension/snippets/dvc-yaml.code-snippets
@@ -1,0 +1,55 @@
+{
+  "Get Started with DVC pipelines": {
+    "prefix": "dvc-help",
+    "body": [
+      "# Snippets are provided by the DVC for VS Code extension to help with building dvc.yaml pipelines.",
+      "# These snippets are all prefixed with dvc-.",
+      "# Type dvc- in the editor to see the list of available snippets.",
+      "# Each snippet is designed to give pointers on basic usage.",
+      "# For further details on building pipelines visit https://dvc.org/doc/user-guide/project-structure/dvcyaml-files",
+      "# If the redhat.yaml extension is installed then on-hover support will be provided for each of the keys in a dvc.yaml file."
+    ],
+    "description": "Information on the support provided for building dvc.yaml pipelines"
+  },
+  "Pipeline Stage Template": {
+    "prefix": "dvc-pipeline-stage",
+    "body": [
+      "  ${1:stage name}:",
+      "    cmd: ${2:command for the stage, e.g. python train.py}",
+      "    deps:",
+      "      - ${3:list dependencies for the stage, e.g. train.py}",
+      "    params:",
+      "      - ${4:list params file(s) for the stage, e.g params.yaml}",
+      "    metrics:",
+      "      - ${5:list metric file(s) for the stage, e.g metrics.json}",
+      "    outs:",
+      "      - ${6:list output(s) of the stage, e.g. model.pkl}"
+    ],
+    "description": "Stage template for dvc.yaml pipeline"
+  },
+  "Minimal Pipeline Stage Template": {
+    "prefix": "dvc-pipeline-minimal-stage",
+    "body": [
+      "  ${1:stage name}:",
+      "    cmd: ${2:command for the stage, e.g. python train.py}",
+      "    deps:",
+      "      - ${3:list dependencies for the stage, e.g. train.py}",
+      "    outs:",
+      "      - ${4:list output(s) of the stage, e.g. model.pkl}"
+    ],
+    "description": "Minimal stage template for dvc.yaml pipeline"
+  },
+  "Foreach Pipeline Stage Template": {
+    "prefix": "dvc-pipeline-foreach-stage",
+    "body": [
+      "  ${1:stage name}:",
+      "    foreach:",
+      "      - ${2:list of simple values to iterate over}",
+      "    do:",
+      "      cmd: ${3:command to be run for each templated item, e.g python evaluate.py} \"\\${item}\"",
+      "      outs:",
+      "      - \\${item}.${5:suffix for the templated output file, e.g. pkl}"
+    ],
+    "description": "Foreach stage template for dvc.yaml pipeline"
+  }
+}

--- a/extension/snippets/dvc-yaml.code-snippets
+++ b/extension/snippets/dvc-yaml.code-snippets
@@ -2,12 +2,11 @@
   "Get Started with DVC pipelines": {
     "prefix": "dvc-help",
     "body": [
-      "# Snippets are provided by the DVC for VS Code extension to help with building dvc.yaml pipelines.",
-      "# These snippets are all prefixed with dvc-.",
+      "# The DVC for VS Code extension provides snippets to help with building dvc.yaml pipelines.",
+      "# These snippets, all prefixed with dvc-, are designed to give pointers on basic usage.",
       "# Type dvc- in the editor to see the list of available snippets.",
-      "# Each snippet is designed to give pointers on basic usage.",
-      "# For further details on building pipelines visit https://dvc.org/doc/user-guide/project-structure/dvcyaml-files",
-      "# If the redhat.yaml extension is installed then on-hover support will be provided for each of the keys in a dvc.yaml file."
+      "# Visit https://dvc.org/doc/user-guide/project-structure/dvcyaml-files for further details on building pipelines.",
+      "# On-hover information and completions will be provided for each of the keys in a dvc.yaml file if the redhat.yaml extension is installed."
     ],
     "description": "Information on the support provided for building dvc.yaml pipelines"
   },

--- a/extension/src/fileSystem/index.test.ts
+++ b/extension/src/fileSystem/index.test.ts
@@ -272,8 +272,7 @@ describe('findOrCreateDvcYamlFile', () => {
     expect(mockedAppendFileSync).toHaveBeenCalledWith(
       `${cwd}/dvc.yaml`,
       expect.stringContaining(
-        `# Read about DVC pipeline configuration (https://dvc.org/doc/user-guide/project-structure/dvcyaml-files#stages)
-# to customize your stages even more`
+        '# Type dvc-help in this file and hit enter to get more information on how the extension can help to setup pipelines'
       )
     )
   })

--- a/extension/src/fileSystem/index.ts
+++ b/extension/src/fileSystem/index.ts
@@ -173,13 +173,13 @@ export const findOrCreateDvcYamlFile = (
     : format(parse(trainingScript))
 
   const pipeline = `
-# Read about DVC pipeline configuration (https://dvc.org/doc/user-guide/project-structure/dvcyaml-files#stages)
-# to customize your stages even more
+# Type dvc-help in this file and hit enter to get more information on how the extension can help to setup pipelines
 stages:
   ${stageName}:
     cmd: ${command} ${scriptPath}
     deps:
-      - ${scriptPath}`
+      - ${scriptPath}
+`
 
   void openFileInEditor(dvcYamlPath)
   return appendFileSync(dvcYamlPath, pipeline)


### PR DESCRIPTION
# 1/3 `main` <- this <- #4234 <- #4235

Part of https://github.com/iterative/vscode-dvc/issues/4194

This PR adds `dvc.yaml` pipeline snippets to the extension. They are:

1. Pipeline Stage Template
2. Minimal Pipeline Stage Template
3. Foreach Pipeline Stage Template

I have also added a `Get Started with DVC pipelines` snippet which can be used to insert a large (helpful) comment into a `dvc.yaml`. I have done my best to link the new functionality up with the existing code used to generate a basic stage for a project that does not yet have a `dvc.yaml`.

### Demo

https://github.com/iterative/vscode-dvc/assets/37993418/1bdb4e8e-6a4f-4dc8-8d24-10e9868c432b

I think we can extend these snippets to help people add top-level plots to their pipelines.