### PR TITLE
Add remove as inline SCM action for added resources

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -345,7 +345,7 @@
         "title": "Remove",
         "command": "dvc.removeTarget",
         "category": "DVC",
-        "icon": "$(trash)"
+        "icon": "$(discard)"
       },
       {
         "title": "Rename",
@@ -1066,6 +1066,11 @@
           "command": "dvc.addTarget",
           "group": "inline",
           "when": "scmProvider == dvc && scmResourceGroup == untracked && dvc.commands.available && !dvc.scm.command.running"
+        },
+        {
+          "command": "dvc.removeTarget",
+          "group": "inline",
+          "when": "scmProvider == dvc && scmResourceState =~ /^.*?Added$/ && dvc.commands.available && !dvc.scm.command.running"
         },
         {
           "command": "dvc.checkoutTarget",

--- a/extension/src/repository/model/tree.ts
+++ b/extension/src/repository/model/tree.ts
@@ -234,14 +234,13 @@ export class RepositoriesTree
 
     this.internalCommands.registerExternalCliCommand<Resource>(
       RegisteredCliCommands.REMOVE_TARGET,
-      async ({ dvcRoot, resourceUri }) => {
+      ({ dvcRoot, resourceUri }) => {
         const relPath = relative(dvcRoot, this.getDataPlaceholder(resourceUri))
-        await this.internalCommands.executeCommand(
+        return this.internalCommands.executeCommand(
           AvailableCommands.REMOVE,
           dvcRoot,
           relPath
         )
-        return deleteTarget(resourceUri)
       }
     )
 

--- a/extension/src/test/suite/repository/model/tree.test.ts
+++ b/extension/src/test/suite/repository/model/tree.test.ts
@@ -14,7 +14,6 @@ import {
   workspace
 } from 'vscode'
 import { Disposable } from '../../../../extension'
-import * as Workspace from '../../../../fileSystem/workspace'
 import { DvcExecutor } from '../../../../cli/dvc/executor'
 import {
   activeTextEditorChangedEvent,
@@ -249,7 +248,6 @@ suite('Repositories Tree Test Suite', () => {
       const relPath = join('mock', 'data', 'MNIST', 'raw')
       stub(path, 'relative').returns(relPath)
 
-      const mockDeleteTarget = stub(Workspace, 'deleteTarget').resolves(true)
       const mockRemove = stub(DvcExecutor.prototype, 'remove').resolves(
         'target destroyed!'
       )
@@ -258,7 +256,6 @@ suite('Repositories Tree Test Suite', () => {
         RegisteredCliCommands.REMOVE_TARGET,
         getPathItem(relPath)
       )
-      expect(mockDeleteTarget).to.be.calledOnce
       expect(mockRemove).to.be.calledOnce
     })
 


### PR DESCRIPTION
# 2/2 `main` <- #4769 <- this

Based on feedback provided in a [customer call](https://iterativeai.slack.com/archives/C01SR9Q12LB/p1696347929524469).

We did already have the move command wired up in the `DVC Tracked` tree but it not only removed the file/folder but deleted it as well. 

I have removed the part of the action that deleted the file after removing it from DVC and added the action inline to the SCM tree for "added" resources.

### Demo

https://github.com/iterative/vscode-dvc/assets/37993418/1dc61fd2-c99e-46fb-9698-69a661fcbe09

https://github.com/iterative/vscode-dvc/assets/37993418/b108cba2-7e19-4658-956f-22a42854de3d


cc @dberenbaum 