### PR TITLE
Ignore every WebdriverIO dependency in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,9 +2,13 @@
   "ignoreDeps": [
     "@types/node",
     "@types/vscode",
+    "@wdio/cli",
+    "@wdio/local-runner",
+    "@wdio/mocha-framework",
+    "@wdio/spec-reporter",
     "execa",
     "process-exists",
-    "webdriverio-monorepo"
+    "webdriverio"
   ],
   "extends": ["config:base"],
   "packageRules": [


### PR DESCRIPTION
Since #4806 did not work, I added every dependency instead.