### PR TITLE
Improve validation of Plot Wizard Y metrics quick pick

### DIFF
--- a/extension/src/pipeline/quickPick.test.ts
+++ b/extension/src/pipeline/quickPick.test.ts
@@ -514,8 +514,9 @@ describe('pickPlotConfiguration', () => {
         { label: 'prob', value: { field: 'prob', file: 'file2.json' } }
       ],
       {
-        title: Title.SELECT_PLOT_Y_METRIC
-      }
+        title: 'Select 2 Metrics for Y'
+      },
+      2
     )
     expect(result).toStrictEqual({
       template: 'simple',

--- a/extension/src/pipeline/quickPick.ts
+++ b/extension/src/pipeline/quickPick.ts
@@ -8,7 +8,11 @@ import {
   isValueTree
 } from '../cli/dvc/contract'
 import { getFileExtension, loadDataFiles } from '../fileSystem'
-import { quickPickOne, quickPickUserOrderedValues } from '../vscode/quickPick'
+import {
+  QuickPickItemWithValue,
+  quickPickOne,
+  quickPickUserOrderedValues
+} from '../vscode/quickPick'
 import { pickFiles } from '../vscode/resourcePicker'
 import { Title } from '../vscode/title'
 import { Toast } from '../vscode/toast'
@@ -86,14 +90,27 @@ const verifyXFields = (xValues: QuickPickFieldValues | undefined) => {
   return x
 }
 
-const verifyYFieldsWithMultiXFields = (
-  y: PlotConfigDataAxis,
-  yValues: QuickPickFieldValues,
+const pickYFieldsWithMultiXFields = async (
+  yItems: QuickPickItemWithValue<{ file: string; field: string } | undefined>[],
   xFieldsLength: number
 ) => {
-  if (yValues.length !== xFieldsLength) {
+  const yValues = (await quickPickUserOrderedValues(
+    yItems,
+    {
+      title: `Select ${xFieldsLength} Metrics for Y` as Title
+    },
+    xFieldsLength
+  )) as QuickPickFieldValues | undefined
+
+  const y = formatFieldQuickPickValues(yValues)
+
+  if (!y) {
+    return
+  }
+
+  if (yValues?.length !== xFieldsLength) {
     void Toast.showError(
-      `Found ${xFieldsLength} x metrics and ${yValues.length} y metric(s). When there are multiple x metrics selected there must be an equal number of y metrics. ${multipleXMetricsExample}`
+      `Found ${xFieldsLength} x metrics and ${yValues?.length} y metric(s). When there are multiple x metrics selected there must be an equal number of y metrics. ${multipleXMetricsExample}`
     )
     return
   }
@@ -107,22 +124,17 @@ const verifyYFieldsWithMultiXFields = (
   return y
 }
 
-const verifyYFields = (
-  yValues: QuickPickFieldValues | undefined,
-  xFieldsLength = 0
+const pickYFields = async (
+  yItems: QuickPickItemWithValue<{ file: string; field: string } | undefined>[]
 ) => {
+  const yValues = (await quickPickUserOrderedValues(yItems, {
+    title: Title.SELECT_PLOT_Y_METRIC
+  })) as { file: string; field: string }[] | undefined
+
   const y = formatFieldQuickPickValues(yValues)
 
   if (!y) {
     return
-  }
-
-  if (xFieldsLength > 1) {
-    return verifyYFieldsWithMultiXFields(
-      y,
-      yValues as QuickPickFieldValues,
-      xFieldsLength
-    )
   }
 
   return y
@@ -133,8 +145,8 @@ const pickFields = async (
 ): Promise<
   | {
       fields: Omit<PlotConfigData, 'title' | 'template'>
-      firstXKey: string
-      firstYKey: string
+      firstXField: string
+      firstYField: string
     }
   | undefined
 > => {
@@ -160,28 +172,29 @@ const pickFields = async (
     return
   }
 
-  const yValues = (await quickPickUserOrderedValues(
-    items.filter(
-      item => item.value === undefined || !xValues?.includes(item.value)
-    ),
-    {
-      title: Title.SELECT_PLOT_Y_METRIC
-    }
-  )) as { file: string; field: string }[] | undefined
+  const xValuesLength = xValues?.length || 0
 
-  const y = verifyYFields(yValues, xValues?.length)
+  const yItems = items.filter(
+    item => item.value === undefined || !xValues?.includes(item.value)
+  )
+  const y =
+    xValuesLength > 1
+      ? await pickYFieldsWithMultiXFields(yItems, xValuesLength)
+      : await pickYFields(yItems)
 
   if (!y) {
     return
   }
 
+  const [firstXField] = Object.values(x)[0]
+  const [firstYField] = Object.values(y)[0]
+
   return {
     fields: { x, y },
-    firstXKey: (xValues as QuickPickFieldValues)[0].field,
-    firstYKey: (yValues as QuickPickFieldValues)[0].field
+    firstXField,
+    firstYField
   }
 }
-
 const pickPlotConfigData = async (
   fileFields: FileFields
 ): Promise<PlotConfigData | undefined> => {
@@ -197,11 +210,11 @@ const pickPlotConfigData = async (
     return
   }
 
-  const { fields, firstYKey, firstXKey } = fieldsInfo
+  const { fields, firstYField, firstXField } = fieldsInfo
 
   const title = await getInput(
     Title.ENTER_PLOT_TITLE,
-    `${firstXKey} vs ${firstYKey}`
+    `${firstXField} vs ${firstYField}`
   )
 
   if (!title) {

--- a/extension/src/pipeline/quickPick.ts
+++ b/extension/src/pipeline/quickPick.ts
@@ -129,7 +129,7 @@ const pickYFields = async (
 ) => {
   const yValues = (await quickPickUserOrderedValues(yItems, {
     title: Title.SELECT_PLOT_Y_METRIC
-  })) as { file: string; field: string }[] | undefined
+  })) as QuickPickFieldValues | undefined
 
   const y = formatFieldQuickPickValues(yValues)
 

--- a/extension/src/test/suite/util.ts
+++ b/extension/src/test/suite/util.ts
@@ -97,12 +97,17 @@ const toggleQuickPickItem = async (number: number, itemsLength: number) => {
 
 export const selectMultipleQuickPickItems = async (
   numbers: number[],
-  itemsLength: number
+  itemsLength: number,
+  acceptItems = true
 ) => {
   for (const number of numbers) {
     await toggleQuickPickItem(number, itemsLength)
   }
-  return commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem')
+  if (acceptItems) {
+    return commands.executeCommand(
+      'workbench.action.acceptSelectedQuickOpenItem'
+    )
+  }
 }
 
 export const experimentsUpdatedEvent = (experiments: Experiments) =>

--- a/extension/src/test/suite/vscode/quickPick.test.ts
+++ b/extension/src/test/suite/vscode/quickPick.test.ts
@@ -186,5 +186,43 @@ suite('Quick Pick Test Suite', () => {
 
       expect(result).to.deep.equal(undefined)
     })
+
+    it('should limit the number of values that can be selected to the max selected items', async () => {
+      const quickPick = disposable.track(
+        window.createQuickPick<QuickPickItemWithValue<number>>()
+      )
+      stub(window, 'createQuickPick').returns(quickPick)
+
+      const maxSelectedItems = 3
+
+      const items = [
+        { label: 'A', value: 1 },
+        { label: 'B', value: 2 },
+        { label: 'C', value: 3 },
+        { label: 'D', value: 4 },
+        { label: 'E', value: 5 },
+        { label: 'F', value: 6 },
+        { label: 'G', value: 7 },
+        { label: 'H', value: 8 },
+        { label: 'I', value: 9 }
+      ]
+
+      void quickPickUserOrderedValues(
+        items,
+        { title: 'select up to 3 values' as Title },
+        maxSelectedItems
+      )
+
+      await selectMultipleQuickPickItems([5, 2, 1], items.length, false)
+
+      expect(
+        quickPick.selectedItems,
+        'the max number of items are selected'
+      ).to.have.lengthOf(maxSelectedItems)
+      expect(
+        quickPick.items,
+        'all items which could be selected are hidden'
+      ).to.have.lengthOf(maxSelectedItems)
+    })
   })
 })

--- a/extension/src/vscode/quickPick.ts
+++ b/extension/src/vscode/quickPick.ts
@@ -241,7 +241,8 @@ const removeMissingUserOrderedItems = <T>(
 
 export const quickPickUserOrderedValues = <T>(
   items: QuickPickItemWithValue<T>[],
-  options: QuickPickOptions & { title: Title }
+  options: QuickPickOptions & { title: Title },
+  maxSelectedItems?: number
 ): Promise<T[] | undefined> =>
   new Promise(resolve => {
     const quickPick = createQuickPick(items, [], {
@@ -263,6 +264,10 @@ export const quickPickUserOrderedValues = <T>(
         selectedItemValues
       )
     })
+
+    if (maxSelectedItems) {
+      limitSelected<T>(quickPick, maxSelectedItems)
+    }
 
     quickPick.onDidAccept(() => {
       resolve(orderedSelection)

--- a/extension/src/vscode/title.ts
+++ b/extension/src/vscode/title.ts
@@ -42,7 +42,7 @@ export enum Title {
   SELECT_SORT_DIRECTION = 'Select Sort Direction',
   SELECT_SORTS_TO_REMOVE = 'Select Sort(s) to Remove',
   SELECT_TRAINING_SCRIPT = 'Select your Training Script',
-  SELECT_PLOT_X_METRIC = 'Select a Metric for X',
+  SELECT_PLOT_X_METRIC = 'Select Metric(s) for X',
   SELECT_PLOT_Y_METRIC = 'Select a Metric for Y',
   SELECT_PLOT_DATA = 'Select Data to Plot',
   SELECT_PLOT_TYPE = 'Select Plot Type',


### PR DESCRIPTION
* If there are multiple x metrics, the quick pick has a different title and has a max number of items

## Demo

https://github.com/iterative/vscode-dvc/assets/43496356/570efac8-f635-4706-9f72-c247b0339823

Followup to [#4789 comment](https://github.com/iterative/vscode-dvc/pull/4798#discussion_r1355908616)