### PR TITLE
Improve performance of experiment column collection

### DIFF
--- a/extension/src/experiments/columns/collect/deps.ts
+++ b/extension/src/experiments/columns/collect/deps.ts
@@ -18,6 +18,12 @@ export const collectDeps = (acc: ColumnAccumulator, data: ExpData) => {
     return
   }
   for (const [file, { hash }] of Object.entries(deps)) {
+    const path = buildDepPath(file)
+    if (acc.collected.has(path)) {
+      return
+    }
+    acc.collected.add(path)
+
     const pathArray = getPathArray(file)
     const label = pathArray.pop() as string
 
@@ -27,7 +33,6 @@ export const collectDeps = (acc: ColumnAccumulator, data: ExpData) => {
       '/',
       label
     )
-    const path = buildDepPath(file)
 
     mergeAncestors(
       acc,

--- a/extension/src/experiments/columns/collect/index.test.ts
+++ b/extension/src/experiments/columns/collect/index.test.ts
@@ -22,13 +22,13 @@ const mockedGetConfigValue = jest.mocked(getConfigValue)
 mockedGetConfigValue.mockImplementation(() => 5)
 
 describe('collectColumns', () => {
-  it('should return a value equal to the columns fixture when given the output fixture', () => {
-    const columns = collectColumns(outputFixture)
+  it('should return a value equal to the columns fixture when given the output fixture', async () => {
+    const columns = await collectColumns(outputFixture)
     expect(columns).toStrictEqual(columnsFixture)
   })
 
-  it('should output both params and metrics when both are present', () => {
-    const columns = collectColumns(
+  it('should output both params and metrics when both are present', async () => {
+    const columns = await collectColumns(
       generateTestExpShowOutput({
         metrics: {
           1: {
@@ -50,8 +50,8 @@ describe('collectColumns', () => {
     expect(metrics).toBeDefined()
   })
 
-  it('should omit params when none exist in the source data', () => {
-    const columns = collectColumns(
+  it('should omit params when none exist in the source data', async () => {
+    const columns = await collectColumns(
       generateTestExpShowOutput({
         metrics: {
           1: {
@@ -66,13 +66,13 @@ describe('collectColumns', () => {
     expect(metrics).toBeDefined()
   })
 
-  it('should return an empty array if no params and metrics are provided', () => {
-    const columns = collectColumns(generateTestExpShowOutput({}))
+  it('should return an empty array if no params and metrics are provided', async () => {
+    const columns = await collectColumns(generateTestExpShowOutput({}))
     expect(columns).toStrictEqual([])
   })
 
-  it('should aggregate multiple different field names', () => {
-    const columns = collectColumns(
+  it('should aggregate multiple different field names', async () => {
+    const columns = await collectColumns(
       generateTestExpShowOutput(
         {
           params: {
@@ -127,8 +127,8 @@ describe('collectColumns', () => {
     ])
   })
 
-  it('should create concatenated columns for nesting deeper than 5', () => {
-    const columns = collectColumns(
+  it('should create concatenated columns for nesting deeper than 5', async () => {
+    const columns = await collectColumns(
       generateTestExpShowOutput({
         params: {
           'params.yaml': {

--- a/extension/src/experiments/columns/model.test.ts
+++ b/extension/src/experiments/columns/model.test.ts
@@ -133,6 +133,7 @@ describe('ColumnsModel', () => {
     )
     await model.transformAndSet(deeplyNestedOutputFixture)
     expect(mockedGetConfigValue).toHaveBeenCalled()
+
     expect(model.getSelected()).toStrictEqual(deeplyNestedColumnsWithHeightOf1)
   })
 

--- a/extension/src/test/fixtures/expShow/deeplyNested/maxHeight.ts
+++ b/extension/src/test/fixtures/expShow/deeplyNested/maxHeight.ts
@@ -352,20 +352,21 @@ export const deeplyNestedColumnsWithHeightOf2: Column[] = [
 export const deeplyNestedColumnsWithHeightOf1: Column[] = [
   timestampColumn,
   {
+    firstValueType: 'string',
     hasChildren: false,
     label: 'params.yaml:nested1.doubled',
     parentPath: 'params',
-    path: 'params:doubled',
+    path: 'params:params.yaml:nested1.doubled',
     pathArray: ['params', 'params.yaml', 'nested1', 'doubled'],
-    type: ColumnType.PARAMS,
-    firstValueType: 'string'
+    type: ColumnType.PARAMS
   },
   {
+    firstValueType: 'string',
     hasChildren: false,
     label:
       'params.yaml:nested1.nested2.nested3.nested4.nested5.nested6.nested7',
     parentPath: 'params',
-    path: 'params:nested7',
+    path: 'params:params.yaml:nested1.nested2.nested3.nested4.nested5.nested6.nested7',
     pathArray: [
       'params',
       'params.yaml',
@@ -377,14 +378,14 @@ export const deeplyNestedColumnsWithHeightOf1: Column[] = [
       'nested6',
       'nested7'
     ],
-    type: ColumnType.PARAMS,
-    firstValueType: 'string'
+    type: ColumnType.PARAMS
   },
   {
+    firstValueType: 'string',
     hasChildren: false,
     label: 'params.yaml:nested1.nested2.nested3.nested4.nested5b.nested6',
     parentPath: 'params',
-    path: 'params:nested6',
+    path: 'params:params.yaml:nested1.nested2.nested3.nested4.nested5b.nested6',
     pathArray: [
       'params',
       'params.yaml',
@@ -395,16 +396,33 @@ export const deeplyNestedColumnsWithHeightOf1: Column[] = [
       'nested5b',
       'nested6'
     ],
-    type: ColumnType.PARAMS,
-    firstValueType: 'string'
+    type: ColumnType.PARAMS
   },
   {
+    firstValueType: 'string',
+    hasChildren: false,
+    label: 'params.yaml:nested1.nested2.nested3.nested4.nested5b.doubled',
+    parentPath: 'params',
+    path: 'params:params.yaml:nested1.nested2.nested3.nested4.nested5b.doubled',
+    pathArray: [
+      'params',
+      'params.yaml',
+      'nested1',
+      'nested2',
+      'nested3',
+      'nested4',
+      'nested5b',
+      'doubled'
+    ],
+    type: ColumnType.PARAMS
+  },
+  {
+    firstValueType: 'number',
     hasChildren: false,
     label: 'params.yaml:outlier',
     parentPath: 'params',
-    path: 'params:outlier',
+    path: 'params:params.yaml:outlier',
     pathArray: ['params', 'params.yaml', 'outlier'],
-    type: ColumnType.PARAMS,
-    firstValueType: 'number'
+    type: ColumnType.PARAMS
   }
 ]


### PR DESCRIPTION
# 2/3 `main` <- #4346 <- this <- #4354

This PR uses promises to make parts of column collection asynchronous, fixes a bug (see inline comment) and improves our early return logic to avoid unnecessary processing.