### PR TITLE
Standardise column like quick pick

### DIFF
--- a/extension/src/experiments/columns/quickPick.test.ts
+++ b/extension/src/experiments/columns/quickPick.test.ts
@@ -49,13 +49,11 @@ describe('pickFromColumnLikes', () => {
     expect(mockedQuickPickValue).toHaveBeenCalledWith(
       [
         {
-          description: epochsParamPath,
-          label: 'epochs',
+          label: epochsParamPath,
           value: epochsParam
         },
         {
-          description: paramsYamlPath,
-          label: paramsYaml,
+          label: paramsYamlPath,
           value: paramsYamlParam
         }
       ],

--- a/extension/src/experiments/columns/quickPick.ts
+++ b/extension/src/experiments/columns/quickPick.ts
@@ -13,12 +13,22 @@ export const pickFromColumnLikes = (
   if (!definedAndNonEmpty(columnLikes)) {
     return Toast.showError('There are no columns to select from.')
   }
-  return quickPickValue<ColumnLike>(
-    columnLikes.map(columnLike => ({
-      description: columnLike.path,
-      label: columnLike.label,
+
+  const items = []
+  for (const columnLike of columnLikes) {
+    if (columnLike.path === 'starred') {
+      items.push({
+        description: columnLike.path,
+        label: columnLike.label,
+        value: columnLike
+      })
+      continue
+    }
+    items.push({
+      label: columnLike.path,
       value: columnLike
-    })),
-    quickPickOptions
-  )
+    })
+  }
+
+  return quickPickValue<ColumnLike>(items, quickPickOptions)
 }

--- a/extension/src/plots/model/quickPick.test.ts
+++ b/extension/src/plots/model/quickPick.test.ts
@@ -231,18 +231,15 @@ describe('pickMetricAndParam', () => {
       1,
       [
         {
-          description: 'metrics:summary.json:loss',
-          label: 'loss',
+          label: 'metrics:summary.json:loss',
           value: { label: 'loss', path: 'metrics:summary.json:loss' }
         },
         {
-          description: 'metrics:summary.json:accuracy',
-          label: 'accuracy',
+          label: 'metrics:summary.json:accuracy',
           value: { label: 'accuracy', path: 'metrics:summary.json:accuracy' }
         },
         {
-          description: 'metrics:summary.json:val_loss',
-          label: 'val_loss',
+          label: 'metrics:summary.json:val_loss',
           value: { label: 'val_loss', path: 'metrics:summary.json:val_loss' }
         }
       ],
@@ -254,8 +251,7 @@ describe('pickMetricAndParam', () => {
       2,
       [
         {
-          description: 'params:params.yaml:epochs',
-          label: 'epochs',
+          label: 'params:params.yaml:epochs',
           value: { label: 'epochs', path: 'params:params.yaml:epochs' }
         }
       ],


### PR DESCRIPTION
# 2/2 `main` <- #4306 <- this

I noticed that we had some inconsistencies in the way that we displayed some quick picks for paths.

### Before

<img width="1728" alt="image" src="https://github.com/iterative/vscode-dvc/assets/37993418/60e57d5a-d5e7-4ebf-829c-c99e1a06a175">

### After

https://github.com/iterative/vscode-dvc/assets/37993418/7a8e55b1-9fba-4053-8190-5e10563f8f5e


Note: I initially did all of the work to convert all quick picks to match the style in the before picture but after looking at the UX I decided to go the other way. Given the way that people invariably set out their data with multiple versions of a column in different folders (i.e train vs test) I think that only showing the final part of the path in the label is less useful than showing the whole thing.