### PR TITLE
Focus pipeline when dvc.yaml file is open in the active editor

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -420,7 +420,8 @@
       {
         "title": "Show Pipeline DAG",
         "command": "dvc.showPipelineDAG",
-        "category": "DVC"
+        "category": "DVC",
+        "icon": "$(symbol-class)"
       },
       {
         "title": "Show Plots",
@@ -1093,6 +1094,11 @@
           "command": "dvc.stopAllRunningExperiments",
           "group": "navigation@0",
           "when": "dvc.experiments.webview.active && dvc.experiment.running && dvc.commands.available"
+        },
+        {
+          "command": "dvc.showPipelineDAG",
+          "group": "navigation@0",
+          "when": "dvc.pipeline.file.active && dvc.commands.available && dvc.project.available"
         },
         {
           "command": "dvc.runExperiment",

--- a/extension/src/pipeline/context.ts
+++ b/extension/src/pipeline/context.ts
@@ -1,0 +1,44 @@
+import { dirname } from 'path'
+import { EventEmitter, window } from 'vscode'
+import { Disposable, Disposer } from '@hediet/std/disposable'
+import { ContextKey, setContextValue } from '../vscode/context'
+import { standardizePossiblePath } from '../fileSystem/path'
+
+const setContextOnDidChangeActiveEditor = (
+  setActiveEditorContext: (path: string) => void,
+  dvcRoot: string
+): Disposable =>
+  window.onDidChangeActiveTextEditor(event => {
+    const path = standardizePossiblePath(event?.document.fileName)
+    if (!path) {
+      setActiveEditorContext('')
+      return
+    }
+
+    if (!path.includes(dvcRoot)) {
+      return
+    }
+
+    setActiveEditorContext(path)
+  })
+
+export const setContextForEditorTitleIcons = (
+  dvcRoot: string,
+  disposer: (() => void) & Disposer,
+  pipelineFileFocused: EventEmitter<string | undefined>
+): void => {
+  const setActiveEditorContext = (path: string) => {
+    const pipeline = path.endsWith('dvc.yaml') ? dirname(path) : undefined
+    void setContextValue(ContextKey.PIPELINE_FILE_ACTIVE, !!pipeline)
+    pipelineFileFocused.fire(pipeline)
+  }
+
+  const activePath = window.activeTextEditor?.document?.fileName
+  if (activePath?.startsWith(dvcRoot)) {
+    setActiveEditorContext(activePath)
+  }
+
+  disposer.track(
+    setContextOnDidChangeActiveEditor(setActiveEditorContext, dvcRoot)
+  )
+}

--- a/extension/src/pipeline/workspace.ts
+++ b/extension/src/pipeline/workspace.ts
@@ -13,6 +13,8 @@ import { getOnDidChangeExtensions, isInstalled } from '../vscode/extensions'
 export class WorkspacePipeline extends BaseWorkspace<Pipeline> {
   private isMermaidSupportInstalled = isInstalled(MARKDOWN_MERMAID_EXTENSION_ID)
 
+  private focusedProject: string | undefined
+
   constructor(internalCommands: InternalCommands) {
     super(internalCommands)
 
@@ -37,11 +39,17 @@ export class WorkspacePipeline extends BaseWorkspace<Pipeline> {
 
     this.setRepository(dvcRoot, pipeline)
 
+    this.dispose.track(
+      pipeline.onDidFocusProject(project => {
+        this.focusedProject = project
+      })
+    )
+
     return pipeline
   }
 
   public async showDag() {
-    const cwd = await this.getOnlyOrPickProject()
+    const cwd = this.focusedProject || (await this.getOnlyOrPickProject())
 
     if (!cwd) {
       return

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -47,6 +47,7 @@ import {
   configurationChangeEvent,
   experimentsUpdatedEvent,
   extensionUri,
+  getActiveEditorUpdatedEvent,
   getInputBoxEvent,
   getMessageReceivedEmitter
 } from '../util'
@@ -1893,17 +1894,6 @@ suite('Experiments Test Suite', () => {
   })
 
   describe('editor/title icons', () => {
-    const getActiveEditorUpdatedEvent = () =>
-      new Promise(resolve => {
-        const listener = disposable.track(
-          window.onDidChangeActiveTextEditor(() => {
-            resolve(undefined)
-            disposable.untrack(listener)
-            listener.dispose()
-          })
-        )
-      })
-
     it('should set the appropriate context value when a params file is open in the active editor/closed', async () => {
       const paramsFile = Uri.file(join(dvcDemoPath, 'params.yaml'))
       await window.showTextDocument(paramsFile)
@@ -1928,7 +1918,7 @@ suite('Experiments Test Suite', () => {
 
       mockSetContextValue.resetHistory()
 
-      const startupEditorClosed = getActiveEditorUpdatedEvent()
+      const startupEditorClosed = getActiveEditorUpdatedEvent(disposable)
 
       await closeAllEditors()
       await startupEditorClosed
@@ -1940,12 +1930,12 @@ suite('Experiments Test Suite', () => {
 
       mockSetContextValue.resetHistory()
 
-      const activeEditorUpdated = getActiveEditorUpdatedEvent()
+      const activeEditorUpdated = getActiveEditorUpdatedEvent(disposable)
 
       await window.showTextDocument(paramsFile)
       await activeEditorUpdated
 
-      const activeEditorClosed = getActiveEditorUpdatedEvent()
+      const activeEditorClosed = getActiveEditorUpdatedEvent(disposable)
 
       expect(
         mockContext['dvc.experiments.file.active'],
@@ -1971,7 +1961,7 @@ suite('Experiments Test Suite', () => {
       await experiments.isReady()
 
       expect(setContextValueSpy).not.to.be.calledWith(
-        VscodeContext.ContextKey.EXPERIMENTS_FILE_ACTIVE
+        'dvc.experiments.file.active'
       )
     })
   })

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -1970,7 +1970,9 @@ suite('Experiments Test Suite', () => {
       const { experiments } = buildExperiments({ disposer: disposable })
       await experiments.isReady()
 
-      expect(setContextValueSpy).not.to.be.called
+      expect(setContextValueSpy).not.to.be.calledWith(
+        VscodeContext.ContextKey.EXPERIMENTS_FILE_ACTIVE
+      )
     })
   })
 

--- a/extension/src/test/suite/util.ts
+++ b/extension/src/test/suite/util.ts
@@ -327,3 +327,14 @@ export const waitForEditorText = async (): Promise<unknown> => {
   }
   return waitForEditorText()
 }
+
+export const getActiveEditorUpdatedEvent = (disposer: Disposer) =>
+  new Promise(resolve => {
+    const listener = disposer.track(
+      window.onDidChangeActiveTextEditor(() => {
+        resolve(undefined)
+        disposer.untrack(listener)
+        listener.dispose()
+      })
+    )
+  })

--- a/extension/src/vscode/context.ts
+++ b/extension/src/vscode/context.ts
@@ -11,6 +11,7 @@ export enum ContextKey {
   EXPERIMENTS_SORTED = 'dvc.experiments.sorted',
   EXPERIMENTS_WEBVIEW_ACTIVE = 'dvc.experiments.webview.active',
   MULTIPLE_PROJECTS = 'dvc.multiple.projects',
+  PIPELINE_FILE_ACTIVE = 'dvc.pipeline.file.active',
   PLOTS_WEBVIEW_ACTIVE = 'dvc.plots.webview.active',
   PROJECT_AVAILABLE = 'dvc.project.available',
   PROJECT_HAS_DATA = 'dvc.project.hasData',


### PR DESCRIPTION
# 3/3 `main` <- #4264 <- #4272 <- this

This PR focuses a pipeline when the respective `dvc.yaml` file is open in the active editor.

This means that we can add the `Show Pipeline DAG` command to the editor/title and bypass showing a choice of pipelines to the user if they choose to run an experiment with a `dvc.yaml` file open.

### Demo


https://github.com/iterative/vscode-dvc/assets/37993418/752da0dc-9fff-4f99-aeab-8e2d2849cb68


PR needs tests.