### PR TITLE
Ignore new .turbo directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ package-lock.json
 storybook-static
 
 .DS_Store
+
+.turbo


### PR DESCRIPTION
Looks like the location of the `.turbo` directory has moved to the repository root after the latest package upgrade. This PR ignores the new folder.