### PR TITLE
Ensure experiment summary info (columns) is always available in the experiment table data

### DIFF
--- a/extension/src/experiments/columns/collect/order.ts
+++ b/extension/src/experiments/columns/collect/order.ts
@@ -1,0 +1,35 @@
+import { Column, ColumnType } from '../../webview/contract'
+import { EXPERIMENT_COLUMN_ID } from '../constants'
+
+export const collectColumnOrder = async (
+  existingColumnOrder: string[],
+  terminalNodes: Column[]
+): Promise<string[]> => {
+  const acc: { [columnType: string]: string[] } = {
+    [ColumnType.DEPS]: [],
+    [ColumnType.METRICS]: [],
+    [ColumnType.PARAMS]: [],
+    [ColumnType.TIMESTAMP]: []
+  }
+  for (const { type, path } of terminalNodes) {
+    if (existingColumnOrder.includes(path)) {
+      continue
+    }
+    acc[type].push(path)
+  }
+
+  // eslint-disable-next-line etc/no-assign-mutated-array
+  await Promise.all([acc.metrics.sort(), acc.params.sort(), acc.deps.sort()])
+
+  if (!existingColumnOrder.includes(EXPERIMENT_COLUMN_ID)) {
+    existingColumnOrder.unshift(EXPERIMENT_COLUMN_ID)
+  }
+
+  return [
+    ...existingColumnOrder,
+    ...acc.timestamp,
+    ...acc.metrics,
+    ...acc.params,
+    ...acc.deps
+  ]
+}

--- a/extension/src/experiments/columns/model.test.ts
+++ b/extension/src/experiments/columns/model.test.ts
@@ -1,7 +1,8 @@
+import { join } from 'path'
 import { Disposable, Disposer } from '@hediet/std/disposable'
 import { ColumnsModel } from './model'
 import { appendColumnToPath, buildMetricOrParamPath } from './paths'
-import { timestampColumn } from './constants'
+import { EXPERIMENT_COLUMN_ID, timestampColumn } from './constants'
 import { buildMockMemento } from '../../test/util'
 import { generateTestExpShowOutput } from '../../test/util/experiments'
 import { Status } from '../../path/selection/model'
@@ -258,7 +259,7 @@ describe('ColumnsModel', () => {
       expect(model.getColumnOrder()).toStrictEqual(persistedState)
     })
 
