### PR TITLE
Clean up hide column terminology

### DIFF
--- a/extension/src/experiments/webview/messages.ts
+++ b/extension/src/experiments/webview/messages.ts
@@ -86,8 +86,8 @@ export class WebviewMessages {
         })
       case MessageFromWebviewType.TOGGLE_EXPERIMENT_STAR:
         return this.setExperimentStars(message.payload)
-      case MessageFromWebviewType.HIDE_EXPERIMENTS_TABLE_COLUMN:
-        return this.hideTableColumn(message.payload)
+      case MessageFromWebviewType.EXPERIMENTS_TABLE_HIDE_COLUMN_PATH:
+        return this.hideColumnPath(message.payload)
       case MessageFromWebviewType.EXPERIMENTS_TABLE_MOVE_TO_START:
         return this.movePathToStart(message.payload)
       case MessageFromWebviewType.OPEN_PARAMS_FILE_TO_THE_SIDE:
@@ -382,13 +382,13 @@ export class WebviewMessages {
     return commandPromise
   }
 
-  private hideTableColumn(path: string) {
+  private hideColumnPath(path: string) {
     this.columns.unselect(path)
 
     this.notifyChanged()
 
     sendTelemetryEvent(
-      EventName.VIEWS_EXPERIMENTS_TABLE_HIDE_COLUMN,
+      EventName.VIEWS_EXPERIMENTS_TABLE_HIDE_COLUMN_PATH,
       { path },
       undefined
     )

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -43,7 +43,8 @@ export const EventName = Object.assign(
       'views.experimentsTable.focusFiltersTree',
     VIEWS_EXPERIMENTS_TABLE_FOCUS_SORTS_TREE:
       'views.experimentsTable.focusSortsTree',
-    VIEWS_EXPERIMENTS_TABLE_HIDE_COLUMN: 'views.experimentsTable.columnHidden',
+    VIEWS_EXPERIMENTS_TABLE_HIDE_COLUMN_PATH:
+      'views.experimentsTable.hideColumnPath',
     VIEWS_EXPERIMENTS_TABLE_MOVE_TO_START: 'views.experimentsTable.moveToStart',
     VIEWS_EXPERIMENTS_TABLE_OPEN_PARAMS_FILE:
       'views.experimentsTable.paramsFileOpened',
@@ -247,7 +248,7 @@ export interface IEventNamePropertyMapping {
   }
   [EventName.VIEWS_EXPERIMENTS_TABLE_CREATED]: undefined
   [EventName.VIEWS_EXPERIMENTS_TABLE_FOCUS_CHANGED]: WebviewFocusChangedProperties
-  [EventName.VIEWS_EXPERIMENTS_TABLE_HIDE_COLUMN]: {
+  [EventName.VIEWS_EXPERIMENTS_TABLE_HIDE_COLUMN_PATH]: {
     path: string
   }
   [EventName.VIEWS_EXPERIMENTS_TABLE_MOVE_TO_START]: { path: string }

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -477,14 +477,14 @@ suite('Experiments Test Suite', () => {
 
       mockMessageReceived.fire({
         payload: mockColumnId,
-        type: MessageFromWebviewType.HIDE_EXPERIMENTS_TABLE_COLUMN
+        type: MessageFromWebviewType.EXPERIMENTS_TABLE_HIDE_COLUMN_PATH
       })
 
       expect(mockUnselect).to.be.calledOnce
       expect(mockUnselect).to.be.calledWithExactly(mockColumnId)
 
       expect(mockSendTelemetryEvent).to.be.calledWithExactly(
-        EventName.VIEWS_EXPERIMENTS_TABLE_HIDE_COLUMN,
+        EventName.VIEWS_EXPERIMENTS_TABLE_HIDE_COLUMN_PATH,
         { path: mockColumnId },
         undefined
       )

--- a/extension/src/webview/contract.ts
+++ b/extension/src/webview/contract.ts
@@ -48,7 +48,7 @@ export enum MessageFromWebviewType {
   SORT_COLUMN = 'sort-column',
   TOGGLE_EXPERIMENT = 'toggle-experiment',
   TOGGLE_EXPERIMENT_STAR = 'toggle-experiment-star',
-  HIDE_EXPERIMENTS_TABLE_COLUMN = 'hide-experiments-table-column',
+  EXPERIMENTS_TABLE_HIDE_COLUMN_PATH = 'experiments-table-hide-column-path',
   EXPERIMENTS_TABLE_MOVE_TO_START = 'experiments-table-move-to-start',
   SELECT_EXPERIMENTS = 'select-experiments',
   SELECT_COLUMNS = 'select-columns',
@@ -132,7 +132,7 @@ export type MessageFromWebview =
       payload: string[]
     }
   | {
-      type: MessageFromWebviewType.HIDE_EXPERIMENTS_TABLE_COLUMN
+      type: MessageFromWebviewType.EXPERIMENTS_TABLE_HIDE_COLUMN_PATH
       payload: string
     }
   | {

--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -781,7 +781,7 @@ describe('App', () => {
           .map(item => item.textContent)
 
         expect(menuitems).toStrictEqual([
-          'Hide Column',
+          'Hide',
           'Move to Start',
           'Set Max Header Height',
           'Select Columns',
@@ -888,7 +888,7 @@ describe('App', () => {
         fireEvent.contextMenu(placeholder, { bubbles: true })
         advanceTimersByTime(100)
 
-        const hideOption = screen.getByText('Hide Column')
+        const hideOption = screen.getByText('Hide')
 
         mockPostMessage.mockClear()
 
@@ -897,7 +897,7 @@ describe('App', () => {
         expect(mockPostMessage).toHaveBeenCalledTimes(1)
         expect(mockPostMessage).toHaveBeenCalledWith({
           payload: 'Created',
-          type: MessageFromWebviewType.HIDE_EXPERIMENTS_TABLE_COLUMN
+          type: MessageFromWebviewType.EXPERIMENTS_TABLE_HIDE_COLUMN_PATH
         })
       })
     })

--- a/webview/src/experiments/components/table/header/ContextMenuContent.tsx
+++ b/webview/src/experiments/components/table/header/ContextMenuContent.tsx
@@ -95,11 +95,11 @@ export const getMenuOptions = (
   const menuOptions: MessagesMenuOptionProps[] = [
     {
       disabled: isFromExperimentColumn(header),
-      id: 'hide-column',
-      label: 'Hide Column',
+      id: 'hide',
+      label: 'Hide',
       message: {
         payload: leafColumn.id,
-        type: MessageFromWebviewType.HIDE_EXPERIMENTS_TABLE_COLUMN
+        type: MessageFromWebviewType.EXPERIMENTS_TABLE_HIDE_COLUMN_PATH
       }
     },
     {


### PR DESCRIPTION
# 2/2 `main` <- #4303 <- this

When testing the previous PR I noticed that you can hide a column group using the "Hide Column" option. Decided this is a feature instead of a bug so cleaned up some of the terminology around the hide command.

### Demo

https://github.com/iterative/vscode-dvc/assets/37993418/e2ce660a-61ed-4aea-afbd-9a5bccd30574

