### PR TITLE
Remove mutli source plots encoding cache

### DIFF
--- a/extension/src/plots/model/index.ts
+++ b/extension/src/plots/model/index.ts
@@ -415,7 +415,7 @@ export class PlotsModel extends ModelWithPersistence {
       await Promise.all([
         collectData(output),
         collectTemplates(output),
-        collectMultiSourceVariations(output, this.multiSourceVariations)
+        collectMultiSourceVariations(output)
       ])
 
     this.comparisonData = {

--- a/extension/src/plots/multiSource/collect.ts
+++ b/extension/src/plots/multiSource/collect.ts
@@ -85,10 +85,8 @@ const collectPathMultiSourceVariations = (
   }
 }
 
-export const collectMultiSourceVariations = (
-  output: PlotsOutput,
-  acc: Record<string, Record<string, unknown>[]>
-) => {
+export const collectMultiSourceVariations = (output: PlotsOutput) => {
+  const acc: Record<string, Record<string, unknown>[]> = {}
   const { data } = output
   for (const [path, plots] of Object.entries(data)) {
     collectPathMultiSourceVariations(acc, path, plots)
@@ -275,6 +273,8 @@ const collectUnmergedShapeEncoding = (
   }
 }
 
+// this is how we can collect the encoding for multi-source plots
+// we need to pass in the anchors that we want to fill as well
 const collectPathMultiSourceEncoding = (
   acc: MultiSourceEncoding,
   path: string,


### PR DESCRIPTION
I ran into some issues while testing/working out some non-happy paths for https://github.com/iterative/dvc/issues/9940.

Previously, if an experiment was created that used fields from multiple files to generate a plot and then a subsequent experiment was created which moved to a single file/field for the same plot then the UI would look broken. Now the appropriate file/field will be shown.

### Demo

#### Main

https://github.com/iterative/vscode-dvc/assets/37993418/5cbed961-14ef-4998-b4c3-1e50b846ccb3


#### PR

https://github.com/iterative/vscode-dvc/assets/37993418/f3aafb56-4283-4b31-bf64-c6f04103104c


