### PR TITLE
Set default number of displayed commits to 1 for non-current branches in the experiments table

### DIFF
--- a/extension/src/cli/dvc/constants.ts
+++ b/extension/src/cli/dvc/constants.ts
@@ -15,7 +15,8 @@ export const DVCLIVE_ONLY_RUNNING_SIGNAL_FILE = join(
 )
 export const EXP_RWLOCK_FILE = join(TEMP_EXP_DIR, 'rwlock.lock')
 
-export const DEFAULT_NUM_OF_COMMITS_TO_SHOW = 3
+export const DEFAULT_CURRENT_BRANCH_COMMITS_TO_SHOW = 3
+export const DEFAULT_OTHER_BRANCH_COMMITS_TO_SHOW = 1
 export const NUM_OF_COMMITS_TO_INCREASE = 2
 
 export enum Command {

--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -35,7 +35,10 @@ import { flattenMapValues } from '../../util/map'
 import { ModelWithPersistence } from '../../persistence/model'
 import { PersistenceKey } from '../../persistence/constants'
 import { sum } from '../../util/math'
-import { DEFAULT_NUM_OF_COMMITS_TO_SHOW } from '../../cli/dvc/constants'
+import {
+  DEFAULT_CURRENT_BRANCH_COMMITS_TO_SHOW,
+  DEFAULT_OTHER_BRANCH_COMMITS_TO_SHOW
+} from '../../cli/dvc/constants'
 
 type StarredExperiments = Record<string, boolean | undefined>
 
@@ -456,7 +459,12 @@ export class ExperimentsModel extends ModelWithPersistence {
   }
 
   public getNbOfCommitsToShow(branch: string) {
-    return this.numberOfCommitsToShow[branch] || DEFAULT_NUM_OF_COMMITS_TO_SHOW
+    return (
+      this.numberOfCommitsToShow[branch] ||
+      (branch === this.currentBranch
+        ? DEFAULT_CURRENT_BRANCH_COMMITS_TO_SHOW
+        : DEFAULT_OTHER_BRANCH_COMMITS_TO_SHOW)
+    )
   }
 
   public getAllNbOfCommitsToShow() {

--- a/extension/src/test/suite/experiments/data/index.test.ts
+++ b/extension/src/test/suite/experiments/data/index.test.ts
@@ -20,7 +20,7 @@ import {
 } from '../../../../commands/internal'
 import { buildExperimentsData } from '../util'
 import {
-  DEFAULT_NUM_OF_COMMITS_TO_SHOW,
+  DEFAULT_CURRENT_BRANCH_COMMITS_TO_SHOW,
   ExperimentFlag
 } from '../../../../cli/dvc/constants'
 import { EXPERIMENTS_GIT_LOGS_REFS } from '../../../../experiments/data/constants'
@@ -103,7 +103,7 @@ suite('Experiments Data Test Suite', () => {
           {
             getBranchesToShow: () => ['main'],
             getNbOfCommitsToShow: () => ({
-              main: DEFAULT_NUM_OF_COMMITS_TO_SHOW
+              main: DEFAULT_CURRENT_BRANCH_COMMITS_TO_SHOW
             }),
             setBranches: stub()
           } as unknown as ExperimentsModel,
@@ -165,7 +165,7 @@ suite('Experiments Data Test Suite', () => {
           {
             getBranchesToShow: () => ['main'],
             getNbOfCommitsToShow: () => ({
-              main: DEFAULT_NUM_OF_COMMITS_TO_SHOW
+              main: DEFAULT_CURRENT_BRANCH_COMMITS_TO_SHOW
             }),
             setBranches: stub()
           } as unknown as ExperimentsModel,

--- a/extension/src/test/suite/experiments/util.ts
+++ b/extension/src/test/suite/experiments/util.ts
@@ -16,7 +16,7 @@ import { ExperimentsData } from '../../../experiments/data'
 import * as Watcher from '../../../fileSystem/watcher'
 import { ExperimentsModel } from '../../../experiments/model'
 import { ColumnsModel } from '../../../experiments/columns/model'
-import { DEFAULT_NUM_OF_COMMITS_TO_SHOW } from '../../../cli/dvc/constants'
+import { DEFAULT_CURRENT_BRANCH_COMMITS_TO_SHOW } from '../../../cli/dvc/constants'
 import { PersistenceKey } from '../../../persistence/constants'
 import { ExpShowOutput } from '../../../cli/dvc/contract'
 import { buildExperimentsPipeline } from '../pipeline/util'
@@ -235,7 +235,7 @@ export const buildExperimentsData = (
       internalCommands,
       {
         getBranchesToShow: mockGetBranchesToShow,
-        getNbOfCommitsToShow: () => DEFAULT_NUM_OF_COMMITS_TO_SHOW,
+        getNbOfCommitsToShow: () => DEFAULT_CURRENT_BRANCH_COMMITS_TO_SHOW,
         setBranches: mockSetBranches
       } as unknown as ExperimentsModel,
       []


### PR DESCRIPTION
Covers the second checkbox in #4269 
> Setting to show only the top of each branch

We achieve this by setting the default number of commits shown for non-current branches to 1. 

### Demo


https://github.com/iterative/vscode-dvc/assets/37993418/e8a59d0f-b63d-49b1-bfcd-1966d4b74215


Note: The main reason for continuing to display 3 commits (by default) for the current branch is to educate people on how the table works and to stop experiments from "disappearing" for new users making commits.