### PR TITLE
Add columns indicator (select columns) to table indicators

### DIFF
--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -1584,136 +1584,178 @@ describe('App', () => {
       expect(sortIndicator).toHaveTextContent('2')
       jest.useRealTimers()
     })
-  })
 
-  it('should show an indicator with the amount of applied filters', () => {
-    renderTable({
-      ...tableDataFixture,
-      filters: []
+    it('should show an indicator with the amount of applied filters', () => {
+      renderTable({
+        ...tableDataFixture,
+        filters: []
+      })
+      jest.useFakeTimers()
+      const filterIndicator = screen.getByLabelText('filters')
+      expect(filterIndicator).toHaveTextContent('')
+
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+
+      fireEvent.mouseEnter(filterIndicator)
+      advanceTimersByTime(1000)
+
+      const tooltip = screen.getByRole('tooltip')
+
+      expect(tooltip).toHaveTextContent('Show Filters')
+
+      const { columns } = tableDataFixture
+      const firstFilterPath = columns[columns.length - 1].path
+      const secondFilterPath = columns[columns.length - 2].path
+      setTableData({
+        ...tableDataFixture,
+        filters: [firstFilterPath]
+      })
+      expect(filterIndicator).toHaveTextContent('1')
+
+      setTableData({
+        ...tableDataFixture,
+        filters: [firstFilterPath, secondFilterPath]
+      })
+      expect(filterIndicator).toHaveTextContent('2')
+
+      setTableData({
+        ...tableDataFixture,
+        filters: [firstFilterPath, secondFilterPath]
+      })
+      expect(filterIndicator).toHaveTextContent('2')
+
+      setTableData({
+        ...tableDataFixture,
+        filters: []
+      })
+      expect(filterIndicator).toHaveTextContent('')
+      expect(tooltip).not.toHaveTextContent('Experiment')
+      jest.useRealTimers()
     })
-    jest.useFakeTimers()
-    const filterIndicator = screen.getByLabelText('filters')
-    expect(filterIndicator).toHaveTextContent('')
 
-    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+    it('should show a tooltip for the branches indicator', () => {
+      renderTable({
+        ...tableDataFixture
+      })
+      jest.useFakeTimers()
+      const branchesIndicator = screen.getByLabelText('branches')
+      expect(branchesIndicator).toHaveTextContent('')
 
-    fireEvent.mouseEnter(filterIndicator)
-    advanceTimersByTime(1000)
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
 
-    const tooltip = screen.getByRole('tooltip')
+      fireEvent.mouseEnter(branchesIndicator)
+      advanceTimersByTime(1000)
 
-    expect(tooltip).toHaveTextContent('Show Filters')
+      const tooltip = screen.getByRole('tooltip')
 
-    const { columns } = tableDataFixture
-    const firstFilterPath = columns[columns.length - 1].path
-    const secondFilterPath = columns[columns.length - 2].path
-    setTableData({
-      ...tableDataFixture,
-      filters: [firstFilterPath]
+      expect(tooltip).toHaveTextContent('Select Branches')
+      jest.useRealTimers()
     })
-    expect(filterIndicator).toHaveTextContent('1')
 
-    setTableData({
-      ...tableDataFixture,
-      filters: [firstFilterPath, secondFilterPath]
-    })
-    expect(filterIndicator).toHaveTextContent('2')
+    it('should show an indicator for the number of branches selected', () => {
+      const branches = ['main', 'other', 'third']
 
-    setTableData({
-      ...tableDataFixture,
-      filters: [firstFilterPath, secondFilterPath]
-    })
-    expect(filterIndicator).toHaveTextContent('2')
-
-    setTableData({
-      ...tableDataFixture,
-      filters: []
-    })
-    expect(filterIndicator).toHaveTextContent('')
-    expect(tooltip).not.toHaveTextContent('Experiment')
-    jest.useRealTimers()
-  })
-
-  it('should show a tooltip for the branches indicator', () => {
-    renderTable({
-      ...tableDataFixture
-    })
-    jest.useFakeTimers()
-    const branchesIndicator = screen.getByLabelText('branches')
-    expect(branchesIndicator).toHaveTextContent('')
-
-    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
-
-    fireEvent.mouseEnter(branchesIndicator)
-    advanceTimersByTime(1000)
-
-    const tooltip = screen.getByRole('tooltip')
-
-    expect(tooltip).toHaveTextContent('Select Branches')
-    jest.useRealTimers()
-  })
-
-  it('should show an indicator for the number of branches selected', () => {
-    const branches = ['main', 'other', 'third']
-
-    let workspace
-    const rowsWithoutWorkspace = []
-    for (const row of tableDataFixture.rows) {
-      if (row.id !== EXPERIMENT_WORKSPACE_ID) {
-        rowsWithoutWorkspace.push(row)
-        continue
+      let workspace
+      const rowsWithoutWorkspace = []
+      for (const row of tableDataFixture.rows) {
+        if (row.id !== EXPERIMENT_WORKSPACE_ID) {
+          rowsWithoutWorkspace.push(row)
+          continue
+        }
+        workspace = row
       }
-      workspace = row
-    }
 
-    const multipleBranches = {
-      ...tableDataFixture,
-      branches,
-      hasData: true,
-      rows: [
-        workspace as Commit,
-        ...rowsWithoutWorkspace.map(row => ({
-          ...row,
-          branch: branches[0],
-          subRows: undefined
-        })),
-        ...rowsWithoutWorkspace.map(row => ({
-          ...row,
-          branch: branches[1],
-          subRows: undefined
-        })),
-        ...rowsWithoutWorkspace.map(row => ({
-          ...row,
-          branch: branches[2],
-          subRows: undefined
-        }))
-      ]
-    }
+      const multipleBranches = {
+        ...tableDataFixture,
+        branches,
+        hasData: true,
+        rows: [
+          workspace as Commit,
+          ...rowsWithoutWorkspace.map(row => ({
+            ...row,
+            branch: branches[0],
+            subRows: undefined
+          })),
+          ...rowsWithoutWorkspace.map(row => ({
+            ...row,
+            branch: branches[1],
+            subRows: undefined
+          })),
+          ...rowsWithoutWorkspace.map(row => ({
+            ...row,
+            branch: branches[2],
+            subRows: undefined
+          }))
+        ]
+      }
 
-    renderTable(multipleBranches)
+      renderTable(multipleBranches)
 
-    const [indicator] = screen.getAllByLabelText('branches')
+      const [indicator] = screen.getAllByLabelText('branches')
 
-    expect(indicator).toHaveTextContent(`${branches.length - 1}`)
-  })
-
-  it('should send a message to focus the relevant tree when clicked', () => {
-    renderTable()
-    mockPostMessage.mockClear()
-    fireEvent.click(screen.getByLabelText('sorts'))
-    expect(mockPostMessage).toHaveBeenCalledWith({
-      type: MessageFromWebviewType.FOCUS_SORTS_TREE
-    })
-    mockPostMessage.mockClear()
-    fireEvent.click(screen.getByLabelText('filters'))
-    expect(mockPostMessage).toHaveBeenCalledWith({
-      type: MessageFromWebviewType.FOCUS_FILTERS_TREE
+      expect(indicator).toHaveTextContent(`${branches.length - 1}`)
     })
 
-    mockPostMessage.mockClear()
-    fireEvent.click(screen.getByLabelText('selected for plots'))
-    expect(mockPostMessage).toHaveBeenCalledWith({
-      type: MessageFromWebviewType.OPEN_PLOTS_WEBVIEW
+    it('should send a message to focus the relevant tree when clicked', () => {
+      renderTable()
+      mockPostMessage.mockClear()
+      fireEvent.click(screen.getByLabelText('sorts'))
+      expect(mockPostMessage).toHaveBeenCalledWith({
+        type: MessageFromWebviewType.FOCUS_SORTS_TREE
+      })
+      mockPostMessage.mockClear()
+      fireEvent.click(screen.getByLabelText('filters'))
+      expect(mockPostMessage).toHaveBeenCalledWith({
+        type: MessageFromWebviewType.FOCUS_FILTERS_TREE
+      })
+
+      mockPostMessage.mockClear()
+      fireEvent.click(screen.getByLabelText('selected for plots'))
+      expect(mockPostMessage).toHaveBeenCalledWith({
+        type: MessageFromWebviewType.OPEN_PLOTS_WEBVIEW
+      })
+    })
+
+    it('should show an indicator with the amount of displayed columns', () => {
+      renderTable({
+        ...tableDataFixture
+      })
+      jest.useFakeTimers()
+      const columnsIndicator = screen.getByLabelText('columns')
+      expect(columnsIndicator).toHaveTextContent('22')
+
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+
+      fireEvent.mouseEnter(columnsIndicator)
+      advanceTimersByTime(1000)
+      const tooltip = screen.getByRole('tooltip')
+
+      expect(tooltip).toHaveTextContent('Select Columns')
+
+      setTableData({
+        ...tableDataFixture,
+        columns: tableDataFixture.columns.slice(1)
+      })
+
+      expect(columnsIndicator).toHaveTextContent('21')
+
+      setTableData({
+        ...tableDataFixture,
+        columns: []
+      })
+
+      expect(columnsIndicator).toHaveTextContent('')
+
+      jest.useRealTimers()
+    })
+
+    it('should send a message to select columns when the select columns icon is clicked', () => {
+      renderTable()
+      mockPostMessage.mockClear()
+      fireEvent.click(screen.getByLabelText('columns'))
+      expect(mockPostMessage).toHaveBeenCalledWith({
+        type: MessageFromWebviewType.SELECT_COLUMNS
+      })
     })
   })
 

--- a/webview/src/experiments/components/table/Indicators.tsx
+++ b/webview/src/experiments/components/table/Indicators.tsx
@@ -6,13 +6,15 @@ import {
   focusFiltersTree,
   focusSortsTree,
   openPlotsWebview,
-  selectBranches
+  selectBranches,
+  selectColumns
 } from '../../util/messages'
 import { Icon } from '../../../shared/components/Icon'
 import {
   Filter,
   GitMerge,
   GraphScatter,
+  ListFilter,
   SortPrecedence
 } from '../../../shared/components/icons'
 import { ExperimentsState } from '../../store'
@@ -72,21 +74,30 @@ export const Indicators = () => {
   const filters = useSelector(
     (state: ExperimentsState) => state.tableData.filters
   )
+  const filtersCount = filters?.length
+
   const sorts = useSelector((state: ExperimentsState) => state.tableData.sorts)
+  const sortsCount = sorts?.length
+
   const selectedForPlotsCount = useSelector(
     (state: ExperimentsState) => state.tableData.selectedForPlotsCount
   )
+
   const branchesSelected = useSelector(
     (state: ExperimentsState) =>
       Math.max(state.tableData.branches.filter(Boolean).length - 1, 0) // We always have one branch by default (the current one which is not selected) and undefined for the workspace
   )
-
   const { hasBranchesToSelect } = useSelector(
     (state: ExperimentsState) => state.tableData
   )
 
-  const sortsCount = sorts?.length
-  const filtersCount = filters?.length
+  const columnsSelected = useSelector(
+    (state: ExperimentsState) =>
+      state.tableData.columns.filter(({ hasChildren }) => !hasChildren).length
+  )
+  const hasColumns = useSelector(
+    (state: ExperimentsState) => state.tableData.hasColumns
+  )
 
   return (
     <div className={styles.tableIndicators}>
@@ -122,6 +133,15 @@ export const Indicators = () => {
         disabled={!hasBranchesToSelect}
       >
         <Icon width={16} height={16} icon={GitMerge} />
+      </Indicator>
+      <Indicator
+        count={columnsSelected}
+        aria-label="columns"
+        onClick={selectColumns}
+        tooltipContent="Select Columns"
+        disabled={!hasColumns}
+      >
+        <Icon width={16} height={16} icon={ListFilter} />
       </Indicator>
     </div>
   )


### PR DESCRIPTION
Related to #4269 & #4229

This PR adds a columns indicator icon to the experiment table indicators. Clicking on the indicator icon will trigger the `Select Columns to Display in the Experiments Table` quick pick.

### Demo

https://github.com/iterative/vscode-dvc/assets/37993418/0b17778e-0994-4abc-b5a6-f25a5c3cb151

Note: I am also planning to add a "Move Columns To Start" or "Move Columns Left" quick pick.