### PR TITLE
Add subscribe to YouTube message to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Code. This extension uses [DVC](https://dvc.org/), an open-source data
 versioning and ML experiment management tool. No additional services or
 databases are required.
 
+🔔 Stay up-to-date with the latest product updates and tutorials by subscribing
+to the [DVC YouTube channel](https://www.youtube.com/@dvcorg8370/videos)!
+
 ![Extension Overview](https://raw.githubusercontent.com/iterative/vscode-dvc/main/extension/docs/overview.gif)
 
 - **Experiment tracking**: Record training data, parameters, and metrics on top


### PR DESCRIPTION
This PR adds a message in to the README asking users to subscribe to the YouTube channel for product updates. The README is currently shown in the GH repository and on the [marketplace listing](https://marketplace.visualstudio.com/items?itemName=Iterative.dvc).

<img width="883" alt="image" src="https://github.com/iterative/vscode-dvc/assets/37993418/37b9824f-0df1-4e05-9a14-381e0a0e3b36">

Please LMK if you would like to update/drop/move this message.
