### PR TITLE
Add Hydra syntax hint (prompt) to input box for modify and queue experiment command

### DIFF
--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -461,14 +461,14 @@ export class Experiments extends BaseRepository<TableData> {
     )
   }
 
-  public pickAndModifyParams() {
+  public pickAndModifyParams(inputPrompt?: string) {
     const params = this.experiments.getWorkspaceParams()
 
     if (!params) {
       return
     }
 
-    return pickAndModifyParams(params)
+    return pickAndModifyParams(params, inputPrompt)
   }
 
   public getWorkspaceAndCommits() {
@@ -529,7 +529,9 @@ export class Experiments extends BaseRepository<TableData> {
       return
     }
 
-    const paramsToModify = await this.pickAndModifyParams()
+    const paramsToModify = await this.pickAndModifyParams(
+      'Use range(start,stop,step) or choice(*choices) to add multiple experiments to the queue'
+    )
     if (!paramsToModify) {
       return
     }

--- a/extension/src/experiments/model/modify/quickPick.test.ts
+++ b/extension/src/experiments/model/modify/quickPick.test.ts
@@ -16,9 +16,10 @@ describe('pickAndModifyParams', () => {
   it('should return early if no params are selected', async () => {
     mockedQuickPickManyValues.mockResolvedValueOnce(undefined)
 
-    const paramsToQueue = await pickAndModifyParams([
-      { path: 'params.yaml:learning_rate', value: 2e-12 }
-    ])
+    const paramsToQueue = await pickAndModifyParams(
+      [{ path: 'params.yaml:learning_rate', value: 2e-12 }],
+      undefined
+    )
 
     expect(paramsToQueue).toBeUndefined()
     expect(mockedGetInput).not.toHaveBeenCalled()
@@ -38,10 +39,10 @@ describe('pickAndModifyParams', () => {
     mockedGetInput.mockResolvedValueOnce(firstInput)
     mockedGetInput.mockResolvedValueOnce(undefined)
 
-    const paramsToQueue = await pickAndModifyParams([
-      unchanged,
-      ...initialUserResponse
-    ])
+    const paramsToQueue = await pickAndModifyParams(
+      [unchanged, ...initialUserResponse],
+      undefined
+    )
 
     expect(paramsToQueue).toBeUndefined()
     expect(mockedGetInput).toHaveBeenCalledTimes(2)
@@ -75,35 +76,40 @@ describe('pickAndModifyParams', () => {
     mockedGetInput.mockResolvedValueOnce(input4)
     mockedGetInput.mockResolvedValueOnce(input5)
 
-    const paramsToQueue = await pickAndModifyParams([
-      unchanged,
-      ...initialUserResponse
-    ])
+    const paramsToQueue = await pickAndModifyParams(
+      [unchanged, ...initialUserResponse],
+      undefined
+    )
 
     expect(mockedGetInput).toHaveBeenCalledTimes(5)
     expect(mockedGetInput).toHaveBeenCalledWith(
       'Enter a Value for params.yaml:dropout',
-      '0.15'
+      '0.15',
+      undefined
     )
 
     expect(mockedGetInput).toHaveBeenCalledWith(
       'Enter a Value for params.yaml:process.threshold',
-      '0.86'
+      '0.86',
+      undefined
     )
 
     expect(mockedGetInput).toHaveBeenCalledWith(
       'Enter a Value for params.yaml:code_names',
-      '[0,1,2]'
+      '[0,1,2]',
+      undefined
     )
 
     expect(mockedGetInput).toHaveBeenCalledWith(
       'Enter a Value for params.yaml:arch',
-      'resnet18'
+      'resnet18',
+      undefined
     )
 
     expect(mockedGetInput).toHaveBeenCalledWith(
       'Enter a Value for params.yaml:transforms',
-      '[Pipeline: PILBase.create, Pipeline: partial -> PILBase.create]'
+      '[Pipeline: PILBase.create, Pipeline: partial -> PILBase.create]',
+      undefined
     )
 
     expect(paramsToQueue).toStrictEqual([

--- a/extension/src/experiments/model/modify/quickPick.ts
+++ b/extension/src/experiments/model/modify/quickPick.ts
@@ -22,13 +22,15 @@ const pickParamsToModify = (params: Param[]): Thenable<Param[] | undefined> =>
   )
 
 const pickNewParamValues = async (
-  paramsToModify: Param[]
+  paramsToModify: Param[],
+  inputPrompt: string | undefined
 ): Promise<string[] | undefined> => {
   const args: string[] = []
   for (const { path, value } of paramsToModify) {
     const input = await getInput(
       getEnterValueTitle(path),
-      standardizeValue(value)
+      standardizeValue(value),
+      inputPrompt
     )
     if (input === undefined) {
       return
@@ -39,7 +41,8 @@ const pickNewParamValues = async (
 }
 
 export const pickAndModifyParams = async (
-  params: Param[]
+  params: Param[],
+  inputPrompt: string | undefined
 ): Promise<string[] | undefined> => {
   const paramsToModify = await pickParamsToModify(params)
 
@@ -47,5 +50,5 @@ export const pickAndModifyParams = async (
     return
   }
 
-  return pickNewParamValues(paramsToModify)
+  return pickNewParamValues(paramsToModify, inputPrompt)
 }

--- a/extension/src/test/suite/repository/model/tree.test.ts
+++ b/extension/src/test/suite/repository/model/tree.test.ts
@@ -281,6 +281,7 @@ suite('Repositories Tree Test Suite', () => {
       expect(mockMove).to.be.calledOnce
       expect(mockInputBox).to.be.calledOnce
       expect(mockInputBox).to.be.calledWith({
+        prompt: undefined,
         title: Title.ENTER_RELATIVE_DESTINATION,
         value: relPath
       })

--- a/extension/src/vscode/inputBox.ts
+++ b/extension/src/vscode/inputBox.ts
@@ -5,9 +5,11 @@ import { getIsoDate, isFreeTextDate } from '../util/date'
 
 export const getInput = (
   title: Title,
-  value?: string
+  value?: string,
+  prompt?: string
 ): Thenable<string | undefined> =>
   window.showInputBox({
+    prompt,
     title,
     value
   })


### PR DESCRIPTION
Closes #4465

This PR adds a hint to the input box for selecting new param values when running the modify and queue command.

### Demo

https://github.com/iterative/vscode-dvc/assets/37993418/b4e9ba9c-666b-4979-ab32-75071675b827
