### PR TITLE
Stop explicitly watching temp queued experiment directories (already covered)

### DIFF
--- a/extension/src/cli/dvc/constants.ts
+++ b/extension/src/cli/dvc/constants.ts
@@ -9,7 +9,7 @@ export const TEMP_PLOTS_DIR = join(DOT_DVC, 'tmp', 'plots')
 
 export const FIELD_SEPARATOR = '::'
 
-export const TEMP_EXP_DIR = join(DOT_DVC, 'tmp', 'exps')
+const TEMP_EXP_DIR = join(DOT_DVC, 'tmp', 'exps')
 const TEMP_EXP_RUN_DIR = join(TEMP_EXP_DIR, 'run')
 export const DVCLIVE_ONLY_RUNNING_SIGNAL_FILE = join(
   TEMP_EXP_RUN_DIR,

--- a/extension/src/data/index.ts
+++ b/extension/src/data/index.ts
@@ -82,7 +82,7 @@ export abstract class BaseData<
     )
   }
 
-  protected listener(path: string) {
+  private listener(path: string) {
     const relPath = relative(this.dvcRoot, path)
     if (
       this.getWatchedFiles().some(

--- a/extension/src/experiments/data/index.ts
+++ b/extension/src/experiments/data/index.ts
@@ -1,4 +1,3 @@
-import { join } from 'path'
 import { collectBranches, collectFiles } from './collect'
 import {
   EXPERIMENTS_GIT_LOGS_REFS,
@@ -18,8 +17,7 @@ import {
   Args,
   DOT_DVC,
   DVCLIVE_STEP_COMPLETED_SIGNAL_FILE,
-  ExperimentFlag,
-  TEMP_EXP_DIR
+  ExperimentFlag
 } from '../../cli/dvc/constants'
 import { COMMITS_SEPARATOR, gitPath } from '../../cli/git/constants'
 import { getGitPath } from '../../fileSystem'
@@ -51,7 +49,6 @@ export class ExperimentsData extends BaseData<ExperimentsOutput> {
     this.experiments = experiments
 
     void this.watchExpGitRefs()
-    void this.watchQueueDirectories()
     void this.managedUpdate()
     this.waitForInitialLocalData()
   }
@@ -185,15 +182,6 @@ export class ExperimentsData extends BaseData<ExperimentsOutput> {
           return this.managedUpdate()
         }
       }
-    )
-  }
-
-  private watchQueueDirectories() {
-    const tempQueueDirectory = join(this.dvcRoot, TEMP_EXP_DIR)
-    return createFileSystemWatcher(
-      disposable => this.dispose.track(disposable),
-      getRelativePattern(tempQueueDirectory, '**'),
-      (path: string) => this.listener(path)
     )
   }
 

--- a/extension/src/test/suite/experiments/data/index.test.ts
+++ b/extension/src/test/suite/experiments/data/index.test.ts
@@ -83,7 +83,7 @@ suite('Experiments Data Test Suite', () => {
       await data.isReady()
 
       expect(mockExpShow).to.be.calledOnce
-      expect(mockCreateFileSystemWatcher).to.be.calledTwice
+      expect(mockCreateFileSystemWatcher).to.be.calledOnce
 
       expect(getArgOfCall(mockCreateFileSystemWatcher, 0, 2)).to.deep.equal(
         new RelativePattern(getTestWorkspaceFolder(), '**')


### PR DESCRIPTION
Reverts #4571 which was replaced by #4579 (and may not have made a difference anyway).