### PR TITLE
Apply experiment filters to workspace

### DIFF
--- a/extension/src/experiments/commands/register.ts
+++ b/extension/src/experiments/commands/register.ts
@@ -159,7 +159,8 @@ const registerExperimentQuickPickCommands = (
 
   internalCommands.registerExternalCommand(
     RegisteredCommands.EXPERIMENT_FILTERS_REMOVE,
-    () => experiments.removeFilters()
+    (context: Context) =>
+      experiments.removeFilters(getDvcRootFromContext(context))
   )
 
   internalCommands.registerExternalCommand(

--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -30,7 +30,12 @@ import {
   WORKSPACE_BRANCH
 } from '../webview/contract'
 import { reorderListSubset } from '../../util/array'
-import { Executor, ExpShowOutput, ExecutorStatus } from '../../cli/dvc/contract'
+import {
+  Executor,
+  ExpShowOutput,
+  ExecutorStatus,
+  EXPERIMENT_WORKSPACE_ID
+} from '../../cli/dvc/contract'
 import { flattenMapValues } from '../../util/map'
 import { ModelWithPersistence } from '../../persistence/model'
 import { PersistenceKey } from '../../persistence/constants'
@@ -412,7 +417,9 @@ export class ExperimentsModel extends ModelWithPersistence {
     const workspace = this.addDetails(this.workspace)
 
     const rows: Commit[] = []
-    if (filterExperiment(this.getFilters(), workspace)) {
+    if (
+      filterExperiment(this.getFilters(), { ...workspace, starred: undefined })
+    ) {
       rows.push({ branch: WORKSPACE_BRANCH, ...workspace })
     }
 
@@ -447,6 +454,9 @@ export class ExperimentsModel extends ModelWithPersistence {
   }
 
   public isStarred(id: string) {
+    if (id === EXPERIMENT_WORKSPACE_ID) {
+      return
+    }
     return !!this.starredExperiments[id]
   }
 
@@ -672,7 +682,7 @@ export class ExperimentsModel extends ModelWithPersistence {
       ...experiment,
       displayColor: this.getDisplayColor(id),
       selected: this.isSelected(id),
-      starred: !!this.isStarred(id)
+      starred: this.isStarred(id)
     }
   }
 

--- a/extension/src/experiments/model/tree.ts
+++ b/extension/src/experiments/model/tree.ts
@@ -41,7 +41,7 @@ import { truncateFromLeft } from '../../util/string'
 type ExperimentAugmented = Experiment & {
   hasChildren: boolean
   selected?: boolean
-  starred: boolean
+  starred?: boolean
   type: ExperimentType
 }
 

--- a/extension/src/experiments/webview/messages.ts
+++ b/extension/src/experiments/webview/messages.ts
@@ -141,6 +141,11 @@ export class WebviewMessages {
 
       case MessageFromWebviewType.FOCUS_FILTERS_TREE:
         return this.focusFiltersTree()
+      case MessageFromWebviewType.REMOVE_FILTERS:
+        return commands.executeCommand(
+          RegisteredCommands.EXPERIMENT_FILTERS_REMOVE,
+          { dvcRoot: this.dvcRoot }
+        )
       case MessageFromWebviewType.FOCUS_SORTS_TREE:
         return this.focusSortsTree()
 

--- a/extension/src/experiments/workspace.ts
+++ b/extension/src/experiments/workspace.ts
@@ -77,8 +77,8 @@ export class WorkspaceExperiments extends BaseWorkspaceWebviews<
     return this.getRepositoryThenUpdate('addStarredFilter', overrideRoot)
   }
 
-  public removeFilters() {
-    return this.getRepositoryThenUpdate('removeFilters')
+  public removeFilters(overrideRoot?: string) {
+    return this.getRepositoryThenUpdate('removeFilters', overrideRoot)
   }
 
   public addSort(overrideRoot?: string) {

--- a/extension/src/test/fixtures/expShow/base/rows.ts
+++ b/extension/src/test/fixtures/expShow/base/rows.ts
@@ -76,7 +76,7 @@ const rowsFixture: Commit[] = [
     },
     executorStatus: ExecutorStatus.RUNNING,
     selected: false,
-    starred: false
+    starred: undefined
   },
   {
     branch: 'main',

--- a/extension/src/test/fixtures/expShow/dataTypes/rows.ts
+++ b/extension/src/test/fixtures/expShow/dataTypes/rows.ts
@@ -23,7 +23,7 @@ const data: Commit[] = [
       }
     },
     selected: false,
-    starred: false
+    starred: undefined
   },
   {
     branch: 'main',

--- a/extension/src/test/fixtures/expShow/deeplyNested/rows.ts
+++ b/extension/src/test/fixtures/expShow/deeplyNested/rows.ts
@@ -27,7 +27,7 @@ export const data = [
     },
     displayColor: undefined,
     selected: false,
-    starred: false
+    starred: undefined
   },
   {
     branch: 'main',

--- a/extension/src/test/fixtures/expShow/survival/rows.ts
+++ b/extension/src/test/fixtures/expShow/survival/rows.ts
@@ -160,7 +160,7 @@ const data: Commit[] = [
     },
     displayColor: undefined,
     selected: false,
-    starred: false
+    starred: undefined
   },
   {
     branch: 'main',

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -1104,6 +1104,7 @@ suite('Experiments Test Suite', () => {
       const { experiments } = buildExperiments({ disposer: disposable })
 
       const webview = await experiments.showWebview()
+      await experiments.isReady()
 
       const mockSendTelemetryEvent = stub(Telemetry, 'sendTelemetryEvent')
       const mockMessageReceived = getMessageReceivedEmitter(webview)
@@ -1131,6 +1132,30 @@ suite('Experiments Test Suite', () => {
         undefined,
         undefined
       )
+    }).timeout(WEBVIEW_TEST_TIMEOUT)
+
+    it('should be able to handle a message to remove filters', async () => {
+      const { experiments } = buildExperiments({ disposer: disposable })
+
+      const webview = await experiments.showWebview()
+      await experiments.isReady()
+
+      const mockMessageReceived = getMessageReceivedEmitter(webview)
+      const executeCommandStub = stub(commands, 'executeCommand')
+
+      const messageReceived = new Promise(resolve =>
+        disposable.track(mockMessageReceived.event(() => resolve(undefined)))
+      )
+
+      mockMessageReceived.fire({
+        type: MessageFromWebviewType.REMOVE_FILTERS
+      })
+
+      expect(executeCommandStub).to.be.calledWith(
+        'dvc.removeExperimentsTableFilters'
+      )
+
+      await messageReceived
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should be able to handle a message to focus the filters tree', async () => {

--- a/extension/src/test/suite/experiments/model/filterBy/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/filterBy/tree.test.ts
@@ -303,7 +303,7 @@ suite('Experiments Filter By Tree Test Suite', () => {
       void experiments.addFilter()
       await tableFilterAdded
 
-      expect(mockTreeView.description).to.equal('5 of 11 Filtered')
+      expect(mockTreeView.description).to.equal('6 of 11 Filtered')
 
       stubPrivateMethod(experimentsModel, 'getFilteredExperiments')
         .onFirstCall()
@@ -359,7 +359,10 @@ suite('Experiments Filter By Tree Test Suite', () => {
         rows: filteredRows
       }
 
-      expect(messageSpy).to.be.calledWithMatch(filteredTableData)
+      expect(messageSpy).to.be.calledWithMatch(
+        filteredTableData,
+        'workspace is unfiltered by stars (starred set to undefined) as it is currently not possible to star the workspace'
+      )
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should provide a shortcut to filter to starred experiments', async () => {

--- a/extension/src/webview/contract.ts
+++ b/extension/src/webview/contract.ts
@@ -30,6 +30,7 @@ export enum MessageFromWebviewType {
   OPEN_STUDIO_PROFILE = 'open-studio-profile',
   PUSH_EXPERIMENT = 'push-experiment',
   REMOVE_COLUMN_SORT = 'remove-column-sort',
+  REMOVE_FILTERS = 'remove-filters',
   REMOVE_EXPERIMENT = 'remove-experiment',
   REORDER_COLUMNS = 'reorder-columns',
   REORDER_PLOTS_COMPARISON = 'reorder-plots-comparison',
@@ -189,6 +190,7 @@ export type MessageFromWebview =
       type: MessageFromWebviewType.REMOVE_COLUMN_SORT
       payload: string
     }
+  | { type: MessageFromWebviewType.REMOVE_FILTERS }
   | { type: MessageFromWebviewType.REMOTE_ADD }
   | { type: MessageFromWebviewType.REMOTE_MODIFY }
   | { type: MessageFromWebviewType.REMOTE_REMOVE }

--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -49,7 +49,8 @@ import {
   renderTableWithSortingData,
   renderTableWithNoRows,
   selectedRows,
-  setTableData
+  setTableData,
+  renderTableWithAllRowsFiltered
 } from '../../test/experimentsTable'
 import { clearSelection, createWindowTextSelection } from '../../test/selection'
 import { sendMessage } from '../../shared/vscode'
@@ -95,6 +96,32 @@ describe('App', () => {
 
     const noColumnsState = screen.queryByText('No Columns Selected.')
     expect(noColumnsState).toBeInTheDocument()
+
+    const addColumnsButton = screen.queryByText('Add Columns')
+    addColumnsButton && fireEvent.click(addColumnsButton)
+    expect(mockPostMessage).toHaveBeenCalledWith({
+      type: MessageFromWebviewType.SELECT_COLUMNS
+    })
+  })
+
+  it('should show the no rows unfiltered empty state when there are no rows provided', () => {
+    renderTableWithAllRowsFiltered()
+    mockPostMessage.mockReset()
+
+    const allRowsFiltered = screen.queryByText('No Experiments to Display.')
+    expect(allRowsFiltered).toBeInTheDocument()
+
+    const focusFiltersTreeButton = screen.queryByText('Show Filters')
+    focusFiltersTreeButton && fireEvent.click(focusFiltersTreeButton)
+    expect(mockPostMessage).toHaveBeenCalledWith({
+      type: MessageFromWebviewType.FOCUS_FILTERS_TREE
+    })
+
+    const removeFiltersButton = screen.queryByText('Remove Filters')
+    removeFiltersButton && fireEvent.click(removeFiltersButton)
+    expect(mockPostMessage).toHaveBeenCalledWith({
+      type: MessageFromWebviewType.REMOVE_FILTERS
+    })
   })
 
   it('should not show the no columns selected empty state when only the timestamp column is provided', () => {

--- a/webview/src/experiments/components/Experiments.tsx
+++ b/webview/src/experiments/components/Experiments.tsx
@@ -126,6 +126,7 @@ export const ExperimentsTable: React.FC = () => {
     columnWidths,
     hasColumns,
     hasConfig,
+    filters,
     rows: data
   } = useSelector((state: ExperimentsState) => state.tableData)
 
@@ -182,9 +183,16 @@ export const ExperimentsTable: React.FC = () => {
   }, [toggleAllRowsExpanded])
 
   const hasOnlyDefaultColumns = columns.length <= 1
-  const hasNoRows = data.length === 0
-  if (hasOnlyDefaultColumns || hasNoRows) {
-    return <GetStarted showWelcome={!hasColumns || hasNoRows} />
+  const hasRows = data.length > 0
+  if (hasOnlyDefaultColumns || !hasRows) {
+    return (
+      <GetStarted
+        hasOnlyDefaultColumns={hasOnlyDefaultColumns}
+        hasColumns={hasColumns}
+        hasRows={hasRows}
+        hasFilters={filters.length > 0}
+      />
+    )
   }
   return (
     <RowSelectionProvider>

--- a/webview/src/experiments/components/emptyState/GetStarted.tsx
+++ b/webview/src/experiments/components/emptyState/GetStarted.tsx
@@ -1,8 +1,34 @@
 import React from 'react'
 import { Welcome } from './Welcome'
 import { AddColumns } from './AddColumns'
+import { RemoveFilters } from './RemoveFilters'
 import { EmptyState } from '../../../shared/components/emptyState/EmptyState'
 
-export const GetStarted: React.FC<{ showWelcome: boolean }> = ({
-  showWelcome
-}) => <EmptyState>{showWelcome ? <Welcome /> : <AddColumns />}</EmptyState>
+export const GetStarted: React.FC<{
+  hasColumns: boolean
+  hasOnlyDefaultColumns: boolean
+  hasRows: boolean
+  hasFilters: boolean
+}> = ({ hasColumns, hasFilters, hasOnlyDefaultColumns, hasRows }) => {
+  if (hasColumns && hasOnlyDefaultColumns) {
+    return (
+      <EmptyState>
+        <AddColumns />
+      </EmptyState>
+    )
+  }
+
+  if (!hasRows && hasFilters) {
+    return (
+      <EmptyState>
+        <RemoveFilters />
+      </EmptyState>
+    )
+  }
+
+  return (
+    <EmptyState>
+      <Welcome />
+    </EmptyState>
+  )
+}

--- a/webview/src/experiments/components/emptyState/RemoveFilters.tsx
+++ b/webview/src/experiments/components/emptyState/RemoveFilters.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Button } from '../../../shared/components/button/Button'
+import { focusFiltersTree, removeFilters } from '../../util/messages'
+
+export const RemoveFilters: React.FC = () => (
+  <div>
+    <p>No Experiments to Display.</p>
+    <Button onClick={focusFiltersTree} text="Show Filters" />
+    <Button
+      appearance="secondary"
+      isNested={true}
+      onClick={removeFilters}
+      text="Remove Filters"
+    />
+  </div>
+)

--- a/webview/src/experiments/util/messages.ts
+++ b/webview/src/experiments/util/messages.ts
@@ -21,6 +21,9 @@ export const addConfiguration = () =>
 export const pushExperiment = (id: string) =>
   sendMessage({ payload: [id], type: MessageFromWebviewType.PUSH_EXPERIMENT })
 
+export const removeFilters = () =>
+  sendMessage({ type: MessageFromWebviewType.REMOVE_FILTERS })
+
 export const reorderColumns = (newOrder: string[]) =>
   sendMessage({
     payload: newOrder,

--- a/webview/src/stories/Table.stories.tsx
+++ b/webview/src/stories/Table.stories.tsx
@@ -289,7 +289,12 @@ LoadingData.args = { tableData: undefined }
 
 export const WithNoExperiments = Template.bind({})
 WithNoExperiments.args = {
-  tableData: { ...tableData, rows: [] }
+  tableData: { ...tableData, filters: [], rows: [] }
+}
+
+export const WithAllExperimentsFiltered = Template.bind({})
+WithAllExperimentsFiltered.args = {
+  tableData: { ...tableData, filters: ['starred'], rows: [] }
 }
 
 export const WithNoColumns = Template.bind({})

--- a/webview/src/test/experimentsTable.tsx
+++ b/webview/src/test/experimentsTable.tsx
@@ -52,6 +52,10 @@ export const renderTableWithNoColumns = () => {
   renderTable({ ...tableDataFixture, columns: [] })
 }
 
+export const renderTableWithAllRowsFiltered = () => {
+  renderTable({ ...tableDataFixture, filters: ['starred'], rows: [] })
+}
+
 export const renderTableWithNoRows = () => {
   renderTable({ ...tableDataFixture, rows: [] })
 }


### PR DESCRIPTION
This PR adds a new "all filtered" empty screen to the experiments webview and apply filters to the workspace.

### Demo

https://github.com/iterative/vscode-dvc/assets/37993418/ccf84e61-c669-44d7-9d85-2974ac92293e

Note: As it is not possible to star the workspace I have excluded it from the `starred` filter (fixed after demo).