### PR TITLE
Rename select columns commands and events

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -567,13 +567,13 @@
       },
       {
         "title": "Select Columns to Display in the Experiments Table",
-        "command": "dvc.views.experimentsColumnsTree.selectColumns",
+        "command": "dvc.views.experiments.selectColumns",
         "category": "DVC",
         "icon": "$(list-filter)"
       },
       {
         "title": "Select Columns to Display First in the Experiments Table",
-        "command": "dvc.views.experimentsColumnsTree.selectFirstColumns",
+        "command": "dvc.views.experiments.selectFirstColumns",
         "category": "DVC",
         "icon": "$(arrow-left)"
       },
@@ -922,11 +922,11 @@
           "when": "dvc.commands.available && dvc.project.available && dvc.experiment.running"
         },
         {
-          "command": "dvc.views.experimentsColumnsTree.selectColumns",
+          "command": "dvc.views.experiments.selectColumns",
           "when": "dvc.commands.available && dvc.project.available"
         },
         {
-          "command": "dvc.views.experimentsColumnsTree.selectFirstColumns",
+          "command": "dvc.views.experiments.selectFirstColumns",
           "when": "dvc.commands.available && dvc.project.available"
         },
         {
@@ -1290,12 +1290,12 @@
           "group": "navigation@2"
         },
         {
-          "command": "dvc.views.experimentsColumnsTree.selectColumns",
+          "command": "dvc.views.experiments.selectColumns",
           "when": "view == dvc.views.experimentsColumnsTree",
           "group": "navigation@2"
         },
         {
-          "command": "dvc.views.experimentsColumnsTree.selectFirstColumns",
+          "command": "dvc.views.experiments.selectFirstColumns",
           "when": "view == dvc.views.experimentsColumnsTree",
           "group": "navigation@3"
         },

--- a/extension/src/commands/external.ts
+++ b/extension/src/commands/external.ts
@@ -50,8 +50,8 @@ export enum RegisteredCliCommands {
 }
 
 export enum RegisteredCommands {
-  EXPERIMENT_COLUMNS_SELECT = 'dvc.views.experimentsColumnsTree.selectColumns',
-  EXPERIMENT_COLUMNS_SELECT_FIRST = 'dvc.views.experimentsColumnsTree.selectFirstColumns',
+  EXPERIMENT_COLUMNS_SELECT = 'dvc.views.experiments.selectColumns',
+  EXPERIMENT_COLUMNS_SELECT_FIRST = 'dvc.views.experiments.selectFirstColumns',
   EXPERIMENT_FILTER_ADD = 'dvc.addExperimentsTableFilter',
   EXPERIMENT_FILTER_ADD_STARRED = 'dvc.addStarredExperimentsTableFilter',
   EXPERIMENT_FILTER_REMOVE = 'dvc.views.experimentsFilterByTree.removeFilter',

--- a/extension/src/test/suite/experiments/columns/tree.test.ts
+++ b/extension/src/test/suite/experiments/columns/tree.test.ts
@@ -355,7 +355,7 @@ suite('Experiments Columns Tree Test Suite', () => {
       ).to.equal(Status.UNSELECTED)
     })
 
-    it('should be able to display selected columns first with dvc.views.experimentsColumnsTree.selectFirstColumns', async () => {
+    it('should be able to display selected columns first with dvc.views.experiments.selectFirstColumns', async () => {
       const { experiments, columnsModel } =
         stubWorkspaceExperimentsGetters(disposable)
       await experiments.isReady()


### PR DESCRIPTION
Small piece of housekeeping related to the underlying names/events for the `dvc.views.experimentsColumnsTree.selectColumns`/`dvc.views.experimentsColumnsTree.selectFirstColumns` commands. These commands are now readily available in the experiments table as well so they should have the generic `dvc.views.experiments.` prefix.