### PR TITLE
Disable exp push when experiment is running in the workspace

### DIFF
--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -1956,4 +1956,28 @@ describe('App', () => {
       })
     })
   })
+
+  describe('Experiment git remote status indicator', () => {
+    it('should not allow pushing an experiment when an experiment is running in the workspace', () => {
+      renderTable()
+
+      fireEvent.click(screen.getByTestId('exp-f13bca-push-experiment'))
+
+      expect(mockPostMessage).not.toHaveBeenCalledWith({
+        payload: ['exp-f13bca'],
+        type: MessageFromWebviewType.PUSH_EXPERIMENT
+      })
+    })
+
+    it('should allow pushing an experiment when an experiment is not running in the workspace', () => {
+      renderTableWithoutRunningExperiments()
+
+      fireEvent.click(screen.getByTestId('exp-f13bca-push-experiment'))
+
+      expect(mockPostMessage).toHaveBeenCalledWith({
+        payload: ['exp-f13bca'],
+        type: MessageFromWebviewType.PUSH_EXPERIMENT
+      })
+    })
+  })
 })

--- a/webview/src/experiments/components/table/body/Cell.tsx
+++ b/webview/src/experiments/components/table/body/Cell.tsx
@@ -35,7 +35,7 @@ const RowExpansionButton: React.FC<RowProp> = ({ row }) =>
       />
     </button>
   ) : (
-    <span className={styles.rowArrowContainer} />
+    <span className={styles.emptyRowArrowContainer} />
   )
 
 export const StubCell: React.FC<

--- a/webview/src/experiments/components/table/body/ExperimentStatusIndicator.tsx
+++ b/webview/src/experiments/components/table/body/ExperimentStatusIndicator.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { VSCodeProgressRing } from '@vscode/webview-ui-toolkit/react'
 import cx from 'classnames'
+import { useSelector } from 'react-redux'
 import {
   ExperimentStatus,
   GitRemoteStatus,
@@ -12,6 +13,7 @@ import { clickAndEnterProps } from '../../../../util/props'
 import { pushExperiment } from '../../../util/messages'
 import { Cloud, CloudUpload } from '../../../../shared/components/icons'
 import { Icon } from '../../../../shared/components/Icon'
+import { ExperimentsState } from '../../../store'
 
 type ExperimentStatusIndicatorProps = {
   status: ExperimentStatus | undefined
@@ -22,6 +24,10 @@ type ExperimentStatusIndicatorProps = {
 export const ExperimentStatusIndicator: React.FC<
   ExperimentStatusIndicatorProps
 > = ({ id, status, gitRemoteStatus }) => {
+  const { hasRunningWorkspaceExperiment } = useSelector(
+    (state: ExperimentsState) => state.tableData
+  )
+
   if (isRunning(status) || gitRemoteStatus === GitRemoteStatus.PUSHING) {
     return (
       <VSCodeProgressRing className={cx(styles.running, 'chromatic-ignore')} />
@@ -29,15 +35,24 @@ export const ExperimentStatusIndicator: React.FC<
   }
 
   if (gitRemoteStatus === GitRemoteStatus.NOT_ON_REMOTE) {
+    const tooltipContent =
+      'Experiment not found on remote' +
+      (hasRunningWorkspaceExperiment ? '' : '\nClick to push')
+
     return (
-      <CellHintTooltip
-        tooltipContent={'Experiment not found on remote\nClick to push'}
-      >
+      <CellHintTooltip tooltipContent={tooltipContent}>
         <div
           className={styles.upload}
-          {...clickAndEnterProps(() => pushExperiment(id))}
+          {...clickAndEnterProps(
+            () => !hasRunningWorkspaceExperiment && pushExperiment(id)
+          )}
         >
-          <Icon className={styles.cloudBox} icon={CloudUpload} />
+          <Icon
+            data-testid={`${id}-push-experiment`}
+            aria-disabled={false}
+            className={styles.cloudBox}
+            icon={CloudUpload}
+          />
         </div>
       </CellHintTooltip>
     )

--- a/webview/src/experiments/components/table/styles.module.scss
+++ b/webview/src/experiments/components/table/styles.module.scss
@@ -30,6 +30,18 @@ $badge-size: 0.85rem;
   margin: 12px 6px;
 }
 
+%rowArrowContainer {
+  width: 20px;
+  height: 32px;
+  padding: 0;
+  flex: 0 0 20px;
+  right: 6px;
+  display: inline-block;
+  position: relative;
+  border: none;
+  background: none;
+}
+
 %truncateLeftParent {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -657,6 +669,11 @@ $badge-size: 0.85rem;
   @extend %iconBox;
 
   padding: 1px;
+
+  &[aria-disabled='true'] {
+    cursor: default;
+    opacity: 0.4;
+  }
 }
 
 .cloudIndicator {
@@ -690,16 +707,15 @@ $badge-size: 0.85rem;
 }
 
 .rowArrowContainer {
-  width: 20px;
-  height: 32px;
-  padding: 0;
-  flex: 0 0 20px;
-  right: 6px;
-  display: inline-block;
-  position: relative;
-  border: none;
-  background: none;
+  @extend %rowArrowContainer;
+
   cursor: pointer;
+}
+
+.emptyRowArrowContainer {
+  @extend %rowArrowContainer;
+
+  cursor: default;
 }
 
 .expandedRowArrow {


### PR DESCRIPTION
This PR disables pushing an experiment via the icon introduced in #4324 when there is an experiment running in the workspace (matches context menu behaviour).

### Demo

https://github.com/iterative/vscode-dvc/assets/37993418/11f84b3a-82ce-415a-8d3a-53de61f21577

