### PR TITLE
Add GIT_OPTIONAL_LOCKS=0 to all Git calls

### DIFF
--- a/extension/src/cli/git/options.ts
+++ b/extension/src/cli/git/options.ts
@@ -17,7 +17,7 @@ export const getOptions = ({
   }
 
   if (env) {
-    options.env = env
+    options.env = { ...env, GIT_OPTIONAL_LOCKS: '0' }
   }
 
   return options

--- a/extension/src/cli/git/reader.test.ts
+++ b/extension/src/cli/git/reader.test.ts
@@ -54,7 +54,7 @@ describe('GitReader', () => {
       expect(mockedCreateProcess).toHaveBeenCalledWith({
         args: ['branch'],
         cwd,
-        env: { LANG: 'en_US.UTF-8' },
+        env: { GIT_OPTIONAL_LOCKS: '0', LANG: 'en_US.UTF-8' },
         executable: 'git'
       })
     })


### PR DESCRIPTION
Related to https://github.com/iterative/vscode-dvc/issues/4111 & https://github.com/iterative/dvc/issues/9749

[Docs](https://git-scm.com/docs/git#Documentation/git.txt-codeGITOPTIONALLOCKScode)

> ### GIT_OPTIONAL_LOCKS
> If this Boolean environment variable is set to false, Git will complete any requested operation without performing any optional sub-operations that require taking a lock. For example, this will prevent git status from refreshing the index as a side effect. This is useful for processes running in the background which do not want to cause lock contention with other operations on the repository. Defaults to 1.