### PR TITLE
Watch deps and outs files for experiment updates

### DIFF
--- a/extension/src/experiments/data/collect.test.ts
+++ b/extension/src/experiments/data/collect.test.ts
@@ -10,9 +10,17 @@ describe('collectFiles', () => {
     files.sort()
 
     expect(files).toStrictEqual([
+      join('data', 'data.xml'),
+      join('data', 'features'),
+      join('data', 'prepared'),
       'metrics.json',
+      'model.pkl',
       join('nested', 'params.yaml'),
       'params.yaml',
+      join('src', 'evaluate.py'),
+      join('src', 'featurization.py'),
+      join('src', 'prepare.py'),
+      join('src', 'train.py'),
       'summary.json'
     ])
   })

--- a/extension/src/experiments/data/collect.ts
+++ b/extension/src/experiments/data/collect.ts
@@ -1,9 +1,14 @@
-import { ExpData, ExpShowOutput, MetricsOrParams } from '../../cli/dvc/contract'
+import {
+  Deps,
+  ExpData,
+  ExpShowOutput,
+  MetricsOrParams
+} from '../../cli/dvc/contract'
 import { getExpData } from '../columns/collect'
 
 const collectFilesFromKeys = (
   acc: Set<string>,
-  metricsOrParams: MetricsOrParams | null | undefined
+  metricsOrParams: MetricsOrParams | Deps | null | undefined
 ): void => {
   for (const file of Object.keys(metricsOrParams || {})) {
     if (!file) {
@@ -22,6 +27,8 @@ const collectFilesFromExperiment = (
   }
   collectFilesFromKeys(acc, data.params)
   collectFilesFromKeys(acc, data.metrics)
+  collectFilesFromKeys(acc, data.deps)
+  collectFilesFromKeys(acc, data.outs)
 }
 
 export const collectFiles = (


### PR DESCRIPTION
This PR adds `deps` and `outs` files into the paths watched for experiments updates.