### PR TITLE
Replace git diff call with git extension state

### DIFF
--- a/extension/src/cli/git/reader.ts
+++ b/extension/src/cli/git/reader.ts
@@ -13,7 +13,6 @@ export const autoRegisteredCommands = {
   GIT_GET_REMOTE_EXPERIMENT_REFS: 'getRemoteExperimentRefs',
   GIT_GET_REMOTE_URL: 'getRemoteUrl',
   GIT_GET_REPOSITORY_ROOT: 'getGitRepositoryRoot',
-  GIT_HAS_CHANGES: 'hasChanges',
   GIT_HAS_NO_COMMITS: 'hasNoCommits',
   GIT_LIST_UNTRACKED: 'listUntracked',
   GIT_VERSION: 'gitVersion'
@@ -24,16 +23,6 @@ export class GitReader extends GitCli {
     autoRegisteredCommands,
     this
   )
-
-  public async hasChanges(cwd: string) {
-    const options = getOptions({
-      args: [Command.DIFF, Flag.NAME_ONLY, Flag.RAW_WITH_NUL],
-      cwd
-    })
-    const output = await this.executeProcess(options)
-
-    return !!output
-  }
 
   public async hasNoCommits(cwd: string) {
     const options = getOptions({

--- a/extension/src/extensions/git.ts
+++ b/extension/src/extensions/git.ts
@@ -1,0 +1,91 @@
+import { Event, Uri } from 'vscode'
+import { getExtensionAPI } from '../vscode/extensions'
+
+const enum Status {
+  INDEX_MODIFIED,
+  INDEX_ADDED,
+  INDEX_DELETED,
+  INDEX_RENAMED,
+  INDEX_COPIED,
+
+  MODIFIED,
+  DELETED,
+  UNTRACKED,
+  IGNORED,
+  INTENT_TO_ADD,
+  INTENT_TO_RENAME,
+  TYPE_CHANGED,
+
+  ADDED_BY_US,
+  ADDED_BY_THEM,
+  DELETED_BY_US,
+  DELETED_BY_THEM,
+  BOTH_ADDED,
+  BOTH_DELETED,
+  BOTH_MODIFIED
+}
+
+type Change = {
+  readonly uri: Uri
+  readonly originalUri: Uri
+  readonly renameUri: Uri | undefined
+  readonly status: Status
+}
+
+export type RepositoryState = {
+  readonly mergeChanges: Change[]
+  readonly indexChanges: Change[]
+  readonly workingTreeChanges: Change[]
+  readonly onDidChange: Event<void>
+}
+
+type Repository = {
+  readonly rootUri: Uri
+  readonly state: RepositoryState
+}
+
+enum APIState {
+  INITIALIZED = 'initialized',
+  UNINITIALIZED = 'uninitialized'
+}
+
+type ExtensionAPI = {
+  readonly state: APIState
+  readonly onDidChangeState: Event<APIState>
+  getRepository(uri: Uri): Repository | null
+}
+
+type VscodeGit = {
+  readonly enabled: boolean
+  readonly onDidChangeEnablement: Event<boolean>
+
+  getAPI(version: number): Thenable<ExtensionAPI>
+}
+
+const isReady = (api: ExtensionAPI) =>
+  new Promise(resolve => {
+    const listener = api.onDidChangeState(state => {
+      if (state === APIState.INITIALIZED) {
+        listener.dispose()
+        resolve(undefined)
+      }
+    })
+
+    if (api.state === APIState.INITIALIZED) {
+      listener.dispose()
+      resolve(undefined)
+    }
+  })
+
+export const getGitExtensionAPI = async (): Promise<
+  ExtensionAPI | undefined
+> => {
+  const extension = await getExtensionAPI<VscodeGit>('vscode.git')
+  if (!extension) {
+    return
+  }
+  const api = await extension.getAPI(1)
+
+  await isReady(api)
+  return api
+}

--- a/extension/src/repository/data/index.ts
+++ b/extension/src/repository/data/index.ts
@@ -17,7 +17,6 @@ import { getGitPath, isPathInProject } from '../../fileSystem'
 
 export type Data = {
   dataStatus: DataStatusOutput | DvcError
-  hasGitChanges: boolean
   untracked: Set<string>
 }
 
@@ -88,13 +87,9 @@ export class RepositoryData extends DeferredDisposable {
   }
 
   private async update() {
-    const [dataStatus, hasGitChanges, untracked] = await Promise.all([
+    const [dataStatus, untracked] = await Promise.all([
       this.internalCommands.executeCommand<DataStatusOutput | DvcError>(
         AvailableCommands.DATA_STATUS,
-        this.dvcRoot
-      ),
-      this.internalCommands.executeCommand<boolean>(
-        AvailableCommands.GIT_HAS_CHANGES,
         this.dvcRoot
       ),
       this.internalCommands.executeCommand<Set<string>>(
@@ -105,7 +100,6 @@ export class RepositoryData extends DeferredDisposable {
 
     return this.notifyChanged({
       dataStatus,
-      hasGitChanges,
       untracked
     })
   }

--- a/extension/src/repository/model/index.test.ts
+++ b/extension/src/repository/model/index.test.ts
@@ -58,9 +58,8 @@ describe('RepositoryModel', () => {
 
       const model = new RepositoryModel(dvcDemoPath)
       const { scmDecorationState, sourceControlManagementState } =
-        model.transformAndSet({
+        model.transformAndSetCli({
           dataStatus,
-          hasGitChanges: true,
           untracked: new Set()
         })
 
@@ -154,9 +153,8 @@ describe('RepositoryModel', () => {
 
       const model = new RepositoryModel(dvcDemoPath)
       const { scmDecorationState, sourceControlManagementState } =
-        model.transformAndSet({
+        model.transformAndSetCli({
           dataStatus,
-          hasGitChanges: false,
           untracked: new Set()
         })
 
@@ -203,9 +201,8 @@ describe('RepositoryModel', () => {
 
       const model = new RepositoryModel(dvcDemoPath)
       const { scmDecorationState, sourceControlManagementState } =
-        model.transformAndSet({
+        model.transformAndSetCli({
           dataStatus,
-          hasGitChanges: true,
           untracked: new Set()
         })
 
@@ -249,13 +246,13 @@ describe('RepositoryModel', () => {
       const emptyRepoError = { ...emptyRepoData, dataStatus: { error } }
       const model = new RepositoryModel(dvcDemoPath)
 
-      model.transformAndSet(emptyRepoData)
+      model.transformAndSetCli(emptyRepoData)
       expect(model.getChildren(dvcDemoPath)).toStrictEqual([])
 
-      model.transformAndSet(emptyRepoError)
+      model.transformAndSetCli(emptyRepoError)
       expect(model.getChildren(dvcDemoPath)).toStrictEqual([{ error: msg }])
 
-      model.transformAndSet(emptyRepoData)
+      model.transformAndSetCli(emptyRepoData)
       expect(model.getChildren(dvcDemoPath)).toStrictEqual([])
     })
   })

--- a/extension/src/test/suite/extension.test.ts
+++ b/extension/src/test/suite/extension.test.ts
@@ -153,7 +153,6 @@ suite('Extension Test Suite', () => {
         'isReady'
       )
 
-      stub(GitReader.prototype, 'hasChanges').resolves(false)
       stub(GitReader.prototype, 'listUntracked').resolves(new Set())
 
       const workspaceExperimentsAreReady = new Promise(resolve =>

--- a/extension/src/test/suite/repository/model/tree.test.ts
+++ b/extension/src/test/suite/repository/model/tree.test.ts
@@ -306,7 +306,6 @@ suite('Repositories Tree Test Suite', () => {
         ]
       })
       stub(gitReader, 'listUntracked').resolves(new Set())
-      stub(gitReader, 'hasChanges').resolves(false)
 
       const repository = disposable.track(
         new Repository(

--- a/extension/src/test/suite/repository/util.ts
+++ b/extension/src/test/suite/repository/util.ts
@@ -25,7 +25,6 @@ export const buildDependencies = (disposer: Disposer) => {
 
   const mockDataStatus = stub(dvcReader, 'dataStatus')
   const mockGetAllUntracked = stub(gitReader, 'listUntracked')
-  const mockGetHasChanges = stub(gitReader, 'hasChanges')
 
   const mockNow = stub(Time, 'getCurrentEpoch')
 
@@ -37,7 +36,6 @@ export const buildDependencies = (disposer: Disposer) => {
     mockCreateFileSystemWatcher,
     mockDataStatus,
     mockGetAllUntracked,
-    mockGetHasChanges,
     mockNow,
     onDidChangeTreeData,
     treeDataChanged


### PR DESCRIPTION
Related to #4111 

This PR replaces a call to `git diff` with state from VS Code's built-in Git extension.

The call to `git diff` was used to determine whether a repository has any SCM changes (`hasChanges`). `hasChanges` is used to determine where certain `scm/title` return a no-op.

### Demo

https://github.com/iterative/vscode-dvc/assets/37993418/724ddecc-e410-411d-87e5-65a12a4b2cdc