-    it('should return the first three visible columns for both metrics and params from the persisted state', async () => {
+    it('should return the first three visible columns for both metrics and params from the persisted state (first)', async () => {
       const persistedState = [
         'id',
         'Created',
@@ -287,7 +288,8 @@ describe('ColumnsModel', () => {
         'params:params.yaml:process.threshold',
         'params:params.yaml:process.test_arg',
         'metrics:summary.json:loss',
-        'metrics:summary.json:accuracy'
+        'metrics:summary.json:accuracy',
+        'metrics:summary.json:val_accuracy'
       ])
 
       model.toggleStatus('params:params.yaml:dvc_logs_dir')
@@ -297,8 +299,63 @@ describe('ColumnsModel', () => {
         'params:params.yaml:process.test_arg',
         'params:params.yaml:dropout',
         'metrics:summary.json:loss',
-        'metrics:summary.json:accuracy'
+        'metrics:summary.json:accuracy',
+        'metrics:summary.json:val_accuracy'
       ])
+    })
+
+    it('should not add a param that is no longer present to the summary column order', async () => {
+      const persistedState = [
+        'id',
+        'Created',
+        'params:params.yaml:an-old-params'
+      ]
+
+      const model = new ColumnsModel(
+        exampleDvcRoot,
+        buildMockMemento({
+          [PersistenceKey.METRICS_AND_PARAMS_COLUMN_ORDER + exampleDvcRoot]:
+            persistedState
+        }),
+        mockedColumnsOrderOrStatusChanged
+      )
+      model.toggleStatus('params:params.yaml:an-old-params')
+      await model.transformAndSet(outputFixture)
+
+      expect(model.getSummaryColumnOrder()).toStrictEqual([
+        join('params:nested', 'params.yaml:test'),
+        'params:params.yaml:code_names',
+        'params:params.yaml:dropout',
+        'metrics:summary.json:accuracy',
+        'metrics:summary.json:loss',
+        'metrics:summary.json:val_accuracy'
+      ])
+    })
+
+    it('should add to the persisted state when there are columns that were not found', async () => {
+      const persistedState = ['params:params.yaml:dvc_logs_dir']
+
+      const model = new ColumnsModel(
+        exampleDvcRoot,
+        buildMockMemento({
+          [PersistenceKey.METRICS_AND_PARAMS_COLUMN_ORDER + exampleDvcRoot]:
+            persistedState
+        }),
+        mockedColumnsOrderOrStatusChanged
+      )
+      await model.transformAndSet(outputFixture)
+
+      expect(model.getSummaryColumnOrder()).toStrictEqual([
+        'params:params.yaml:dvc_logs_dir',
+        join('params:nested', 'params.yaml:test'),
+        'params:params.yaml:code_names',
+        'metrics:summary.json:accuracy',
+        'metrics:summary.json:loss',
+        'metrics:summary.json:val_accuracy'
+      ])
+
+      const [id] = model.getColumnOrder()
+      expect(id).toStrictEqual(EXPERIMENT_COLUMN_ID)
     })
 
     it('should return the first three metric and param columns (none hidden) collected from data if state is empty', async () => {
@@ -310,23 +367,23 @@ describe('ColumnsModel', () => {
       await model.transformAndSet(outputFixture)
 
       expect(model.getSummaryColumnOrder()).toStrictEqual([
+        join('params:nested', 'params.yaml:test'),
         'params:params.yaml:code_names',
-        'params:params.yaml:epochs',
-        'params:params.yaml:learning_rate',
-        'metrics:summary.json:loss',
+        'params:params.yaml:dropout',
         'metrics:summary.json:accuracy',
-        'metrics:summary.json:val_loss'
+        'metrics:summary.json:loss',
+        'metrics:summary.json:val_accuracy'
       ])
 
       model.toggleStatus('params:params.yaml:code_names')
 
       expect(model.getSummaryColumnOrder()).toStrictEqual([
-        'params:params.yaml:epochs',
-        'params:params.yaml:learning_rate',
+        join('params:nested', 'params.yaml:test'),
+        'params:params.yaml:dropout',
         'params:params.yaml:dvc_logs_dir',
-        'metrics:summary.json:loss',
         'metrics:summary.json:accuracy',
-        'metrics:summary.json:val_loss'
+        'metrics:summary.json:loss',
+        'metrics:summary.json:val_accuracy'
       ])
     })
 

--- a/extension/src/path/selection/model.ts
+++ b/extension/src/path/selection/model.ts
@@ -67,9 +67,21 @@ export abstract class PathSelectionModel<
   }
 
   protected setNewStatuses(data: { path: string }[]) {
+    const paths = new Set<string>()
     for (const { path } of data) {
       if (this.status[path] === undefined) {
         this.status[path] = Status.SELECTED
+      }
+      paths.add(path)
+    }
+
+    this.removeMissingSelected(paths)
+  }
+
+  private removeMissingSelected(paths: Set<string>) {
+    for (const [path, status] of Object.entries(this.status)) {
+      if (!paths.has(path) && status === Status.SELECTED) {
+        delete this.status[path]
       }
     }
   }

--- a/extension/src/test/fixtures/expShow/base/columns.ts
+++ b/extension/src/test/fixtures/expShow/base/columns.ts
@@ -11,27 +11,27 @@ const nestedParamsFile = join('nested', 'params.yaml')
 export const dataColumnOrder: string[] = [
   'id',
   'Created',
-  'metrics:summary.json:loss',
   'metrics:summary.json:accuracy',
-  'metrics:summary.json:val_loss',
+  'metrics:summary.json:loss',
   'metrics:summary.json:val_accuracy',
+  'metrics:summary.json:val_loss',
+  join('params:nested', 'params.yaml:test'),
   'params:params.yaml:code_names',
+  'params:params.yaml:dropout',
+  'params:params.yaml:dvc_logs_dir',
   'params:params.yaml:epochs',
   'params:params.yaml:learning_rate',
-  'params:params.yaml:dvc_logs_dir',
   'params:params.yaml:log_file',
-  'params:params.yaml:dropout',
-  'params:params.yaml:process.threshold',
   'params:params.yaml:process.test_arg',
-  join('params:nested', 'params.yaml:test'),
+  'params:params.yaml:process.threshold',
   join('deps:data', 'data.xml'),
-  join('deps:data', 'prepared'),
   join('deps:data', 'features'),
-  join('deps:src', 'prepare.py'),
-  join('deps:src', 'featurization.py'),
-  join('deps:src', 'train.py'),
+  join('deps:data', 'prepared'),
+  'deps:model.pkl',
   join('deps:src', 'evaluate.py'),
-  'deps:model.pkl'
+  join('deps:src', 'featurization.py'),
+  join('deps:src', 'prepare.py'),
+  join('deps:src', 'train.py')
 ]
 
 const data: Column[] = [

--- a/extension/src/test/fixtures/plotsDiff/index.ts
+++ b/extension/src/test/fixtures/plotsDiff/index.ts
@@ -1,6 +1,5 @@
 import { TopLevelSpec } from 'vega-lite'
 import { VisualizationSpec } from 'react-vega'
-import rowsFixture from '../expShow/base/rows'
 import { extendVegaSpec, isMultiViewPlot } from '../../../plots/vega/util'
 import { EXPERIMENT_WORKSPACE_ID, PlotsOutput } from '../../../cli/dvc/contract'
 import {
@@ -19,7 +18,7 @@ import {
 } from '../../../plots/webview/contract'
 import { join } from '../../util/path'
 import { copyOriginalColors } from '../../../experiments/model/status/colors'
-import { ColumnType, Commit } from '../../../experiments/webview/contract'
+import { ColumnType } from '../../../experiments/webview/contract'
 
 const basicVega = {
   [join('logs', 'loss.tsv')]: [
@@ -534,34 +533,30 @@ export const getRevisions = (): Revision[] => {
       fetched: true,
       summaryColumns: [
         {
+          path: join('nested', 'params.yaml:test'),
+          type: ColumnType.PARAMS,
+          value: 'true'
+        },
+        {
           path: 'params.yaml:code_names',
           type: ColumnType.PARAMS,
           value: '[0,1]'
         },
+        { path: 'params.yaml:dropout', type: ColumnType.PARAMS, value: 0.124 },
         {
-          path: 'params.yaml:epochs',
-          type: ColumnType.PARAMS,
-          value: 5
-        },
-        {
-          path: 'params.yaml:learning_rate',
-          type: ColumnType.PARAMS,
-          value: 2.1e-7
-        },
-        {
-          type: ColumnType.METRICS,
-          path: 'summary.json:loss',
-          value: 1.775016188621521
-        },
-        {
-          type: ColumnType.METRICS,
           path: 'summary.json:accuracy',
+          type: ColumnType.METRICS,
           value: 0.5926499962806702
         },
         {
+          path: 'summary.json:loss',
           type: ColumnType.METRICS,
-          path: 'summary.json:val_loss',
-          value: 1.7233840227127075
+          value: 1.775016188621521
+        },
+        {
+          path: 'summary.json:val_accuracy',
+          type: ColumnType.METRICS,
+          value: 0.6704000234603882
         }
       ]
     },
@@ -571,19 +566,20 @@ export const getRevisions = (): Revision[] => {
       fetched: true,
       summaryColumns: [
         {
+          path: join('nested', 'params.yaml:test'),
+          type: ColumnType.PARAMS,
+          value: 'true'
+        },
+        {
           path: 'params.yaml:code_names',
           type: ColumnType.PARAMS,
           value: '[0,1]'
         },
+        { path: 'params.yaml:dropout', type: ColumnType.PARAMS, value: 0.122 },
         {
-          path: 'params.yaml:epochs',
-          type: ColumnType.PARAMS,
-          value: 5
-        },
-        {
-          path: 'params.yaml:learning_rate',
-          type: ColumnType.PARAMS,
-          value: 2.1e-7
+          path: 'summary.json:accuracy',
+          type: ColumnType.METRICS,
+          value: 0.3484833240509033
         },
         {
           path: 'summary.json:loss',
@@ -591,14 +587,9 @@ export const getRevisions = (): Revision[] => {
           value: 2.048856019973755
         },
         {
-          path: 'summary.json:accuracy',
+          path: 'summary.json:val_accuracy',
           type: ColumnType.METRICS,
-          value: 0.3484833240509033
-        },
-        {
-          type: ColumnType.METRICS,
-          path: 'summary.json:val_loss',
-          value: 1.9979369640350342
+          value: 0.4277999997138977
         }
       ],
       id: 'main',
@@ -611,34 +602,30 @@ export const getRevisions = (): Revision[] => {
       fetched: true,
       summaryColumns: [
         {
+          path: join('nested', 'params.yaml:test'),
+          type: ColumnType.PARAMS,
+          value: 'true'
+        },
+        {
           path: 'params.yaml:code_names',
           type: ColumnType.PARAMS,
           value: '[0,1]'
         },
+        { path: 'params.yaml:dropout', type: ColumnType.PARAMS, value: 0.15 },
         {
-          path: 'params.yaml:epochs',
-          type: ColumnType.PARAMS,
-          value: 2
-        },
-        {
-          path: 'params.yaml:learning_rate',
-          type: ColumnType.PARAMS,
-          value: 2e-12
-        },
-        {
-          type: ColumnType.METRICS,
-          path: 'summary.json:loss',
-          value: 2.0205044746398926
-        },
-        {
-          type: ColumnType.METRICS,
           path: 'summary.json:accuracy',
+          type: ColumnType.METRICS,
           value: 0.3724166750907898
         },
         {
+          path: 'summary.json:loss',
           type: ColumnType.METRICS,
-          path: 'summary.json:val_loss',
-          value: 1.9979370832443237
+          value: 2.0205044746398926
+        },
+        {
+          path: 'summary.json:val_accuracy',
+          type: ColumnType.METRICS,
+          value: 0.4277999997138977
         }
       ],
       id: 'exp-e7a67',
@@ -651,34 +638,30 @@ export const getRevisions = (): Revision[] => {
       fetched: true,
       summaryColumns: [
         {
+          path: join('nested', 'params.yaml:test'),
+          type: ColumnType.PARAMS,
+          value: 'true'
+        },
+        {
           path: 'params.yaml:code_names',
           type: ColumnType.PARAMS,
           value: '[0,1]'
         },
+        { path: 'params.yaml:dropout', type: ColumnType.PARAMS, value: 0.122 },
         {
-          path: 'params.yaml:epochs',
-          type: ColumnType.PARAMS,
-          value: 2
-        },
-        {
-          path: 'params.yaml:learning_rate',
-          type: ColumnType.PARAMS,
-          value: 2.2e-7
-        },
-        {
-          type: ColumnType.METRICS,
-          path: 'summary.json:loss',
-          value: 1.9293040037155151
-        },
-        {
-          type: ColumnType.METRICS,
           path: 'summary.json:accuracy',
+          type: ColumnType.METRICS,
           value: 0.4668000042438507
         },
         {
+          path: 'summary.json:loss',
           type: ColumnType.METRICS,
-          path: 'summary.json:val_loss',
-          value: 1.8770883083343506
+          value: 1.9293040037155151
+        },
+        {
+          path: 'summary.json:val_accuracy',
+          type: ColumnType.METRICS,
+          value: 0.5608000159263611
         }
       ],
       id: 'test-branch',
@@ -691,34 +674,30 @@ export const getRevisions = (): Revision[] => {
       fetched: true,
       summaryColumns: [
         {
+          path: join('nested', 'params.yaml:test'),
+          type: ColumnType.PARAMS,
+          value: 'true'
+        },
+        {
           path: 'params.yaml:code_names',
           type: ColumnType.PARAMS,
           value: '[0,1]'
         },
+        { path: 'params.yaml:dropout', type: ColumnType.PARAMS, value: 0.124 },
         {
-          path: 'params.yaml:epochs',
-          type: ColumnType.PARAMS,
-          value: 5
-        },
-        {
-          path: 'params.yaml:learning_rate',
-          type: ColumnType.PARAMS,
-          value: 2.1e-7
-        },
-        {
-          type: ColumnType.METRICS,
-          path: 'summary.json:loss',
-          value: 1.775016188621521
-        },
-        {
-          type: ColumnType.METRICS,
           path: 'summary.json:accuracy',
+          type: ColumnType.METRICS,
           value: 0.5926499962806702
         },
         {
+          path: 'summary.json:loss',
           type: ColumnType.METRICS,
-          path: 'summary.json:val_loss',
-          value: 1.7233840227127075
+          value: 1.775016188621521
+        },
+        {
+          path: 'summary.json:val_accuracy',
+          type: ColumnType.METRICS,
+          value: 0.6704000234603882
         }
       ],
       id: 'exp-83425',

--- a/extension/src/test/suite/experiments/model/filterBy/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/filterBy/tree.test.ts
@@ -359,6 +359,14 @@ suite('Experiments Filter By Tree Test Suite', () => {
         rows: filteredRows
       }
 
+      expect(
+        messageSpy.lastCall.args[0].columns,
+        'fixture match'
+      ).to.deep.equal(columnsFixture)
+      expect(messageSpy.lastCall.args[0].columnOrder, 'order').to.deep.equal(
+        columnsOrderFixture
+      )
+
       expect(messageSpy).to.be.calledWithMatch(filteredTableData)
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 

--- a/extension/src/test/suite/experiments/workspace.test.ts
+++ b/extension/src/test/suite/experiments/workspace.test.ts
@@ -452,15 +452,15 @@ suite('Workspace Experiments Test Suite', () => {
           {
             description: '[exp-e7a67]',
             detail:
-              'code_names:[0,1], epochs:2, learning_rate:2e-12, loss:2.0205045, accuracy:0.37241668, val_loss:1.9979371',
+              'test:true, code_names:[0,1], dropout:0.15, accuracy:0.37241668, loss:2.0205045, val_accuracy:0.42780000',
             label: '4fb124a',
             value: queueTaskId
           },
           {
             description: '[exp-83425]',
             detail:
-              'code_names:[0,1], epochs:5, learning_rate:2.1e-7, loss:1.7750162, accuracy:0.59265000, val_loss:1.7233840',
-            label: 'workspace',
+              'test:true, code_names:[0,1], dropout:0.124, accuracy:0.59265000, loss:1.7750162, val_accuracy:0.67040002',
+            label: EXPERIMENT_WORKSPACE_ID,
             value: 'exp-83425'
           }
         ],
@@ -543,49 +543,49 @@ suite('Workspace Experiments Test Suite', () => {
             description:
               '$(git-commit)Update version and CHANGELOG for release (#4022) ...',
             detail:
-              'code_names:[0,1], epochs:5, learning_rate:2.1e-7, loss:2.0488560, accuracy:0.34848332, val_loss:1.9979370',
+              'test:true, code_names:[0,1], dropout:0.122, accuracy:0.34848332, loss:2.0488560, val_accuracy:0.42780000',
             label: 'main',
             value: 'main'
           },
           {
             description: '[exp-e7a67]',
             detail:
-              'code_names:[0,1], epochs:2, learning_rate:2e-12, loss:2.0205045, accuracy:0.37241668, val_loss:1.9979371',
+              'test:true, code_names:[0,1], dropout:0.15, accuracy:0.37241668, loss:2.0205045, val_accuracy:0.42780000',
             label: '4fb124a',
             value: 'exp-e7a67'
           },
           {
             description: '[test-branch]',
             detail:
-              'code_names:[0,1], epochs:2, learning_rate:2.2e-7, loss:1.9293040, accuracy:0.46680000, val_loss:1.8770883',
+              'test:true, code_names:[0,1], dropout:0.122, accuracy:0.46680000, loss:1.9293040, val_accuracy:0.56080002',
             label: '42b8736',
             value: 'test-branch'
           },
           {
             description: '[exp-83425]',
             detail:
-              'code_names:[0,1], epochs:5, learning_rate:2.1e-7, loss:1.7750162, accuracy:0.59265000, val_loss:1.7233840',
+              'test:true, code_names:[0,1], dropout:0.124, accuracy:0.59265000, loss:1.7750162, val_accuracy:0.67040002',
             label: 'workspace',
             value: 'exp-83425'
           },
           {
             description: undefined,
             detail:
-              'code_names:-, epochs:-, learning_rate:-, loss:-, accuracy:-, val_loss:-',
+              'test:-, code_names:-, dropout:-, accuracy:-, loss:-, val_accuracy:-',
             label: '489fd8b',
             value: '489fd8b'
           },
           {
             description: '[exp-f13bca]',
             detail:
-              'code_names:[0,1], epochs:5, learning_rate:2.1e-7, loss:-, accuracy:-, val_loss:-',
+              'test:true, code_names:[0,1], dropout:0.124, accuracy:-, loss:-, val_accuracy:-',
             label: 'f0f9186',
             value: 'exp-f13bca'
           },
           {
             description: undefined,
             detail:
-              'code_names:[0,2], epochs:5, learning_rate:2.1e-7, loss:-, accuracy:-, val_loss:-',
+              'test:true, code_names:[0,2], dropout:0.125, accuracy:-, loss:-, val_accuracy:-',
             label: '55d492c',
             value: '55d492c'
           },
@@ -593,7 +593,7 @@ suite('Workspace Experiments Test Suite', () => {
             description:
               '$(git-commit)Improve "Get Started" walkthrough (#4020) ...',
             detail:
-              'code_names:[0,1], epochs:5, learning_rate:2.1e-7, loss:2.0488560, accuracy:0.34848332, val_loss:1.9979370',
+              'test:true, code_names:[0,1], dropout:0.122, accuracy:0.34848332, loss:2.0488560, val_accuracy:0.42780000',
             label: 'fe2919b',
             value: 'fe2919b'
           },
@@ -601,7 +601,7 @@ suite('Workspace Experiments Test Suite', () => {
             description:
               '$(git-commit)Add capabilities to text mentioning storage provider extensions (#4015)',
             detail:
-              'code_names:[0,1], epochs:5, learning_rate:2.1e-7, loss:2.0488560, accuracy:0.34848332, val_loss:1.9979370',
+              'test:true, code_names:[0,1], dropout:0.122, accuracy:0.34848332, loss:2.0488560, val_accuracy:0.42780000',
             label: '7df876c',
             value: '7df876c'
           }
@@ -690,42 +690,42 @@ suite('Workspace Experiments Test Suite', () => {
           {
             description: '[exp-e7a67]',
             detail:
-              'code_names:[0,1], epochs:2, learning_rate:2e-12, loss:2.0205045, accuracy:0.37241668, val_loss:1.9979371',
+              'test:true, code_names:[0,1], dropout:0.15, accuracy:0.37241668, loss:2.0205045, val_accuracy:0.42780000',
             label: '4fb124a',
             value: 'exp-e7a67'
           },
           {
             description: '[test-branch]',
             detail:
-              'code_names:[0,1], epochs:2, learning_rate:2.2e-7, loss:1.9293040, accuracy:0.46680000, val_loss:1.8770883',
+              'test:true, code_names:[0,1], dropout:0.122, accuracy:0.46680000, loss:1.9293040, val_accuracy:0.56080002',
             label: '42b8736',
             value: 'test-branch'
           },
           {
             description: '[exp-83425]',
             detail:
-              'code_names:[0,1], epochs:5, learning_rate:2.1e-7, loss:1.7750162, accuracy:0.59265000, val_loss:1.7233840',
+              'test:true, code_names:[0,1], dropout:0.124, accuracy:0.59265000, loss:1.7750162, val_accuracy:0.67040002',
             label: EXPERIMENT_WORKSPACE_ID,
             value: 'exp-83425'
           },
           {
             description: undefined,
             detail:
-              'code_names:-, epochs:-, learning_rate:-, loss:-, accuracy:-, val_loss:-',
+              'test:-, code_names:-, dropout:-, accuracy:-, loss:-, val_accuracy:-',
             label: '489fd8b',
             value: '489fd8b'
           },
           {
             description: '[exp-f13bca]',
             detail:
-              'code_names:[0,1], epochs:5, learning_rate:2.1e-7, loss:-, accuracy:-, val_loss:-',
+              'test:true, code_names:[0,1], dropout:0.124, accuracy:-, loss:-, val_accuracy:-',
             label: 'f0f9186',
             value: 'exp-f13bca'
           },
           {
             description: undefined,
             detail:
-              'code_names:[0,2], epochs:5, learning_rate:2.1e-7, loss:-, accuracy:-, val_loss:-',
+              'test:true, code_names:[0,2], dropout:0.125, accuracy:-, loss:-, val_accuracy:-',
             label: '55d492c',
             value: '55d492c'
           }
@@ -787,49 +787,49 @@ suite('Workspace Experiments Test Suite', () => {
           {
             description: '[exp-e7a67]',
             detail:
-              'code_names:[0,1], epochs:2, learning_rate:2e-12, loss:2.0205045, accuracy:0.37241668, val_loss:1.9979371',
+              'test:true, code_names:[0,1], dropout:0.15, accuracy:0.37241668, loss:2.0205045, val_accuracy:0.42780000',
             label: '4fb124a',
             value: 'exp-e7a67'
           },
           {
             description: '[test-branch]',
             detail:
-              'code_names:[0,1], epochs:2, learning_rate:2.2e-7, loss:1.9293040, accuracy:0.46680000, val_loss:1.8770883',
+              'test:true, code_names:[0,1], dropout:0.122, accuracy:0.46680000, loss:1.9293040, val_accuracy:0.56080002',
             label: '42b8736',
             value: 'test-branch'
           },
           {
             description: '[exp-83425]',
             detail:
-              'code_names:[0,1], epochs:5, learning_rate:2.1e-7, loss:1.7750162, accuracy:0.59265000, val_loss:1.7233840',
+              'test:true, code_names:[0,1], dropout:0.124, accuracy:0.59265000, loss:1.7750162, val_accuracy:0.67040002',
             label: EXPERIMENT_WORKSPACE_ID,
             value: 'exp-83425'
           },
           {
             description: undefined,
             detail:
-              'code_names:-, epochs:-, learning_rate:-, loss:-, accuracy:-, val_loss:-',
+              'test:-, code_names:-, dropout:-, accuracy:-, loss:-, val_accuracy:-',
             label: '489fd8b',
             value: '489fd8b'
           },
           {
             description: '[exp-f13bca]',
             detail:
-              'code_names:[0,1], epochs:5, learning_rate:2.1e-7, loss:-, accuracy:-, val_loss:-',
+              'test:true, code_names:[0,1], dropout:0.124, accuracy:-, loss:-, val_accuracy:-',
             label: 'f0f9186',
             value: 'exp-f13bca'
           },
           {
             description: undefined,
             detail:
-              'code_names:[0,1], epochs:5, learning_rate:2.1e-7, loss:-, accuracy:-, val_loss:-',
+              'test:true, code_names:[0,1], dropout:0.124, accuracy:-, loss:-, val_accuracy:-',
             label: '90aea7f',
             value: '90aea7f'
           },
           {
             description: undefined,
             detail:
-              'code_names:[0,2], epochs:5, learning_rate:2.1e-7, loss:-, accuracy:-, val_loss:-',
+              'test:true, code_names:[0,2], dropout:0.125, accuracy:-, loss:-, val_accuracy:-',
             label: '55d492c',
             value: '55d492c'
           }


### PR DESCRIPTION
When looking at tooltips for https://github.com/iterative/vscode-dvc/issues/4229 I found multiple ways to completely break the tooltips by having the columnOrder out of sync with the data in the table. Previously the only way to fix this was by moving a column. This PR should close the loop.