### PR TITLE
fix: show current max depth value instead of 0

### DIFF
--- a/extension/src/experiments/webview/messages.ts
+++ b/extension/src/experiments/webview/messages.ts
@@ -19,7 +19,7 @@ import { ExperimentsModel } from '../model'
 import { SortDefinition } from '../model/sortBy'
 import { getPositiveIntegerInput } from '../../vscode/inputBox'
 import { Title } from '../../vscode/title'
-import { ConfigKey, setConfigValue } from '../../vscode/config'
+import { ConfigKey, getConfigValue, setConfigValue } from '../../vscode/config'
 import { NUM_OF_COMMITS_TO_INCREASE } from '../../cli/dvc/constants'
 import { Pipeline } from '../../pipeline'
 import { collectColumnsWithChangedValues } from '../columns/collect'
@@ -376,9 +376,10 @@ export class WebviewMessages {
   }
 
   private async setMaxTableHeadDepth() {
+    const currentValue = getConfigValue(ConfigKey.EXP_TABLE_HEAD_MAX_HEIGHT)
     const newValue = await getPositiveIntegerInput(
       Title.SET_EXPERIMENTS_HEADER_HEIGHT,
-      { prompt: 'Use 0 for infinite height.', value: '0' },
+      { prompt: 'Use 0 for infinite height.', value: currentValue },
       true
     )
 


### PR DESCRIPTION
<table>
<tr>
 <th> Current
 <th> PR
<tr>
 <td> 

https://github.com/iterative/vscode-dvc/assets/20840228/d19f93c9-118a-4e15-943f-c0dc2ecbfc3e

 <td>

https://github.com/iterative/vscode-dvc/assets/20840228/7acfa69f-a691-4f43-b5ba-9a921b25c633

</table>


