### PR TITLE
Rename experiment status to executor status

### DIFF
--- a/extension/src/cli/dvc/contract.ts
+++ b/extension/src/cli/dvc/contract.ts
@@ -38,7 +38,7 @@ export const isValueTree = (
 ): value is NonNullable<ValueTree> =>
   !!(value && !Array.isArray(value) && typeof value === 'object')
 
-export enum ExperimentStatus {
+export enum ExecutorStatus {
   FAILED = 'failed',
   QUEUED = 'queued',
   RUNNING = 'running',
@@ -81,7 +81,7 @@ export enum Executor {
 }
 
 export type ExecutorState = {
-  state: ExperimentStatus
+  state: ExecutorStatus
   name: Executor | null
   local: {
     root: string | null

--- a/extension/src/experiments/model/collect.ts
+++ b/extension/src/experiments/model/collect.ts
@@ -15,7 +15,7 @@ import {
 } from '../webview/contract'
 import {
   EXPERIMENT_WORKSPACE_ID,
-  ExperimentStatus,
+  ExecutorStatus,
   ExpShowOutput,
   ExpState,
   Executor,
@@ -229,11 +229,11 @@ const collectExecutorInfo = (
 
   const { name, state } = executor
 
-  if (name && state === ExperimentStatus.RUNNING) {
+  if (name && state === ExecutorStatus.RUNNING) {
     experiment.executor = name
   }
-  if (state && state !== ExperimentStatus.SUCCESS) {
-    experiment.status = state
+  if (state && state !== ExecutorStatus.SUCCESS) {
+    experiment.executorStatus = state
   }
 }
 
@@ -241,7 +241,7 @@ const collectRunningExperiment = (
   acc: ExperimentsAccumulator,
   experiment: Experiment
 ): void => {
-  if (!isRunning(experiment.status)) {
+  if (!isRunning(experiment.executorStatus)) {
     return
   }
   acc.runningExperiments.push({
@@ -310,7 +310,7 @@ const setWorkspaceAsRunning = (
     )
   ) {
     acc.workspace.executor = Executor.WORKSPACE
-    acc.workspace.status = ExperimentStatus.RUNNING
+    acc.workspace.executorStatus = ExecutorStatus.RUNNING
   }
 
   if (dvcLiveOnly) {
@@ -435,7 +435,7 @@ const collectExperimentsAndCommit = (
 ): void => {
   acc.push(commit)
   for (const experiment of experiments) {
-    if (isQueued(experiment.status)) {
+    if (isQueued(experiment.executorStatus)) {
       continue
     }
     acc.push(experiment)

--- a/extension/src/experiments/model/index.test.ts
+++ b/extension/src/experiments/model/index.test.ts
@@ -20,7 +20,7 @@ import dataTypesOutputFixture from '../../test/fixtures/expShow/dataTypes/output
 import survivalOutputFixture from '../../test/fixtures/expShow/survival/output'
 import survivalRowsFixture from '../../test/fixtures/expShow/survival/rows'
 import {
-  ExperimentStatus,
+  ExecutorStatus,
   EXPERIMENT_WORKSPACE_ID,
   Executor,
   ExpWithError,
@@ -111,7 +111,9 @@ describe('ExperimentsModel', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const runningWorkspace = (model as any).workspace
     expect(runningWorkspace?.executor).toStrictEqual(EXPERIMENT_WORKSPACE_ID)
-    expect(runningWorkspace?.status).toStrictEqual(ExperimentStatus.RUNNING)
+    expect(runningWorkspace?.executorStatus).toStrictEqual(
+      ExecutorStatus.RUNNING
+    )
 
     model.transformAndSetLocal(dvcLiveOnly, ...DEFAULT_DATA)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -292,7 +294,7 @@ describe('ExperimentsModel', () => {
             executor: {
               local: null,
               name: Executor.WORKSPACE,
-              state: ExperimentStatus.RUNNING
+              state: ExecutorStatus.RUNNING
             },
             name: runningExpName,
             rev: EXPERIMENT_WORKSPACE_ID
@@ -305,7 +307,7 @@ describe('ExperimentsModel', () => {
             executor: {
               local: null,
               name: Executor.DVC_TASK,
-              state: ExperimentStatus.RUNNING
+              state: ExecutorStatus.RUNNING
             },
             name: runningTaskName,
             rev: EXPERIMENT_WORKSPACE_ID

--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -30,11 +30,7 @@ import {
   WORKSPACE_BRANCH
 } from '../webview/contract'
 import { reorderListSubset } from '../../util/array'
-import {
-  Executor,
-  ExpShowOutput,
-  ExperimentStatus
-} from '../../cli/dvc/contract'
+import { Executor, ExpShowOutput, ExecutorStatus } from '../../cli/dvc/contract'
 import { flattenMapValues } from '../../util/map'
 import { ModelWithPersistence } from '../../persistence/model'
 import { PersistenceKey } from '../../persistence/constants'
@@ -184,7 +180,7 @@ export class ExperimentsModel extends ModelWithPersistence {
       ({ id: expId }) => expId === id
     )
 
-    if (isQueued(experiment?.status)) {
+    if (isQueued(experiment?.executorStatus)) {
       return UNSELECTED
     }
 
@@ -378,8 +374,8 @@ export class ExperimentsModel extends ModelWithPersistence {
   }
 
   public getExperiments() {
-    return this.getExperimentsAndQueued().filter(({ status }) => {
-      return !isQueued(status)
+    return this.getExperimentsAndQueued().filter(({ executorStatus }) => {
+      return !isQueued(executorStatus)
     })
   }
 
@@ -397,7 +393,7 @@ export class ExperimentsModel extends ModelWithPersistence {
 
   public getRunningExperiments() {
     return this.getExperimentsAndQueued().filter(experiment =>
-      isRunning(experiment.status)
+      isRunning(experiment.executorStatus)
     )
   }
 
@@ -471,7 +467,7 @@ export class ExperimentsModel extends ModelWithPersistence {
     return this.getExperimentsByCommit(commit)?.map(experiment => ({
       ...experiment,
       hasChildren: false,
-      type: this.getExperimentType(experiment.status)
+      type: this.getExperimentType(experiment.executorStatus)
     }))
   }
 
@@ -569,7 +565,7 @@ export class ExperimentsModel extends ModelWithPersistence {
     if (
       this.remoteExpShas === undefined ||
       !experiment.sha ||
-      ![undefined, ExperimentStatus.SUCCESS].includes(experiment.status)
+      ![undefined, ExecutorStatus.SUCCESS].includes(experiment.executorStatus)
     ) {
       return
     }
@@ -670,11 +666,11 @@ export class ExperimentsModel extends ModelWithPersistence {
     }
   }
 
-  private getExperimentType(status?: ExperimentStatus) {
-    if (isQueued(status)) {
+  private getExperimentType(executorStatus?: ExecutorStatus) {
+    if (isQueued(executorStatus)) {
       return ExperimentType.QUEUED
     }
-    if (isRunning(status)) {
+    if (isRunning(executorStatus)) {
       return ExperimentType.RUNNING
     }
 

--- a/extension/src/experiments/model/status/collect.test.ts
+++ b/extension/src/experiments/model/status/collect.test.ts
@@ -3,7 +3,7 @@ import { collectColoredStatus } from './collect'
 import { copyOriginalColors } from './colors'
 import { Experiment } from '../../webview/contract'
 import {
-  ExperimentStatus,
+  ExecutorStatus,
   EXPERIMENT_WORKSPACE_ID
 } from '../../../cli/dvc/contract'
 
@@ -39,7 +39,7 @@ describe('collectColoredStatus', () => {
   it('should not push queued experiments into the returned object', () => {
     const experiments = [
       { id: 'exp1' },
-      { id: 'exp2', status: ExperimentStatus.QUEUED }
+      { executorStatus: ExecutorStatus.QUEUED, id: 'exp2' }
     ] as Experiment[]
     const colors = copyOriginalColors()
 
@@ -214,8 +214,8 @@ describe('collectColoredStatus', () => {
       [
         {
           executor: null,
-          id: 'exp-1',
-          status: ExperimentStatus.SUCCESS
+          executorStatus: ExecutorStatus.SUCCESS,
+          id: 'exp-1'
         },
         {
           id: EXPERIMENT_WORKSPACE_ID

--- a/extension/src/experiments/model/status/collect.ts
+++ b/extension/src/experiments/model/status/collect.ts
@@ -18,7 +18,7 @@ const canAssign = (
 ): boolean => canSelect(coloredStatus) && definedAndNonEmpty(unassignedColors)
 
 const collectStatus = (acc: ColoredStatus, experiment: Experiment): void => {
-  const { id, status } = experiment
+  const { id, executorStatus: status } = experiment
   if (!id || isQueued(status) || hasKey(acc, id)) {
     return
   }
@@ -164,8 +164,10 @@ const assignSelected = (
   return { availableColors, coloredStatus }
 }
 
-const cannotSelect = (ids: Set<string>, { id, status }: Experiment): boolean =>
-  isQueued(status) || ids.has(id)
+const cannotSelect = (
+  ids: Set<string>,
+  { id, executorStatus: status }: Experiment
+): boolean => isQueued(status) || ids.has(id)
 
 export const collectSelectable = (
   selectedExperiments: Experiment[]

--- a/extension/src/experiments/model/status/index.test.ts
+++ b/extension/src/experiments/model/status/index.test.ts
@@ -1,7 +1,7 @@
 import { canSelect, limitToMaxSelected } from '.'
 import { copyOriginalColors } from './colors'
 import { Experiment } from '../../webview/contract'
-import { ExperimentStatus } from '../../../cli/dvc/contract'
+import { ExecutorStatus } from '../../../cli/dvc/contract'
 
 describe('canSelect', () => {
   const colors = copyOriginalColors()
@@ -51,9 +51,9 @@ describe('limitToMaxSelected', () => {
         ...mockedExperiments,
         {
           branch: 'main',
+          executorStatus: ExecutorStatus.RUNNING,
           id: '1',
-          label: 'R',
-          status: ExperimentStatus.RUNNING
+          label: 'R'
         }
       ])
         .map(({ label }) => label)

--- a/extension/src/experiments/model/status/index.ts
+++ b/extension/src/experiments/model/status/index.ts
@@ -25,9 +25,9 @@ const compareTimestamps = (a: Experiment, b: Experiment) =>
 export const limitToMaxSelected = (experiments: Experiment[]) =>
   [...experiments]
     .sort((a, b) => {
-      if (a.status === b.status) {
+      if (a.executorStatus === b.executorStatus) {
         return compareTimestamps(a, b)
       }
-      return isRunning(a.status) ? -1 : 1
+      return isRunning(a.executorStatus) ? -1 : 1
     })
     .slice(0, MAX_SELECTED_EXPERIMENTS)

--- a/extension/src/experiments/webview/contract.ts
+++ b/extension/src/experiments/webview/contract.ts
@@ -1,7 +1,6 @@
-import { Executor, ExperimentStatus, ValueTree } from '../../cli/dvc/contract'
+import { Executor, ExecutorStatus, ValueTree } from '../../cli/dvc/contract'
 import { SortDefinition } from '../model/sortBy'
-
-export { ExperimentStatus } from '../../cli/dvc/contract'
+export { ExecutorStatus } from '../../cli/dvc/contract'
 
 export interface MetricOrParamColumns {
   [filename: string]: ValueTree
@@ -51,24 +50,25 @@ export type Experiment = {
   selected?: boolean
   sha?: string
   starred?: boolean
-  status?: ExperimentStatus
+  executorStatus?: ExecutorStatus
   timestamp?: string | null
   branch?: string | typeof WORKSPACE_BRANCH
 }
 
-export const isRunning = (status: ExperimentStatus | undefined): boolean =>
-  status === ExperimentStatus.RUNNING
+export const isRunning = (
+  executorStatus: ExecutorStatus | undefined
+): boolean => executorStatus === ExecutorStatus.RUNNING
 
-export const isQueued = (status: ExperimentStatus | undefined): boolean =>
-  status === ExperimentStatus.QUEUED
+export const isQueued = (executorStatus: ExecutorStatus | undefined): boolean =>
+  executorStatus === ExecutorStatus.QUEUED
 
 export const isRunningInQueue = ({
-  status,
+  executorStatus,
   executor
 }: {
-  status?: ExperimentStatus
+  executorStatus?: ExecutorStatus
   executor?: string | null
-}): boolean => isRunning(status) && executor === Executor.DVC_TASK
+}): boolean => isRunning(executorStatus) && executor === Executor.DVC_TASK
 
 export interface Commit extends Experiment {
   subRows?: Experiment[]

--- a/extension/src/test/fixtures/expShow/base/output.ts
+++ b/extension/src/test/fixtures/expShow/base/output.ts
@@ -2,7 +2,7 @@ import { join } from '../../../util/path'
 import {
   EXPERIMENT_WORKSPACE_ID,
   Executor,
-  ExperimentStatus,
+  ExecutorStatus,
   ExpShowOutput
 } from '../../../../cli/dvc/contract'
 
@@ -345,7 +345,7 @@ const data: ExpShowOutput = [
         ],
         executor: {
           name: Executor.DVC_TASK,
-          state: ExperimentStatus.RUNNING,
+          state: ExecutorStatus.RUNNING,
           local: null
         }
       },
@@ -580,7 +580,7 @@ const data: ExpShowOutput = [
         executor: {
           name: Executor.WORKSPACE,
           local: { pid: 1234, root: null, log: null, returncode: null },
-          state: ExperimentStatus.RUNNING
+          state: ExecutorStatus.RUNNING
         }
       },
       {
@@ -593,7 +593,7 @@ const data: ExpShowOutput = [
             }
           }
         ],
-        executor: { state: ExperimentStatus.FAILED, local: null, name: null }
+        executor: { state: ExecutorStatus.FAILED, local: null, name: null }
       },
       {
         name: 'exp-f13bca',
@@ -811,7 +811,7 @@ const data: ExpShowOutput = [
           }
         ],
         executor: {
-          state: ExperimentStatus.QUEUED,
+          state: ExecutorStatus.QUEUED,
           name: Executor.DVC_TASK,
           local: {
             root: null,
@@ -902,7 +902,7 @@ const data: ExpShowOutput = [
             }
           }
         ],
-        executor: { state: ExperimentStatus.FAILED, local: null, name: null }
+        executor: { state: ExecutorStatus.FAILED, local: null, name: null }
       }
     ]
   },

--- a/extension/src/test/fixtures/expShow/base/rows.ts
+++ b/extension/src/test/fixtures/expShow/base/rows.ts
@@ -7,7 +7,7 @@ import {
 import { copyOriginalColors } from '../../../../experiments/model/status/colors'
 import { shortenForLabel } from '../../../../util/string'
 import {
-  ExperimentStatus,
+  ExecutorStatus,
   EXPERIMENT_WORKSPACE_ID,
   Executor
 } from '../../../../cli/dvc/contract'
@@ -74,7 +74,7 @@ const rowsFixture: Commit[] = [
         test: true
       }
     },
-    status: ExperimentStatus.RUNNING,
+    executorStatus: ExecutorStatus.RUNNING,
     selected: false,
     starred: false
   },
@@ -194,7 +194,7 @@ const rowsFixture: Commit[] = [
             test: true
           }
         },
-        status: ExperimentStatus.RUNNING,
+        executorStatus: ExecutorStatus.RUNNING,
         selected: false,
         sha: '4fb124aebddb2adf1545030907687fa9a4c80e70',
         starred: false,
@@ -313,7 +313,7 @@ const rowsFixture: Commit[] = [
         },
         selected: true,
         starred: false,
-        status: ExperimentStatus.RUNNING,
+        executorStatus: ExecutorStatus.RUNNING,
         Created: '2020-12-29T15:27:02'
       },
       {
@@ -326,7 +326,7 @@ const rowsFixture: Commit[] = [
           "unable to read: 'params.yaml', YAML file structure is corrupted",
         selected: false,
         starred: false,
-        status: ExperimentStatus.FAILED
+        executorStatus: ExecutorStatus.FAILED
       },
       {
         branch: 'main',
@@ -425,7 +425,7 @@ const rowsFixture: Commit[] = [
           }
         },
         selected: false,
-        status: ExperimentStatus.QUEUED,
+        executorStatus: ExecutorStatus.QUEUED,
         sha: '90aea7f2482117a55dfcadcdb901aaa6610fbbc9',
         starred: false,
         Created: '2020-12-29T15:25:27'
@@ -476,7 +476,7 @@ const rowsFixture: Commit[] = [
           }
         },
         selected: false,
-        status: ExperimentStatus.FAILED,
+        executorStatus: ExecutorStatus.FAILED,
         sha: '55d492c9c633912685351b32df91bfe1f9ecefb9',
         starred: false,
         Created: '2020-12-29T15:25:27'

--- a/extension/src/test/suite/experiments/model/sortBy/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/sortBy/tree.test.ts
@@ -20,7 +20,7 @@ import { RegisteredCommands } from '../../../../../commands/external'
 import {
   EXPERIMENT_WORKSPACE_ID,
   Executor,
-  ExperimentStatus
+  ExecutorStatus
 } from '../../../../../cli/dvc/contract'
 import { WEBVIEW_TEST_TIMEOUT } from '../../../timeouts'
 import { starredSort } from '../../../../../experiments/model/sortBy/constants'
@@ -44,7 +44,7 @@ suite('Experiments Sort By Tree Test Suite', () => {
           executor: {
             local: null,
             name: Executor.WORKSPACE,
-            state: ExperimentStatus.RUNNING
+            state: ExecutorStatus.RUNNING
           },
           name: 'exp-1',
           rev: EXPERIMENT_WORKSPACE_ID

--- a/extension/src/test/util/experiments.ts
+++ b/extension/src/test/util/experiments.ts
@@ -3,7 +3,7 @@ import {
   ExecutorState,
   ExpData,
   EXPERIMENT_WORKSPACE_ID,
-  ExperimentStatus,
+  ExecutorStatus,
   ExpRange,
   ExpShowOutput,
   ExpState
@@ -44,7 +44,7 @@ const getExecutorState = (executor: Partial<ExecutorState>): ExecutorState => {
   return {
     local: null,
     name: Executor.WORKSPACE,
-    state: ExperimentStatus.RUNNING,
+    state: ExecutorStatus.RUNNING,
     ...executor
   }
 }

--- a/webview/src/experiments/components/table/body/Cell.tsx
+++ b/webview/src/experiments/components/table/body/Cell.tsx
@@ -51,18 +51,25 @@ export const StubCell: React.FC<
     }
   } = cell
   const {
-    original: { error, status, gitRemoteStatus, label, id, description = '' }
+    original: {
+      error,
+      executorStatus,
+      gitRemoteStatus,
+      label,
+      id,
+      description = ''
+    }
   } = row
   const { toggleExperiment } = rowActionsProps
 
   return (
     <td className={cx(styles.experimentsTd, styles.experimentCell)}>
       <div className={styles.innerCell} style={{ width: getSize() }}>
-        <CellRowActions status={status} {...rowActionsProps} />
+        <CellRowActions executorStatus={executorStatus} {...rowActionsProps} />
         <RowExpansionButton row={row} />
         <ExperimentStatusIndicator
           id={id}
-          status={status}
+          executorStatus={executorStatus}
           gitRemoteStatus={gitRemoteStatus}
         />
 

--- a/webview/src/experiments/components/table/body/CellRowActions.tsx
+++ b/webview/src/experiments/components/table/body/CellRowActions.tsx
@@ -1,9 +1,6 @@
 import React, { MouseEventHandler, ReactElement } from 'react'
 import { VSCodeCheckbox } from '@vscode/webview-ui-toolkit/react'
-import {
-  ExperimentStatus,
-  isQueued
-} from 'dvc/src/experiments/webview/contract'
+import { ExecutorStatus, isQueued } from 'dvc/src/experiments/webview/contract'
 import { CellHintTooltip } from './CellHintTooltip'
 import { Indicator } from '../Indicators'
 import { addStarredFilter, openPlotsWebview } from '../../../util/messages'
@@ -22,7 +19,7 @@ export type CellRowActionsProps = {
   plotColor?: string
   showSubRowStates: boolean
   starred?: boolean
-  status?: ExperimentStatus
+  executorStatus?: ExecutorStatus
   subRowStates: {
     plotSelections: number
     selections: number
@@ -88,7 +85,7 @@ const ClickableTooltipContent: React.FC<ClickableTooltipContentProps> = ({
 
 export const CellRowActions: React.FC<CellRowActionsProps> = ({
   plotColor,
-  status,
+  executorStatus: status,
   toggleExperiment,
   isRowSelected,
   showSubRowStates,

--- a/webview/src/experiments/components/table/body/ExperimentStatusIndicator.tsx
+++ b/webview/src/experiments/components/table/body/ExperimentStatusIndicator.tsx
@@ -3,7 +3,7 @@ import { VSCodeProgressRing } from '@vscode/webview-ui-toolkit/react'
 import cx from 'classnames'
 import { useSelector } from 'react-redux'
 import {
-  ExperimentStatus,
+  ExecutorStatus,
   GitRemoteStatus,
   isRunning
 } from 'dvc/src/experiments/webview/contract'
@@ -16,14 +16,14 @@ import { Icon } from '../../../../shared/components/Icon'
 import { ExperimentsState } from '../../../store'
 
 type ExperimentStatusIndicatorProps = {
-  status: ExperimentStatus | undefined
+  executorStatus: ExecutorStatus | undefined
   gitRemoteStatus: GitRemoteStatus | undefined
   id: string
 }
 
 export const ExperimentStatusIndicator: React.FC<
   ExperimentStatusIndicatorProps
-> = ({ id, status, gitRemoteStatus }) => {
+> = ({ id, executorStatus: status, gitRemoteStatus }) => {
   const { hasRunningWorkspaceExperiment } = useSelector(
     (state: ExperimentsState) => state.tableData
   )

--- a/webview/src/experiments/components/table/body/RowContextMenu.tsx
+++ b/webview/src/experiments/components/table/body/RowContextMenu.tsx
@@ -2,8 +2,8 @@ import React, { useContext, useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { MessageFromWebviewType } from 'dvc/src/webview/contract'
 import {
-  ExperimentStatus,
   WORKSPACE_BRANCH,
+  ExecutorStatus,
   isQueued,
   isRunning,
   isRunningInQueue
@@ -44,10 +44,11 @@ const collectIdByStarred = (
 ) => (starred ? starredExperimentIds.push(id) : unstarredExperimentIds.push(id))
 
 const isRunningOrNotExperiment = (
-  status: ExperimentStatus | undefined,
+  executorStatus: ExecutorStatus | undefined,
   depth: number,
   hasRunningWorkspaceExperiment: boolean
-): boolean => isRunning(status) || depth !== 1 || hasRunningWorkspaceExperiment
+): boolean =>
+  isRunning(executorStatus) || depth !== 1 || hasRunningWorkspaceExperiment
 
 const collectDisabledOptions = (
   selectedRowsList: RowProp[],
@@ -61,7 +62,7 @@ const collectDisabledOptions = (
 
   for (const { row } of selectedRowsList) {
     const { original, depth } = row
-    const { starred, status, id } = original
+    const { starred, executorStatus, id } = original
 
     selectedIds.push(id)
 
@@ -73,12 +74,16 @@ const collectDisabledOptions = (
     )
 
     if (
-      isRunningOrNotExperiment(status, depth, hasRunningWorkspaceExperiment)
+      isRunningOrNotExperiment(
+        executorStatus,
+        depth,
+        hasRunningWorkspaceExperiment
+      )
     ) {
       disableExperimentOnlyOption = true
     }
 
-    if (!isRunning(status)) {
+    if (!isRunning(executorStatus)) {
       disableStopOption = true
     }
   }
@@ -209,11 +214,11 @@ const getSingleSelectMenuOptions = (
   projectHasCheckpoints: boolean,
   hasRunningWorkspaceExperiment: boolean,
   depth: number,
-  status?: ExperimentStatus,
+  executorStatus?: ExecutorStatus,
   starred?: boolean,
   executor?: string | null
 ) => {
-  const isNotExperiment = isQueued(status) || isWorkspace || depth <= 0
+  const isNotExperiment = isQueued(executorStatus) || isWorkspace || depth <= 0
 
   const disableIfRunning = (
     label: string,
@@ -225,7 +230,7 @@ const getSingleSelectMenuOptions = (
       id,
       label,
       type,
-      disabled || hasRunningWorkspaceExperiment || isRunning(status),
+      disabled || hasRunningWorkspaceExperiment || isRunning(executorStatus),
       divider
     )
 
@@ -246,7 +251,7 @@ const getSingleSelectMenuOptions = (
       id,
       'Show Logs',
       MessageFromWebviewType.SHOW_EXPERIMENT_LOGS,
-      !isRunningInQueue({ executor, status })
+      !isRunningInQueue({ executor, executorStatus })
     ),
     disableIfRunningOrWorkspace(
       'Apply to Workspace',
@@ -260,7 +265,9 @@ const getSingleSelectMenuOptions = (
       [id],
       'Push',
       MessageFromWebviewType.PUSH_EXPERIMENT,
-      isNotExperiment || hasRunningWorkspaceExperiment || isRunning(status),
+      isNotExperiment ||
+        hasRunningWorkspaceExperiment ||
+        isRunning(executorStatus),
       true
     ),
     ...getRunResumeOptions(
@@ -279,7 +286,7 @@ const getSingleSelectMenuOptions = (
       [id],
       'Stop',
       MessageFromWebviewType.STOP_EXPERIMENTS,
-      !isRunning(status),
+      !isRunning(executorStatus),
       id !== EXPERIMENT_WORKSPACE_ID
     ),
     disableIfRunning(
@@ -299,7 +306,7 @@ const getContextMenuOptions = (
   hasRunningWorkspaceExperiment: boolean,
   depth: number,
   selectedRows: Record<string, RowProp | undefined>,
-  status?: ExperimentStatus,
+  executorStatus?: ExecutorStatus,
   starred?: boolean,
   executor?: string | null
 ) => {
@@ -322,7 +329,7 @@ const getContextMenuOptions = (
         projectHasCheckpoints,
         hasRunningWorkspaceExperiment,
         depth,
-        status,
+        executorStatus,
         starred,
         executor
       )
@@ -331,7 +338,7 @@ const getContextMenuOptions = (
 
 export const RowContextMenu: React.FC<RowProp> = ({
   row: {
-    original: { branch, status, starred, id, executor },
+    original: { branch, executorStatus, starred, id, executor },
     depth
   }
 }) => {
@@ -352,14 +359,14 @@ export const RowContextMenu: React.FC<RowProp> = ({
       hasRunningWorkspaceExperiment,
       depth,
       selectedRows,
-      status,
+      executorStatus,
       starred,
       executor
     )
   }, [
     branch,
     executor,
-    status,
+    executorStatus,
     starred,
     isWorkspace,
     depth,

--- a/webview/src/stories/Table.stories.tsx
+++ b/webview/src/stories/Table.stories.tsx
@@ -10,10 +10,7 @@ import dataTypesTableFixture from 'dvc/src/test/fixtures/expShow/dataTypes/table
 import survivalTableData from 'dvc/src/test/fixtures/expShow/survival/tableData'
 import { timestampColumn } from 'dvc/src/experiments/columns/constants'
 import { delay } from 'dvc/src/util/time'
-import {
-  ExperimentStatus,
-  isRunning
-} from 'dvc/src/experiments/webview/contract'
+import { ExecutorStatus, isRunning } from 'dvc/src/experiments/webview/contract'
 import { EXPERIMENT_WORKSPACE_ID } from 'dvc/src/cli/dvc/contract'
 import {
   within,
@@ -62,12 +59,12 @@ const noRunningExperiments = {
   hasRunningWorkspaceExperiment: false,
   rows: rowsFixture.map(row => ({
     ...row,
-    status: ExperimentStatus.SUCCESS,
+    executorStatus: ExecutorStatus.SUCCESS,
     subRows: row.subRows?.map(experiment => ({
       ...experiment,
-      status: isRunning(experiment.status)
-        ? ExperimentStatus.SUCCESS
-        : experiment.status
+      executorStatus: isRunning(experiment.executorStatus)
+        ? ExecutorStatus.SUCCESS
+        : experiment.executorStatus
     }))
   }))
 }
@@ -77,12 +74,12 @@ const noRunningExperimentsNoCheckpoints = {
   hasCheckpoints: false,
   rows: rowsFixture.map(row => ({
     ...row,
-    status: ExperimentStatus.SUCCESS,
+    executorStatus: ExecutorStatus.SUCCESS,
     subRows: row.subRows?.map(experiment => ({
       ...experiment,
-      status: isRunning(experiment.status)
-        ? ExperimentStatus.SUCCESS
-        : experiment.status,
+      executorStatus: isRunning(experiment.executorStatus)
+        ? ExecutorStatus.SUCCESS
+        : experiment.executorStatus,
       subRows: []
     }))
   }))

--- a/webview/src/test/experimentsTable.tsx
+++ b/webview/src/test/experimentsTable.tsx
@@ -12,7 +12,7 @@ import { Provider } from 'react-redux'
 import deeplyNestedTableDataFixture from 'dvc/src/test/fixtures/expShow/deeplyNested/tableData'
 import tableDataFixture from 'dvc/src/test/fixtures/expShow/base/tableData'
 import { MessageToWebviewType } from 'dvc/src/webview/contract'
-import { ExperimentStatus } from 'dvc/src/cli/dvc/contract'
+import { ExecutorStatus } from 'dvc/src/cli/dvc/contract'
 import { tableData as sortingTableDataFixture } from './sort'
 import { customQueries, getRow } from './queries'
 import { App } from '../experiments/components/App'
@@ -69,10 +69,10 @@ export const renderTableWithoutRunningExperiments = (
     hasRunningWorkspaceExperiment: false,
     rows: tableDataFixture.rows.map(row => ({
       ...row,
-      status: ExperimentStatus.SUCCESS,
+      executorStatus: ExecutorStatus.SUCCESS,
       subRows: row.subRows?.map(subRow => ({
         ...subRow,
-        status: ExperimentStatus.SUCCESS
+        executorStatus: ExecutorStatus.SUCCESS
       }))
     }))
   })


### PR DESCRIPTION
Follow up to https://github.com/iterative/vscode-dvc/pull/4324#discussion_r1272009241

<img width="832" alt="image" src="https://github.com/iterative/vscode-dvc/assets/37993418/1e1624c7-94b8-4096-9f42-a8f4944fa65a">

Reason being that we now also have a `gitRemoteStatus` field and there will be more in the future.
