### PR TITLE
Handle pull requests from forks

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -42,16 +42,25 @@ jobs:
 
       - run: yarn run lint
 
-      - uses: paambaati/codeclimate-action@v5.0.0
+      - name: Run Coverage Report
+        if: '!github.event.pull_request.head.repo.fork'
+        uses: paambaati/codeclimate-action@v5.0.0
         env:
           CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
         with:
           coverageCommand: xvfb-run -a yarn run cover
           coverageLocations: ${{github.workspace}}/coverage/lcov.info:lcov
 
-      - run: yarn build-storybook
+      - name: Run Fork Coverage
+        if: 'github.event.pull_request.head.repo.fork'
+        run: xvfb-run -a yarn run cover
+
+      - name: Build Storybook
+        if: '!github.event.pull_request.head.repo.fork'
+        run: yarn build-storybook
 
       - name: Publish to Chromatic
+        if: '!github.event.pull_request.head.repo.fork'
         uses: chromaui/action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Needed for #4616

The continuous integration workflow will currently always fail for forked pull requests. This is due to secrets not being passed to forks.

Comments inline.

If we start getting a lot of outside contributions then we can revisit.