### PR TITLE
Hide refresh experiments from the command palette

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -960,6 +960,10 @@
           "when": "false"
         },
         {
+          "command": "dvc.views.experiments.refresh",
+          "when": "false"
+        },
+        {
           "command": "dvc.views.experiments.removeExperiment",
           "when": "false"
         },


### PR DESCRIPTION
Fixes [this issue](https://github.com/iterative/vscode-dvc/issues/4528#issuecomment-1683685613) 