### PR TITLE
Fix error when user chooses no Y fields in the Plot Wizard

### DIFF
--- a/extension/src/pipeline/quickPick.test.ts
+++ b/extension/src/pipeline/quickPick.test.ts
@@ -497,19 +497,26 @@ describe('pickPlotConfiguration', () => {
   })
 
   it('should return early if the user does not pick a y field', async () => {
-    mockedPickFiles.mockResolvedValueOnce(['/file.json'])
-    mockedLoadDataFiles.mockResolvedValueOnce([
+    mockedPickFiles.mockResolvedValue(['/file.json'])
+    mockedLoadDataFiles.mockResolvedValue([
       { data: mockValidData, file: 'file.json' }
     ])
-    mockedQuickPickOne.mockResolvedValueOnce('simple')
-    mockedGetInput.mockResolvedValueOnce('simple_plot')
-    mockedQuickPickValue.mockResolvedValueOnce('actual')
-    mockedQuickPickValues.mockResolvedValueOnce(undefined)
+    mockedQuickPickOne.mockResolvedValue('simple')
+    mockedGetInput.mockResolvedValue('simple_plot')
+    mockedQuickPickValue.mockResolvedValue('actual')
+    mockedQuickPickValues
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([])
 
-    const result = await pickPlotConfiguration('/')
+    const undefinedResult = await pickPlotConfiguration('/')
 
     expect(mockedQuickPickValues).toHaveBeenCalledTimes(1)
-    expect(result).toStrictEqual(undefined)
+    expect(undefinedResult).toStrictEqual(undefined)
+
+    const emptyFieldsResult = await pickPlotConfiguration('/')
+
+    expect(mockedQuickPickValues).toHaveBeenCalledTimes(2)
+    expect(emptyFieldsResult).toStrictEqual(undefined)
   })
 
   it('should return early if the user does not pick a title', async () => {

--- a/extension/src/pipeline/quickPick.ts
+++ b/extension/src/pipeline/quickPick.ts
@@ -92,7 +92,7 @@ const pickFields = async (
     { title: Title.SELECT_PLOT_Y_METRIC }
   )) as { file: string; key: string }[] | undefined
 
-  if (!yValues) {
+  if (!yValues || yValues.length === 0) {
     return
   }
 


### PR DESCRIPTION
Realized that a user could possibly select 0 fields when it comes to choosing y fields. I added a extra check so that the extension doesn't throw an error:

![Screenshot 2023-10-11 at 11 07 12 AM](https://github.com/iterative/vscode-dvc/assets/43496356/f42716ae-a388-43c5-ad23-c7d7186fb049)
