### PR TITLE
Fix experiments table move to start functionality

### DIFF
--- a/webview/src/experiments/components/App.test.tsx
+++ b/webview/src/experiments/components/App.test.tsx
@@ -25,6 +25,7 @@ import { vsCodeApi } from '../../shared/api'
 import {
   commonColumnFields,
   expectHeaders,
+  getHeaders,
   tableData as sortingTableDataFixture
 } from '../../test/sort'
 import {
@@ -162,6 +163,30 @@ describe('App', () => {
     dragAndDrop(headerB, headerD, DragEnterDirection.AUTO)
 
     await expectHeaders(['A', 'C', 'D', 'B'])
+  })
+
+  it('should be able to move columns to the start', async () => {
+    renderTable({
+      ...sortingTableDataFixture,
+      columnOrder: ['id', 'Created', 'params:A', 'params:B', 'params:C']
+    })
+
+    await expectHeaders(['A', 'B', 'C'])
+
+    const moveBCtoStart = ['id', 'params:B', 'params:C', 'Created', 'params:A']
+
+    setTableData({
+      ...sortingTableDataFixture,
+      columnOrder: moveBCtoStart
+    })
+
+    expect(await getHeaders()).toStrictEqual([
+      'Experiment',
+      'B',
+      'C',
+      'Created',
+      'A'
+    ])
   })
 
   describe('Row expansion', () => {

--- a/webview/src/experiments/components/Experiments.tsx
+++ b/webview/src/experiments/components/Experiments.tsx
@@ -13,7 +13,8 @@ import {
   Row as TableRow,
   getCoreRowModel,
   getExpandedRowModel,
-  ColumnSizingState
+  ColumnSizingState,
+  ColumnOrderState
 } from '@tanstack/react-table'
 import { Table } from './table/Table'
 import styles from './table/styles.module.scss'
@@ -64,7 +65,8 @@ export const ExperimentsTable: React.FC = () => {
   const [columns, setColumns] = useState(buildColumns(columnData))
   const [columnSizing, setColumnSizing] =
     useState<ColumnSizingState>(columnWidths)
-  const [columnOrder, setColumnOrder] = useState(columnOrderData)
+  const [columnOrder, setColumnOrder] =
+    useState<ColumnOrderState>(columnOrderData)
   const resizeTimeout = useRef(0)
 
   useEffect(() => {
@@ -74,6 +76,10 @@ export const ExperimentsTable: React.FC = () => {
   useEffect(() => {
     setColumns(buildColumns(columnData))
   }, [columnData])
+
+  useEffect(() => {
+    setColumnOrder(columnOrderData)
+  }, [columnOrderData])
 
   const getRowId = useCallback(
     (experiment: Commit, relativeIndex: number, parent?: TableRow<Commit>) =>


### PR DESCRIPTION
Pretty sure that I broke this.

I noticed this issue while testing https://github.com/iterative/vscode-dvc/pull/4691. 

### Demo

https://github.com/iterative/vscode-dvc/assets/37993418/30ee6a06-079e-4be9-b9cf-5ac5f325639f

Note: it would be good to check that this still works with the change above.