### PR TITLE
Revert collecting remote exp refs

### DIFF
--- a/extension/src/experiments/model/collect.test.ts
+++ b/extension/src/experiments/model/collect.test.ts
@@ -1,4 +1,4 @@
-import { collectExperiments, collectRemoteExpDetails } from './collect'
+import { collectExperiments, collectRemoteExpRefs } from './collect'
 import { generateTestExpShowOutput } from '../../test/util/experiments'
 import { ExpShowOutput } from '../../cli/dvc/contract'
 
@@ -102,7 +102,7 @@ describe('collectExperiments', () => {
   })
 })
 
-describe('collectRemoteExpDetails', () => {
+describe('collectRemoteExpRefs', () => {
   it('should parse the git ls-remote output', () => {
     const output = `263e4408e42a0e215b0f70b36b2ab7b65a160d7e        refs/exps/a9/b32d14966b9be1396f2211d9eb743359708a07/vital-taal
     d4f2a35773ead55b7ce4b596f600e98360e49372        refs/exps/a9/b32d14966b9be1396f2211d9eb743359708a07/whole-bout
@@ -111,16 +111,7 @@ describe('collectRemoteExpDetails', () => {
     390aef747f45fc49ec8928b24771f8950d057393        refs/exps/a9/d8057e088d46842f15c3b6d1bb2e4befd5f677/known-flus
     142a803b83ff784ba1106cc4ad0ba03310da6186        refs/exps/a9/d8057e088d46842f15c3b6d1bb2e4befd5f677/tight-lira
     21ce298cd1743405a0d73f5cb4cf52289ffa3276        refs/exps/bf/6ca8a35911bc6e62fb9bcaa506d4f4e185450c/crumb-orcs`
-    const { remoteExpRefs, remoteExpShas } = collectRemoteExpDetails(output)
-    expect(remoteExpRefs).toStrictEqual([
-      'refs/exps/a9/b32d14966b9be1396f2211d9eb743359708a07/vital-taal',
-      'refs/exps/a9/b32d14966b9be1396f2211d9eb743359708a07/whole-bout',
-      'refs/exps/a9/d8057e088d46842f15c3b6d1bb2e4befd5f677/deism-bots',
-      'refs/exps/a9/d8057e088d46842f15c3b6d1bb2e4befd5f677/inter-gulf',
-      'refs/exps/a9/d8057e088d46842f15c3b6d1bb2e4befd5f677/known-flus',
-      'refs/exps/a9/d8057e088d46842f15c3b6d1bb2e4befd5f677/tight-lira',
-      'refs/exps/bf/6ca8a35911bc6e62fb9bcaa506d4f4e185450c/crumb-orcs'
-    ])
+    const remoteExpShas = collectRemoteExpRefs(output)
     expect(remoteExpShas).toStrictEqual(
       new Set([
         '263e4408e42a0e215b0f70b36b2ab7b65a160d7e',

--- a/extension/src/experiments/model/collect.ts
+++ b/extension/src/experiments/model/collect.ts
@@ -485,15 +485,11 @@ export const collectRunningInWorkspace = (
   }
 }
 
-export const collectRemoteExpDetails = (
-  lsRemoteOutput: string
-): { remoteExpShas: Set<string>; remoteExpRefs: string[] } => {
-  const remoteExpRefs: string[] = []
-  const remoteExpShas = new Set<string>()
+export const collectRemoteExpRefs = (lsRemoteOutput: string): Set<string> => {
+  const acc = new Set<string>()
   for (const shaAndRef of trimAndSplit(lsRemoteOutput)) {
-    const [sha, ref] = shaAndRef.split(/\s+/)
-    remoteExpShas.add(sha)
-    remoteExpRefs.push(ref.trim())
+    const [sha] = shaAndRef.split(/\s+/)
+    acc.add(sha)
   }
-  return { remoteExpRefs, remoteExpShas }
+  return acc
 }

--- a/extension/src/experiments/model/index.ts
+++ b/extension/src/experiments/model/index.ts
@@ -6,7 +6,7 @@ import {
   collectAddRemoveCommitsDetails,
   collectExperiments,
   collectOrderedCommitsAndExperiments,
-  collectRemoteExpDetails,
+  collectRemoteExpRefs,
   collectRunningInQueue,
   collectRunningInWorkspace
 } from './collect'
@@ -181,9 +181,8 @@ export class ExperimentsModel extends ModelWithPersistence {
   }
 
   public transformAndSetRemote(lsRemoteOutput: string) {
-    const { remoteExpShas } = collectRemoteExpDetails(lsRemoteOutput)
+    const remoteExpShas = collectRemoteExpRefs(lsRemoteOutput)
     this.remoteExpShas = remoteExpShas
-    this.deferred.resolve()
   }
 
   public toggleStars(ids: string[]) {


### PR DESCRIPTION
# 2/2 `main` <- #4600 <- this

This PR removes the collection of remote exp refs. We no longer need this information now we are not calling `https://studio.iterative.ai/webhook/dvc`.