### PR TITLE
Add ability to zoom and pan plots when zoomed

### DIFF
--- a/extension/src/plots/vega/util.test.ts
+++ b/extension/src/plots/vega/util.test.ts
@@ -8,7 +8,8 @@ import {
   extendVegaSpec,
   getColorScale,
   Encoding,
-  reverseOfLegendSuppressionUpdate
+  reverseOfLegendSuppressionUpdate,
+  makePlotZoomOnWheel
 } from './util'
 import confusionTemplate from '../../test/fixtures/plotsDiff/templates/confusion'
 import confusionNormalizedTemplate from '../../test/fixtures/plotsDiff/templates/confusionNormalized'
@@ -347,5 +348,25 @@ describe('reverseOfLegendSuppressionUpdate', () => {
     )
     expect(result).not.toContain('"legend":{"disable":true}')
     expect(result).toContain('"legend":{"disable":false}')
+  })
+})
+
+describe('makePlotZoomOnWheel', () => {
+  it('should provide a spec update that makes custom plots zoom on wheel (and enable pan when zoomed)', () => {
+    const { spec: specUpdate } = makePlotZoomOnWheel(true, false)
+
+    expect(Object.keys(specUpdate)).toContain('params')
+  })
+
+  it('should provide a spec update that does not break template plots but enables zoom on wheel (and pan when zoomed)', () => {
+    const { spec: specUpdate } = makePlotZoomOnWheel(false, false)
+
+    expect(Object.keys(specUpdate)).not.toContain('params')
+  })
+
+  it('should provide a spec update that enables zoom on wheel (and pan when zoomed) for the default templates which have smoothing', () => {
+    const { spec: specUpdate } = makePlotZoomOnWheel(false, true)
+
+    expect(specUpdate.layer?.[0].params).not.toBeUndefined()
   })
 })

--- a/extension/src/plots/vega/util.ts
+++ b/extension/src/plots/vega/util.ts
@@ -353,3 +353,42 @@ export const reverseOfLegendSuppressionUpdate = () => ({
     }
   }
 })
+
+export const makePlotZoomOnWheel = (
+  isCustomPlot: boolean,
+  hasSmoothing: boolean
+) => {
+  if (isCustomPlot) {
+    return {
+      spec: {
+        params: [
+          {
+            bind: 'scales',
+            name: 'grid',
+            select: 'interval'
+          }
+        ]
+      }
+    }
+  }
+  if (hasSmoothing) {
+    return {
+      spec: {
+        layer: [
+          { params: [{ bind: 'scales', name: 'grid', select: 'interval' }] }
+        ]
+      }
+    }
+  }
+
+  return {
+    spec: {
+      selection: {
+        grid: {
+          bind: 'scales',
+          type: 'interval'
+        }
+      }
+    }
+  }
+}

--- a/webview/src/plots/components/ZoomedInPlot.tsx
+++ b/webview/src/plots/components/ZoomedInPlot.tsx
@@ -3,7 +3,10 @@ import VegaLite, { VegaLiteProps } from 'react-vega/lib/VegaLite'
 import { Config } from 'vega-lite'
 import merge from 'lodash.merge'
 import cloneDeep from 'lodash.clonedeep'
-import { reverseOfLegendSuppressionUpdate } from 'dvc/src/plots/vega/util'
+import {
+  makePlotZoomOnWheel,
+  reverseOfLegendSuppressionUpdate
+} from 'dvc/src/plots/vega/util'
 import { TemplateVegaLite } from './templatePlots/TemplateVegaLite'
 import styles from './styles.module.scss'
 import { getThemeValue, ThemeProperty } from '../../util/styles'
@@ -40,6 +43,12 @@ export const ZoomedInPlot: React.FC<ZoomedInPlotProps> = ({
   isTemplatePlot,
   openActionsMenu
 }: ZoomedInPlotProps) => {
+  const isCustomPlot = !isTemplatePlot
+  const hasSmoothing =
+    isTemplatePlot &&
+    (props.spec as { params?: { name: string }[] }).params?.[0]?.name ===
+      'smooth'
+
   const zoomedInPlotRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -72,8 +81,13 @@ export const ZoomedInPlot: React.FC<ZoomedInPlotProps> = ({
     }
   }
 
+  const specUpdate = merge(
+    reverseOfLegendSuppressionUpdate(),
+    makePlotZoomOnWheel(isCustomPlot, hasSmoothing)
+  )
+
   const vegaLiteProps = {
-    ...merge({ ...cloneDeep(props) }, reverseOfLegendSuppressionUpdate()),
+    ...merge({ ...cloneDeep(props) }, specUpdate),
     actions: {
       compiled: false,
       editor: false,


### PR DESCRIPTION
Closes #4530
Related to https://github.com/iterative/dvc-render/issues/7

This PR adds the ability to zoom (using the mouse wheel) and pan plots when they are focused. I have limited the change to only focused because it mitigates the unexpected behaviour of the plot being zoomed when the user is trying to scroll between plots.

Types covered by this change?:

1. Scatter plots
2. Smooth plots
3. Simple plots
4. Horizontal bar plots
5. Custom plots

What's not covered:

- Confusion matrices (and probably other multiview plots)

### Demo


https://github.com/iterative/vscode-dvc/assets/37993418/63dc7c1f-4585-4fa7-bda0-f99a58105200



Note: has the potential to break custom templates.