### PR TITLE
Increase windows tests timeout

### DIFF
--- a/.github/workflows/cross-platform-test.yml
+++ b/.github/workflows/cross-platform-test.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   suite:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 25
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [windows-latest]


### PR DESCRIPTION
The reason for this change is that dependency updates often timeout on Windows because they can't utilise the yarn cache.