### PR TITLE
Only allow moving selected columns to the left of the experiments table

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -572,6 +572,12 @@
         "icon": "$(list-filter)"
       },
       {
+        "title": "Select Columns to Display First in the Experiments Table",
+        "command": "dvc.views.experimentsColumnsTree.selectFirstColumns",
+        "category": "DVC",
+        "icon": "$(arrow-left)"
+      },
+      {
         "title": "Select Plots to Display",
         "command": "dvc.views.plotsPathsTree.selectPlots",
         "category": "DVC",
@@ -917,6 +923,10 @@
         },
         {
           "command": "dvc.views.experimentsColumnsTree.selectColumns",
+          "when": "dvc.commands.available && dvc.project.available"
+        },
+        {
+          "command": "dvc.views.experimentsColumnsTree.selectFirstColumns",
           "when": "dvc.commands.available && dvc.project.available"
         },
         {
@@ -1283,6 +1293,11 @@
           "command": "dvc.views.experimentsColumnsTree.selectColumns",
           "when": "view == dvc.views.experimentsColumnsTree",
           "group": "navigation@2"
+        },
+        {
+          "command": "dvc.views.experimentsColumnsTree.selectFirstColumns",
+          "when": "view == dvc.views.experimentsColumnsTree",
+          "group": "navigation@3"
         },
         {
           "command": "dvc.stopAllRunningExperiments",

--- a/extension/src/commands/external.ts
+++ b/extension/src/commands/external.ts
@@ -51,6 +51,7 @@ export enum RegisteredCliCommands {
 
 export enum RegisteredCommands {
   EXPERIMENT_COLUMNS_SELECT = 'dvc.views.experimentsColumnsTree.selectColumns',
+  EXPERIMENT_COLUMNS_SELECT_FIRST = 'dvc.views.experimentsColumnsTree.selectFirstColumns',
   EXPERIMENT_FILTER_ADD = 'dvc.addExperimentsTableFilter',
   EXPERIMENT_FILTER_ADD_STARRED = 'dvc.addStarredExperimentsTableFilter',
   EXPERIMENT_FILTER_REMOVE = 'dvc.views.experimentsFilterByTree.removeFilter',

--- a/extension/src/experiments/columns/model.ts
+++ b/extension/src/experiments/columns/model.ts
@@ -94,6 +94,17 @@ export class ColumnsModel extends PathSelectionModel<Column> {
     this.statusChanged?.fire()
   }
 
+  public selectFirst(firstColumns: string[]) {
+    const columnOrder = [
+      'id',
+      ...firstColumns,
+      ...this.getColumnOrder().filter(
+        column => !['id', ...firstColumns].includes(column)
+      )
+    ]
+    this.setColumnOrder(columnOrder)
+  }
+
   public setColumnWidth(id: string, width: number) {
     this.columnWidthsState[id] = width
     this.persist(

--- a/extension/src/experiments/commands/register.ts
+++ b/extension/src/experiments/commands/register.ts
@@ -191,6 +191,12 @@ const registerExperimentQuickPickCommands = (
   )
 
   internalCommands.registerExternalCommand(
+    RegisteredCommands.EXPERIMENT_COLUMNS_SELECT_FIRST,
+    (context: Context) =>
+      experiments.selectFirstColumns(getDvcRootFromContext(context))
+  )
+
+  internalCommands.registerExternalCommand(
     RegisteredCommands.EXPERIMENT_STOP,
     () => experiments.selectExperimentsToStop()
   )

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -45,6 +45,7 @@ import { checkSignalFile, pollSignalFileForProcess } from '../fileSystem'
 import { DVCLIVE_ONLY_RUNNING_SIGNAL_FILE } from '../cli/dvc/constants'
 import { Response } from '../vscode/response'
 import { Pipeline } from '../pipeline'
+import { definedAndNonEmpty } from '../util/array'
 
 export const ExperimentsScale = {
   ...omit(ColumnType, 'TIMESTAMP'),
@@ -356,12 +357,27 @@ export class Experiments extends BaseRepository<TableData> {
   public async selectColumns() {
     const columns = this.columns.getTerminalNodes()
 
-    const selected = await pickPaths('columns', columns)
+    const selected = await pickPaths(columns, Title.SELECT_COLUMNS)
     if (!selected) {
       return
     }
 
     this.columns.setSelected(selected)
+    return this.notifyChanged()
+  }
+
+  public async selectFirstColumns() {
+    const columns = this.columns.getTerminalNodes()
+
+    const selected = await pickPaths(
+      columns.map(column => ({ ...column, selected: false })),
+      Title.SELECT_FIRST_COLUMNS
+    )
+    if (!definedAndNonEmpty(selected)) {
+      return
+    }
+
+    this.columns.selectFirst(selected.map(({ path }) => path))
     return this.notifyChanged()
   }
 

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -598,6 +598,7 @@ export class Experiments extends BaseRepository<TableData> {
       () => this.getWebview(),
       () => this.notifyChanged(),
       () => this.selectColumns(),
+      () => this.selectFirstColumns(),
       (branchesSelected: string[]) => this.selectBranches(branchesSelected),
       () => this.data.update()
     )

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -369,8 +369,16 @@ export class Experiments extends BaseRepository<TableData> {
   public async selectFirstColumns() {
     const columns = this.columns.getTerminalNodes()
 
+    const selectedColumns = []
+    for (const column of columns) {
+      if (!column.selected) {
+        continue
+      }
+      selectedColumns.push({ ...column, selected: false })
+    }
+
     const selected = await pickPaths(
-      columns.map(column => ({ ...column, selected: false })),
+      selectedColumns,
       Title.SELECT_FIRST_COLUMNS
     )
     if (!definedAndNonEmpty(selected)) {

--- a/extension/src/experiments/webview/messages.ts
+++ b/extension/src/experiments/webview/messages.ts
@@ -33,6 +33,7 @@ export class WebviewMessages {
   private readonly getWebview: () => BaseWebview<TableData> | undefined
   private readonly notifyChanged: () => void
   private readonly selectColumns: () => Promise<void>
+  private readonly selectFirstColumns: () => Promise<void>
 
   private readonly selectBranches: (
     branchesSelected: string[]
@@ -48,6 +49,7 @@ export class WebviewMessages {
     getWebview: () => BaseWebview<TableData> | undefined,
     notifyChanged: () => void,
     selectColumns: () => Promise<void>,
+    selectFirstColumns: () => Promise<void>,
     selectBranches: (
       branchesSelected: string[]
     ) => Promise<string[] | undefined>,
@@ -60,6 +62,7 @@ export class WebviewMessages {
     this.getWebview = getWebview
     this.notifyChanged = notifyChanged
     this.selectColumns = selectColumns
+    this.selectFirstColumns = selectFirstColumns
     this.selectBranches = selectBranches
     this.update = update
   }
@@ -131,6 +134,8 @@ export class WebviewMessages {
 
       case MessageFromWebviewType.SELECT_COLUMNS:
         return this.setColumnsStatus()
+      case MessageFromWebviewType.SELECT_FIRST_COLUMNS:
+        return this.setFirstColumns()
 
       case MessageFromWebviewType.FOCUS_FILTERS_TREE:
         return this.focusFiltersTree()
@@ -315,6 +320,15 @@ export class WebviewMessages {
 
   private setColumnsStatus() {
     void this.selectColumns()
+    sendTelemetryEvent(
+      EventName.VIEWS_EXPERIMENTS_TABLE_SELECT_COLUMNS,
+      undefined,
+      undefined
+    )
+  }
+
+  private setFirstColumns() {
+    void this.selectFirstColumns()
     sendTelemetryEvent(
       EventName.VIEWS_EXPERIMENTS_TABLE_SELECT_COLUMNS,
       undefined,

--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -101,6 +101,10 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
     return this.getRepositoryThenUpdate('selectColumns', overrideRoot)
   }
 
+  public selectFirstColumns(overrideRoot?: string) {
+    return this.getRepositoryThenUpdate('selectFirstColumns', overrideRoot)
+  }
+
   public async selectExperimentsToStop() {
     const cwd = await this.getFocusedOrOnlyOrPickProject()
     if (!cwd) {
@@ -407,7 +411,8 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
       | 'addStarredSort'
       | 'removeSorts'
       | 'selectExperimentsToPlot'
-      | 'selectColumns',
+      | 'selectColumns'
+      | 'selectFirstColumns',
     overrideRoot?: string
   ) {
     const dvcRoot = await this.getDvcRoot(overrideRoot)

--- a/extension/src/path/selection/quickPick.test.ts
+++ b/extension/src/path/selection/quickPick.test.ts
@@ -21,7 +21,7 @@ beforeEach(() => {
 describe('pickPaths', () => {
   it('should not call quickPickManyValues if undefined is provided', async () => {
     mockedQuickPickManyValues.mockResolvedValueOnce([])
-    await pickPaths('plots', undefined)
+    await pickPaths(undefined, Title.SELECT_COLUMNS)
 
     expect(mockedShowError).toHaveBeenCalledTimes(1)
     expect(mockedQuickPickManyValues).not.toHaveBeenCalled()
@@ -29,7 +29,7 @@ describe('pickPaths', () => {
 
   it('should not call quickPickManyValues if no plots paths are provided', async () => {
     mockedQuickPickManyValues.mockResolvedValueOnce([])
-    await pickPaths('plots', [])
+    await pickPaths([], Title.SELECT_COLUMNS)
 
     expect(mockedShowError).toHaveBeenCalledTimes(1)
     expect(mockedQuickPickManyValues).not.toHaveBeenCalled()
@@ -69,7 +69,7 @@ describe('pickPaths', () => {
       }
     ]
 
-    await pickPaths('plots', plotPaths)
+    await pickPaths(plotPaths, Title.SELECT_PLOTS)
 
     expect(mockedShowError).not.toHaveBeenCalled()
     expect(mockedQuickPickManyValues).toHaveBeenCalledTimes(1)

--- a/extension/src/path/selection/quickPick.ts
+++ b/extension/src/path/selection/quickPick.ts
@@ -33,10 +33,13 @@ const collectItems = <T extends PathType>(
 }
 
 export const pickPaths = <T extends PathType>(
-  type: 'plots' | 'columns',
-  paths?: PathWithSelected<T>[]
+  paths: PathWithSelected<T>[] | undefined,
+  title:
+    | typeof Title.SELECT_PLOTS
+    | typeof Title.SELECT_COLUMNS
+    | typeof Title.SELECT_FIRST_COLUMNS
 ): Thenable<PathWithSelected<T>[] | undefined> => {
-  const title = type === 'plots' ? Title.SELECT_PLOTS : Title.SELECT_COLUMNS
+  const type = Title.SELECT_PLOTS === title ? 'plots' : 'columns'
 
   if (!definedAndNonEmpty(paths)) {
     return Toast.showError(`There are no ${type} to select.`)

--- a/extension/src/plots/index.ts
+++ b/extension/src/plots/index.ts
@@ -96,7 +96,7 @@ export class Plots extends BaseRepository<TPlotsData> {
   public async selectPlots() {
     const paths = this.paths.getTerminalNodes()
 
-    const selected = await pickPaths('plots', paths)
+    const selected = await pickPaths(paths, Title.SELECT_PLOTS)
     if (!selected) {
       return
     }

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -130,6 +130,7 @@ export interface IEventNamePropertyMapping {
   [EventName.EXPERIMENT_APPLY]: undefined
   [EventName.EXPERIMENT_BRANCH]: undefined
   [EventName.EXPERIMENT_COLUMNS_SELECT]: undefined
+  [EventName.EXPERIMENT_COLUMNS_SELECT_FIRST]: undefined
   [EventName.EXPERIMENT_FILTER_ADD]: undefined
   [EventName.EXPERIMENT_FILTER_ADD_STARRED]: undefined
   [EventName.EXPERIMENT_FILTER_REMOVE]: undefined

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -57,6 +57,9 @@ export const EventName = Object.assign(
       'views.experimentsTable.selectColumns',
     VIEWS_EXPERIMENTS_TABLE_SELECT_EXPERIMENTS_FOR_PLOTS:
       'views.experimentsTable.selectExperimentsForPlots',
+    VIEWS_EXPERIMENTS_TABLE_SELECT_FIRST_COLUMNS:
+      'views.experimentsTable.selectFirstColumns',
+
     VIEWS_EXPERIMENTS_TABLE_SET_MAX_HEADER_HEIGHT:
       'views.experimentsTable.updateHeaderMaxHeight',
     VIEWS_EXPERIMENTS_TABLE_SHOW_LESS_COMMITS:
@@ -250,6 +253,7 @@ export interface IEventNamePropertyMapping {
   [EventName.VIEWS_EXPERIMENTS_TABLE_SELECT_EXPERIMENTS_FOR_PLOTS]: {
     experimentCount: number
   }
+  [EventName.VIEWS_EXPERIMENTS_TABLE_SELECT_FIRST_COLUMNS]: undefined
   [EventName.VIEWS_EXPERIMENTS_TABLE_SHOW_MORE_COMMITS]: undefined
   [EventName.VIEWS_EXPERIMENTS_TABLE_SHOW_LESS_COMMITS]: undefined
   [EventName.VIEWS_EXPERIMENTS_TABLE_OPEN_PARAMS_FILE]: {

--- a/extension/src/test/suite/experiments/columns/tree.test.ts
+++ b/extension/src/test/suite/experiments/columns/tree.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, it, suite } from 'mocha'
 import { expect } from 'chai'
-import { stub, restore } from 'sinon'
-import { commands } from 'vscode'
+import { stub, restore, SinonStub } from 'sinon'
+import { QuickPickItem, commands, window } from 'vscode'
 import { Disposable } from '../../../../extension'
 import { WorkspaceExperiments } from '../../../../experiments/workspace'
 import { dvcDemoPath } from '../../../util'
@@ -10,9 +10,13 @@ import {
   appendColumnToPath,
   buildMetricOrParamPath
 } from '../../../../experiments/columns/paths'
-import { buildExperiments } from '../util'
+import { buildExperiments, stubWorkspaceExperimentsGetters } from '../util'
 import { Status } from '../../../../path/selection/model'
 import { ColumnType } from '../../../../experiments/webview/contract'
+import {
+  QuickPickItemWithValue,
+  QuickPickOptionsWithTitle
+} from '../../../../vscode/quickPick'
 
 suite('Experiments Columns Tree Test Suite', () => {
   const paramsFile = 'params.yaml'
@@ -348,6 +352,68 @@ suite('Experiments Columns Tree Test Suite', () => {
         unselectedGrandParent?.status,
         'the grandparent is now unselected'
       ).to.equal(Status.UNSELECTED)
+    })
+
+    it('should be able to display selected columns first with dvc.views.experimentsColumnsTree.selectFirstColumns', async () => {
+      const { experiments, columnsModel } =
+        stubWorkspaceExperimentsGetters(disposable)
+      await experiments.isReady()
+
+      const columnsOrder = columnsModel.getColumnOrder()
+
+      const firstColumns = []
+      const otherColumns = []
+      for (const column of columnsOrder) {
+        if (column === 'id') {
+          continue
+        }
+        if (
+          [
+            'params:params.yaml:learning_rate',
+            'params:params.yaml:dvc_logs_dir'
+          ].includes(column)
+        ) {
+          firstColumns.push(column)
+          continue
+        }
+        otherColumns.push(column)
+      }
+
+      ;(
+        stub(window, 'showQuickPick') as SinonStub<
+          [items: readonly QuickPickItem[], options: QuickPickOptionsWithTitle],
+          Thenable<QuickPickItemWithValue<{ path: string }>[] | undefined>
+        >
+      ).resolves(
+        firstColumns.map(
+          path =>
+            ({
+              label: path,
+              value: { path }
+            }) as QuickPickItemWithValue<{ path: string }>
+        )
+      )
+
+      const orderUpdated = new Promise(resolve =>
+        disposable.track(
+          experiments.onDidChangeColumnOrderOrStatus(() => {
+            resolve(undefined)
+          })
+        )
+      )
+
+      await Promise.all([
+        commands.executeCommand(
+          RegisteredCommands.EXPERIMENT_COLUMNS_SELECT_FIRST
+        ),
+        orderUpdated
+      ])
+
+      expect(columnsModel.getColumnOrder()).to.deep.equal([
+        'id',
+        ...firstColumns,
+        ...otherColumns
+      ])
     })
   })
 })

--- a/extension/src/test/suite/experiments/util.ts
+++ b/extension/src/test/suite/experiments/util.ts
@@ -255,8 +255,14 @@ export const stubWorkspaceExperimentsGetters = (
   disposer: Disposer,
   dvcRoot = dvcDemoPath
 ) => {
-  const { dvcExecutor, dvcRunner, experiments, experimentsModel, messageSpy } =
-    buildExperiments({ disposer })
+  const {
+    columnsModel,
+    dvcExecutor,
+    dvcRunner,
+    experiments,
+    experimentsModel,
+    messageSpy
+  } = buildExperiments({ disposer })
 
   const mockGetOnlyOrPickProject = stub(
     WorkspaceExperiments.prototype,
@@ -269,6 +275,7 @@ export const stubWorkspaceExperimentsGetters = (
   ).returns(experiments)
 
   return {
+    columnsModel,
     dvcExecutor,
     dvcRunner,
     experiments,

--- a/extension/src/vscode/title.ts
+++ b/extension/src/vscode/title.ts
@@ -23,6 +23,7 @@ export enum Title {
   SELECT_EXPERIMENTS_REMOVE = 'Select Experiment(s) to Remove',
   SELECT_EXPERIMENTS_TO_PLOT = 'Select up to 7 Experiments to Display in Plots',
   SELECT_FILTERS_TO_REMOVE = 'Select Filter(s) to Remove',
+  SELECT_FIRST_COLUMNS = 'Select Column(s) to Display First in the Experiments Table',
   SELECT_FOCUSED_PROJECTS = 'Select Project(s) to Focus (set dvc.focusedProjects)',
   SELECT_OPERATOR = 'Select an Operator',
   SELECT_PARAM_OR_METRIC_FILTER = 'Select a Param or Metric to Filter by',

--- a/extension/src/webview/contract.ts
+++ b/extension/src/webview/contract.ts
@@ -50,6 +50,7 @@ export enum MessageFromWebviewType {
   HIDE_EXPERIMENTS_TABLE_COLUMN = 'hide-experiments-table-column',
   SELECT_EXPERIMENTS = 'select-experiments',
   SELECT_COLUMNS = 'select-columns',
+  SELECT_FIRST_COLUMNS = 'select-first-columns',
   SELECT_PLOTS = 'select-plots',
   SET_EXPERIMENTS_FOR_PLOTS = 'set-experiments-for-plots',
   SET_EXPERIMENTS_AND_OPEN_PLOTS = 'set-experiments-and-open-plots',
@@ -211,6 +212,7 @@ export type MessageFromWebview =
   | { type: MessageFromWebviewType.REFRESH_EXP_DATA }
   | { type: MessageFromWebviewType.REFRESH_REVISIONS }
   | { type: MessageFromWebviewType.SELECT_COLUMNS }
+  | { type: MessageFromWebviewType.SELECT_FIRST_COLUMNS }
   | { type: MessageFromWebviewType.FOCUS_FILTERS_TREE }
   | { type: MessageFromWebviewType.FOCUS_SORTS_TREE }
   | { type: MessageFromWebviewType.OPEN_PLOTS_WEBVIEW }

--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -737,10 +737,10 @@ describe('App', () => {
       advanceTimersByTime(100)
 
       const menuitems = screen.getAllByRole('menuitem')
-      expect(menuitems).toHaveLength(6)
+      expect(menuitems).toHaveLength(8)
       expect(
         menuitems.filter(item => !item.className.includes('disabled'))
-      ).toHaveLength(3)
+      ).toHaveLength(5)
 
       fireEvent.keyDown(paramsFileHeader, { bubbles: true, key: 'Escape' })
       expect(screen.queryAllByRole('menuitem')).toHaveLength(0)
@@ -761,7 +761,7 @@ describe('App', () => {
       expect(disabledMenuItem).toBeDefined()
 
       disabledMenuItem && fireEvent.click(disabledMenuItem, { bubbles: true })
-      expect(screen.queryAllByRole('menuitem')).toHaveLength(6)
+      expect(screen.queryAllByRole('menuitem')).toHaveLength(8)
     })
 
     it('should have the same enabled options in the empty placeholders', () => {
@@ -783,6 +783,8 @@ describe('App', () => {
         expect(menuitems).toStrictEqual([
           'Hide Column',
           'Set Max Header Height',
+          'Select Columns',
+          'Select First Columns',
           'Sort Ascending',
           'Sort Descending'
         ])
@@ -807,10 +809,52 @@ describe('App', () => {
           .filter(item => !item.className.includes('disabled'))
           .map(item => item.textContent)
 
-        expect(menuitems).toStrictEqual(['Set Max Header Height'])
+        expect(menuitems).toStrictEqual([
+          'Set Max Header Height',
+          'Select Columns',
+          'Select First Columns'
+        ])
 
         fireEvent.keyDown(segment, { bubbles: true, key: 'Escape' })
       }
+    })
+
+    it('should send the correct message when Select Columns is clicked', () => {
+      renderTableWithPlaceholder()
+      const placeholders = screen.getAllByTestId(/header-Created/)
+      const placeholder = placeholders[0]
+      fireEvent.contextMenu(placeholder, { bubbles: true })
+      advanceTimersByTime(100)
+
+      const selectOption = screen.getByText('Select Columns')
+
+      mockPostMessage.mockClear()
+
+      fireEvent.click(selectOption)
+
+      expect(mockPostMessage).toHaveBeenCalledTimes(1)
+      expect(mockPostMessage).toHaveBeenCalledWith({
+        type: MessageFromWebviewType.SELECT_COLUMNS
+      })
+    })
+
+    it('should send the correct message when Select First Columns is clicked', () => {
+      renderTableWithPlaceholder()
+      const placeholders = screen.getAllByTestId(/header-Created/)
+      const placeholder = placeholders[0]
+      fireEvent.contextMenu(placeholder, { bubbles: true })
+      advanceTimersByTime(100)
+
+      const selectOption = screen.getByText('Select First Columns')
+
+      mockPostMessage.mockClear()
+
+      fireEvent.click(selectOption)
+
+      expect(mockPostMessage).toHaveBeenCalledTimes(1)
+      expect(mockPostMessage).toHaveBeenCalledWith({
+        type: MessageFromWebviewType.SELECT_FIRST_COLUMNS
+      })
     })
 
     describe('Hiding a column from its empty placeholder', () => {

--- a/webview/src/experiments/components/Experiments.tsx
+++ b/webview/src/experiments/components/Experiments.tsx
@@ -122,7 +122,7 @@ const defaultColumn: Partial<ColumnDef<Commit>> = {
 export const ExperimentsTable: React.FC = () => {
   const {
     columns: columnsData,
-    columnOrder: initialColumnOrder,
+    columnOrder: columnOrderData,
     columnWidths,
     hasColumns,
     hasConfig,
@@ -134,7 +134,7 @@ export const ExperimentsTable: React.FC = () => {
   const [columns, setColumns] = useState(getColumns(columnsData))
   const [columnSizing, setColumnSizing] =
     useState<ColumnSizingState>(columnWidths)
-  const [columnOrder, setColumnOrder] = useState(initialColumnOrder)
+  const [columnOrder, setColumnOrder] = useState(columnOrderData)
   const resizeTimeout = useRef(0)
 
   useEffect(() => {
@@ -144,6 +144,10 @@ export const ExperimentsTable: React.FC = () => {
   useEffect(() => {
     setColumns(getColumns(columnsData))
   }, [columnsData])
+
+  useEffect(() => {
+    setColumnOrder(columnOrderData)
+  }, [columnOrderData])
 
   const getRowId = useCallback(
     (experiment: Commit, relativeIndex: number, parent?: TableRow<Commit>) =>

--- a/webview/src/experiments/components/table/header/ContextMenuContent.tsx
+++ b/webview/src/experiments/components/table/header/ContextMenuContent.tsx
@@ -114,10 +114,25 @@ export const getMenuOptions = (
       }
     },
     {
+      divider: true,
       id: 'update-header-depth',
       label: 'Set Max Header Height',
       message: {
         type: MessageFromWebviewType.SET_EXPERIMENTS_HEADER_HEIGHT
+      }
+    },
+    {
+      id: 'select-columns',
+      label: 'Select Columns',
+      message: {
+        type: MessageFromWebviewType.SELECT_COLUMNS
+      }
+    },
+    {
+      id: 'select-first-columns',
+      label: 'Select First Columns',
+      message: {
+        type: MessageFromWebviewType.SELECT_FIRST_COLUMNS
       }
     }
   ]


### PR DESCRIPTION
- Add select first experiment table columns quick pick
- Add select column options to table header cell context menu
- Only allow moving selected columns to the left of the experiments table
