### PR TITLE
Fix custom plots breaking with non-numeric values

### DIFF
--- a/extension/src/plots/model/collect.ts
+++ b/extension/src/plots/model/collect.ts
@@ -47,7 +47,7 @@ export const getCustomPlotId = (metric: string, param: string) =>
   `custom-${metric}-${param}`
 
 const getValueFromColumn = (path: string, experiment: Experiment) =>
-  get(experiment, splitColumnPath(path)) as number | undefined
+  get(experiment, splitColumnPath(path)) as number | string | undefined
 
 const getValues = (
   experiments: Experiment[],
@@ -84,9 +84,16 @@ const getCustomPlotData = (
 
   const values = getValues(experiments, metricPath, paramPath)
 
+  const [{ param: paramVal, metric: metricVal }] = values
   const yTitle = truncateVerticalTitle(metric, nbItemsPerRow, height) as string
 
-  const spec = createSpec(yTitle, metric, param)
+  const spec = createSpec(
+    yTitle,
+    metric,
+    param,
+    typeof metricVal,
+    typeof paramVal
+  )
 
   return {
     id: getCustomPlotId(metric, param),

--- a/extension/src/plots/model/custom.test.ts
+++ b/extension/src/plots/model/custom.test.ts
@@ -6,18 +6,18 @@ describe('cleanupOlderValue', () => {
   it('should update value if contents are outdated', () => {
     const output = cleanupOldOrderValue({
       metric: 'metrics:summary.json:loss',
-      param: 'params:params.yaml:dropout'
+      param: 'params:params.yaml:log_file'
     })
     expect(output).toStrictEqual({
       metric: 'summary.json:loss',
-      param: 'params.yaml:dropout'
+      param: 'params.yaml:log_file'
     })
   })
 
   it('should not update value if contents are not outdated', () => {
     const value = {
       metric: 'summary.json:loss',
-      param: 'params.yaml:dropout'
+      param: 'params.yaml:log_file'
     }
     const output = cleanupOldOrderValue(value)
     expect(output).toStrictEqual(value)
@@ -30,13 +30,13 @@ describe('checkForCustomPlotOptions', () => {
       [
         {
           hasChildren: false,
-          label: 'dropout',
-          path: 'params:params.yaml:dropout',
+          label: 'log_file',
+          path: 'params:params.yaml:log_file',
           type: ColumnType.PARAMS
         },
         {
           hasChildren: false,
-          label: 'dropout',
+          label: 'log_file',
           path: 'params:params.yaml:epochs',
           type: ColumnType.PARAMS
         },
@@ -63,13 +63,13 @@ describe('checkForCustomPlotOptions', () => {
       [
         {
           hasChildren: false,
-          label: 'dropout',
-          path: 'params:params.yaml:dropout',
+          label: 'log_file',
+          path: 'params:params.yaml:log_file',
           type: ColumnType.PARAMS
         },
         {
           hasChildren: false,
-          label: 'dropout',
+          label: 'log_file',
           path: 'params:params.yaml:epochs',
           type: ColumnType.PARAMS
         },
@@ -90,7 +90,7 @@ describe('checkForCustomPlotOptions', () => {
         ...customPlotsOrderFixture,
         {
           metric: 'summary.json:accuracy',
-          param: 'params.yaml:dropout'
+          param: 'params.yaml:log_file'
         },
         {
           metric: 'summary.json:loss',

--- a/extension/src/plots/model/custom.ts
+++ b/extension/src/plots/model/custom.ts
@@ -69,7 +69,16 @@ export const checkForCustomPlotOptions = (
   return false
 }
 
-export const createSpec = (title: string, metric: string, param: string) =>
+const getSpecDataType = (type: string) =>
+  type === 'number' ? 'quantitative' : 'nominal'
+
+export const createSpec = (
+  title: string,
+  metric: string,
+  param: string,
+  metricType: string,
+  paramType: string
+) =>
   ({
     $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
     data: { name: 'values' },
@@ -80,7 +89,7 @@ export const createSpec = (title: string, metric: string, param: string) =>
           zero: false
         },
         title: param,
-        type: 'quantitative'
+        type: getSpecDataType(paramType)
       },
       y: {
         field: 'metric',
@@ -88,7 +97,7 @@ export const createSpec = (title: string, metric: string, param: string) =>
           zero: false
         },
         title,
-        type: 'quantitative'
+        type: getSpecDataType(metricType)
       }
     },
     height: 'container',

--- a/extension/src/plots/model/custom.ts
+++ b/extension/src/plots/model/custom.ts
@@ -84,6 +84,10 @@ export const createSpec = (
     data: { name: 'values' },
     encoding: {
       x: {
+        axis: {
+          labelLimit: 75,
+          titlePadding: 30
+        },
         field: 'param',
         scale: {
           zero: false
@@ -92,6 +96,10 @@ export const createSpec = (
         type: getSpecDataType(paramType)
       },
       y: {
+        axis: {
+          labelLimit: 75,
+          titlePadding: 30
+        },
         field: 'metric',
         scale: {
           zero: false

--- a/extension/src/plots/model/quickPick.test.ts
+++ b/extension/src/plots/model/quickPick.test.ts
@@ -87,8 +87,8 @@ describe('pickMetricAndParam', () => {
     mockedQuickPickValue
       .mockResolvedValueOnce({
         hasChildren: false,
-        label: 'dropout',
-        path: 'params:params.yaml:dropout',
+        label: 'log_file',
+        path: 'params:params.yaml:log_file',
         type: ColumnType.PARAMS
       })
       .mockResolvedValueOnce(undefined)
@@ -98,8 +98,8 @@ describe('pickMetricAndParam', () => {
       [
         {
           hasChildren: false,
-          label: 'dropout',
-          path: 'params:params.yaml:dropout',
+          label: 'log_file',
+          path: 'params:params.yaml:log_file',
           type: ColumnType.PARAMS
         },
         {
@@ -117,8 +117,8 @@ describe('pickMetricAndParam', () => {
       [
         {
           hasChildren: false,
-          label: 'dropout',
-          path: 'params:params.yaml:dropout',
+          label: 'log_file',
+          path: 'params:params.yaml:log_file',
           type: ColumnType.PARAMS
         },
         {
@@ -151,8 +151,8 @@ describe('pickMetricAndParam', () => {
         { ...expectedParam, hasChildren: false, type: ColumnType.PARAMS },
         {
           hasChildren: false,
-          label: 'dropout',
-          path: 'params:params.yaml:dropout',
+          label: 'log_file',
+          path: 'params:params.yaml:log_file',
           type: ColumnType.PARAMS
         },
         {
@@ -191,8 +191,8 @@ describe('pickMetricAndParam', () => {
         },
         {
           hasChildren: false,
-          label: 'dropout',
-          path: 'params:params.yaml:dropout',
+          label: 'log_file',
+          path: 'params:params.yaml:log_file',
           type: ColumnType.PARAMS
         },
         {
@@ -218,7 +218,7 @@ describe('pickMetricAndParam', () => {
         ...customPlotsOrderFixture,
         {
           metric: 'summary.json:val_accuracy',
-          param: 'params.yaml:dropout'
+          param: 'params.yaml:log_file'
         },
         {
           metric: 'summary.json:val_accuracy',

--- a/extension/src/plots/webview/contract.ts
+++ b/extension/src/plots/webview/contract.ts
@@ -80,8 +80,8 @@ export interface PlotsComparisonData {
 
 export type CustomPlotValues = {
   id: string
-  metric: number
-  param: number
+  metric: number | string
+  param: number | string
 }[]
 
 export type ColorScale = { domain: string[]; range: Color[] }

--- a/extension/src/test/fixtures/expShow/base/customPlots.ts
+++ b/extension/src/test/fixtures/expShow/base/customPlots.ts
@@ -104,6 +104,10 @@ const data: CustomPlotsData = {
         data: { name: 'values' },
         encoding: {
           x: {
+            axis: {
+              labelLimit: 75,
+              titlePadding: 30
+            },
             field: 'param',
             scale: {
               zero: false
@@ -112,6 +116,10 @@ const data: CustomPlotsData = {
             type: 'nominal'
           },
           y: {
+            axis: {
+              labelLimit: 75,
+              titlePadding: 30
+            },
             field: 'metric',
             scale: {
               zero: false
@@ -206,6 +214,10 @@ const data: CustomPlotsData = {
         data: { name: 'values' },
         encoding: {
           x: {
+            axis: {
+              labelLimit: 75,
+              titlePadding: 30
+            },
             field: 'param',
             scale: {
               zero: false
@@ -214,6 +226,10 @@ const data: CustomPlotsData = {
             type: 'quantitative'
           },
           y: {
+            axis: {
+              labelLimit: 75,
+              titlePadding: 30
+            },
             field: 'metric',
             scale: {
               zero: false

--- a/extension/src/test/fixtures/expShow/base/customPlots.ts
+++ b/extension/src/test/fixtures/expShow/base/customPlots.ts
@@ -9,7 +9,7 @@ import { Experiment } from '../../../../experiments/webview/contract'
 export const customPlotsOrderFixture: CustomPlotsOrderValue[] = [
   {
     metric: 'summary.json:loss',
-    param: 'params.yaml:dropout'
+    param: 'params.yaml:log_file'
   },
   {
     metric: 'summary.json:accuracy',
@@ -28,7 +28,7 @@ export const experimentsWithCommits: Experiment[] = [
         accuracy: 0.3484833240509033
       }
     },
-    params: { 'params.yaml': { dropout: 0.122, epochs: 5 } }
+    params: { 'params.yaml': { log_file: 'logs.csv', epochs: 5 } }
   },
   {
     branch: 'main',
@@ -40,7 +40,7 @@ export const experimentsWithCommits: Experiment[] = [
         accuracy: 0.3484833240509033
       }
     },
-    params: { 'params.yaml': { dropout: 0.122, epochs: 5 } }
+    params: { 'params.yaml': { log_file: 'logs.csv', epochs: 5 } }
   },
   {
     branch: 'main',
@@ -52,7 +52,7 @@ export const experimentsWithCommits: Experiment[] = [
         accuracy: 0.3484833240509033
       }
     },
-    params: { 'params.yaml': { dropout: 0.122, epochs: 5 } }
+    params: { 'params.yaml': { log_file: 'logs.csv', epochs: 5 } }
   },
   {
     branch: 'main',
@@ -64,7 +64,7 @@ export const experimentsWithCommits: Experiment[] = [
       }
     },
     label: '1224',
-    params: { 'params.yaml': { dropout: 0.15, epochs: 2 } }
+    params: { 'params.yaml': { log_file: 'logs.csv', epochs: 2 } }
   },
   {
     branch: 'main',
@@ -76,7 +76,7 @@ export const experimentsWithCommits: Experiment[] = [
         loss: 1.9293040037155151
       }
     },
-    params: { 'params.yaml': { dropout: 0.122, epochs: 2 } }
+    params: { 'params.yaml': { log_file: 'logs.csv', epochs: 2 } }
   },
   {
     branch: 'main',
@@ -88,7 +88,7 @@ export const experimentsWithCommits: Experiment[] = [
         loss: 1.775016188621521
       }
     },
-    params: { 'params.yaml': { dropout: 0.124, epochs: 5 } }
+    params: { 'params.yaml': { log_file: 'logs.csv', epochs: 5 } }
   }
 ]
 
@@ -96,9 +96,9 @@ const data: CustomPlotsData = {
   enablePlotCreation: true,
   plots: [
     {
-      id: 'custom-summary.json:loss-params.yaml:dropout',
+      id: 'custom-summary.json:loss-params.yaml:log_file',
       metric: 'summary.json:loss',
-      param: 'params.yaml:dropout',
+      param: 'params.yaml:log_file',
       spec: {
         $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
         data: { name: 'values' },
@@ -108,8 +108,8 @@ const data: CustomPlotsData = {
             scale: {
               zero: false
             },
-            title: 'params.yaml:dropout',
-            type: 'quantitative'
+            title: 'params.yaml:log_file',
+            type: 'nominal'
           },
           y: {
             field: 'metric',
@@ -135,7 +135,7 @@ const data: CustomPlotsData = {
                 },
                 {
                   field: 'param',
-                  title: 'params.yaml:dropout'
+                  title: 'params.yaml:log_file'
                 }
               ]
             },
@@ -149,35 +149,19 @@ const data: CustomPlotsData = {
         width: 'container'
       },
       values: [
-        {
-          id: 'main',
-          metric: 2.048856019973755,
-          param: 0.122
-        },
+        { id: 'main', metric: 2.048856019973755, param: 'logs.csv' },
         {
           id: 'fe2919b',
           metric: 2.048856019973755,
-          param: 0.122
+          param: 'logs.csv'
         },
-        {
-          id: '7df876c',
-          metric: 2.048856019973755,
-          param: 0.122
-        },
-        {
-          id: 'exp-e7a67',
-          metric: 2.0205044746398926,
-          param: 0.15
-        },
-        {
-          id: 'test-branch',
-          metric: 1.9293040037155151,
-          param: 0.122
-        },
+        { id: '7df876c', metric: 2.048856019973755, param: 'logs.csv' },
+        { id: 'exp-e7a67', metric: 2.0205044746398926, param: 'logs.csv' },
+        { id: 'test-branch', metric: 1.9293040037155151, param: 'logs.csv' },
         {
           id: 'exp-83425',
           metric: 1.775016188621521,
-          param: 0.124
+          param: 'logs.csv'
         }
       ]
     },

--- a/extension/src/test/suite/plots/index.test.ts
+++ b/extension/src/test/suite/plots/index.test.ts
@@ -654,7 +654,7 @@ suite('Plots Test Suite', () => {
 
       const mockNewCustomPlotsOrder = [
         'custom-summary.json:accuracy-params.yaml:epochs',
-        'custom-summary.json:loss-params.yaml:dropout'
+        'custom-summary.json:loss-params.yaml:log_file'
       ]
 
       stub(plotsModel, 'getCustomPlots')
@@ -680,7 +680,7 @@ suite('Plots Test Suite', () => {
         },
         {
           metric: 'summary.json:loss',
-          param: 'params.yaml:dropout'
+          param: 'params.yaml:log_file'
         }
       ])
       expect(messageSpy).to.be.calledOnce

--- a/extension/src/test/suite/plots/workspace.test.ts
+++ b/extension/src/test/suite/plots/workspace.test.ts
@@ -37,7 +37,7 @@ suite('Workspace Plots Test Suite', () => {
 
       const mockMetricVsParamOrderValue = {
         metric: 'summary.json:accuracy',
-        param: 'params.yaml:dropout'
+        param: 'params.yaml:log_file'
       }
 
       mockGetMetricAndParam.onFirstCall().resolves(mockMetricVsParamOrderValue)
@@ -88,12 +88,12 @@ suite('Workspace Plots Test Suite', () => {
 
       mockSelectCustomPlots
         .onFirstCall()
-        .resolves(['custom-summary.json:loss-params.yaml:dropout'])
+        .resolves(['custom-summary.json:loss-params.yaml:log_file'])
 
       stub(plotsModel, 'getCustomPlotsOrder').returns([
         {
           metric: 'summary.json:loss',
-          param: 'params.yaml:dropout'
+          param: 'params.yaml:log_file'
         }
       ])
 
@@ -121,7 +121,7 @@ suite('Workspace Plots Test Suite', () => {
       stub(plotsModel, 'getCustomPlotsOrder').returns([
         {
           metric: 'summary.json:loss',
-          param: 'params.yaml:dropout'
+          param: 'params.yaml:log_file'
         }
       ])
 

--- a/webview/src/plots/components/App.test.tsx
+++ b/webview/src/plots/components/App.test.tsx
@@ -874,7 +874,7 @@ describe('App', () => {
     let plots = screen.getAllByTestId(/summary\.json/)
 
     expect(plots.map(plot => plot.id)).toStrictEqual([
-      'custom-summary.json:loss-params.yaml:dropout',
+      'custom-summary.json:loss-params.yaml:log_file',
       'custom-summary.json:accuracy-params.yaml:epochs'
     ])
 
@@ -884,7 +884,7 @@ describe('App', () => {
 
     expect(plots.map(plot => plot.id)).toStrictEqual([
       'custom-summary.json:accuracy-params.yaml:epochs',
-      'custom-summary.json:loss-params.yaml:dropout'
+      'custom-summary.json:loss-params.yaml:log_file'
     ])
   })
 
@@ -895,7 +895,7 @@ describe('App', () => {
 
     const plots = screen.getAllByTestId(/summary\.json/)
     expect(plots.map(plot => plot.id)).toStrictEqual([
-      'custom-summary.json:loss-params.yaml:dropout',
+      'custom-summary.json:loss-params.yaml:log_file',
       'custom-summary.json:accuracy-params.yaml:epochs'
     ])
 
@@ -905,7 +905,7 @@ describe('App', () => {
 
     const expectedOrder = [
       'custom-summary.json:accuracy-params.yaml:epochs',
-      'custom-summary.json:loss-params.yaml:dropout'
+      'custom-summary.json:loss-params.yaml:log_file'
     ]
 
     expect(mockPostMessage).toHaveBeenCalledTimes(1)
@@ -928,7 +928,7 @@ describe('App', () => {
 
     expect(
       screen.getAllByTestId(/summary\.json/).map(plot => plot.id)
-    ).toStrictEqual(['custom-summary.json:loss-params.yaml:dropout'])
+    ).toStrictEqual(['custom-summary.json:loss-params.yaml:log_file'])
 
     sendSetDataMessage({
       custom: customPlotsFixture
@@ -937,7 +937,7 @@ describe('App', () => {
     expect(
       screen.getAllByTestId(/summary\.json/).map(plot => plot.id)
     ).toStrictEqual([
-      'custom-summary.json:loss-params.yaml:dropout',
+      'custom-summary.json:loss-params.yaml:log_file',
       'custom-summary.json:accuracy-params.yaml:epochs'
     ])
   })
@@ -950,7 +950,7 @@ describe('App', () => {
     expect(
       screen.getAllByTestId(/summary\.json/).map(plot => plot.id)
     ).toStrictEqual([
-      'custom-summary.json:loss-params.yaml:dropout',
+      'custom-summary.json:loss-params.yaml:log_file',
       'custom-summary.json:accuracy-params.yaml:epochs'
     ])
 
@@ -978,7 +978,7 @@ describe('App', () => {
     dragAndDrop(templatePlots[0], customPlots[1])
 
     expect(customPlots.map(plot => plot.id)).toStrictEqual([
-      'custom-summary.json:loss-params.yaml:dropout',
+      'custom-summary.json:loss-params.yaml:log_file',
       'custom-summary.json:accuracy-params.yaml:epochs'
     ])
   })
@@ -1221,7 +1221,7 @@ describe('App', () => {
 
     const expectedOrder = [
       'custom-summary.json:accuracy-params.yaml:epochs',
-      'custom-summary.json:loss-params.yaml:dropout'
+      'custom-summary.json:loss-params.yaml:log_file'
     ]
 
     expect(


### PR DESCRIPTION
## `main`

<img width="1337" alt="image" src="https://github.com/iterative/vscode-dvc/assets/43496356/c5d28c87-3f39-474f-8eb3-7a901e7eb1d1">

## PR

<img width="1356" alt="image" src="https://github.com/iterative/vscode-dvc/assets/43496356/2ef0e79b-404c-4ed8-862b-5381b843042d">

~Looks buggy due to the length of the param string, but that would not be a quick fix since I'd need to do some extra research on what we could do.~

Fixes #4625