### PR TITLE
Remove await from inside of loops

### DIFF
--- a/extension/src/repository/model/collect.ts
+++ b/extension/src/repository/model/collect.ts
@@ -335,9 +335,15 @@ export const collectTrackedPaths = async (
     return acc
   }
   const children = await getChildren(resourceUri.fsPath)
+  const promises = []
   for (const child of children) {
-    acc.push(...(await collectTrackedPaths(child, getChildren)))
+    promises.push(collectTrackedPaths(child, getChildren))
   }
+  const results = await Promise.all(promises)
+  for (const result of results) {
+    acc.push(...result)
+  }
+
   return acc
 }
 


### PR DESCRIPTION
# 3/3 `main` <- #4346 <- #4353 <- this

I turned on eslint's [no-await-in-loop](https://eslint.org/docs/latest/rules/no-await-in-loop) and reviewed all instances case-by-case. Of the 30 or so instances of a rule violation, the two in this PR were the ones that stood out.