### PR TITLE
Accomodate new DVCLive signal file format

### DIFF
--- a/extension/src/fileSystem/index.ts
+++ b/extension/src/fileSystem/index.ts
@@ -252,6 +252,16 @@ export const writeTsv = async (
   return writeFileSync(path, csv)
 }
 
+const getPid = (contents: string): number | undefined => {
+  try {
+    const { pid } = JSON.parse(contents) as { pid?: string }
+    if (pid) {
+      return createValidInteger(pid)
+    }
+  } catch {}
+  return createValidInteger(contents)
+}
+
 export const getPidFromFile = async (
   path: string
 ): Promise<number | undefined> => {
@@ -260,7 +270,7 @@ export const getPidFromFile = async (
   }
 
   const contents = readFileSync(path).toString()
-  const pid = createValidInteger(contents)
+  const pid = getPid(contents)
 
   if (!pid || !(await processExists(pid))) {
     removeSync(path)


### PR DESCRIPTION
# 1/2 `main` <- this <- #4566 

Related to #4491

We need to add the experiment name to the DVCLIVE_ONLY signal file created when DVCLive is running without DVC (i.e. in a notebook) so that we can "select it for plotting" when the experiment has finished.

Accompanying PR in DVCLive is https://github.com/iterative/dvclive/pull/674