### PR TITLE
Warn user before trying to add a stage to their pipeline

### DIFF
--- a/extension/src/experiments/webview/messages.ts
+++ b/extension/src/experiments/webview/messages.ts
@@ -377,7 +377,7 @@ export class WebviewMessages {
   }
 
   private addConfiguration() {
-    return this.pipeline.checkOrAddPipeline()
+    return this.pipeline.addPipeline()
   }
 
   private async setMaxTableHeadDepth() {

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -1523,14 +1523,14 @@ suite('Experiments Test Suite', () => {
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should handle a message to add a configuration', async () => {
-      const { mockMessageReceived, mockCheckOrAddPipeline } =
+      const { mockMessageReceived, mockAddPipeline } =
         await buildExperimentsWebview({ disposer: disposable })
 
       mockMessageReceived.fire({
         type: MessageFromWebviewType.ADD_CONFIGURATION
       })
 
-      expect(mockCheckOrAddPipeline).to.be.calledOnce
+      expect(mockAddPipeline).to.be.calledOnce
     }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should handle a message to show more commits', async () => {

--- a/extension/src/test/suite/experiments/util.ts
+++ b/extension/src/test/suite/experiments/util.ts
@@ -86,6 +86,7 @@ export const buildExperiments = ({
     internalCommands
   })
   const mockCheckOrAddPipeline = stub(pipeline, 'checkOrAddPipeline')
+  const mockAddPipeline = stub(pipeline, 'addPipeline')
   const mockSelectBranches = stub().resolves(['main', 'other'])
   const mockMemento = buildMockMemento({
     [`${PersistenceKey.EXPERIMENTS_BRANCHES}${dvcRoot}`]: ['main'],
@@ -130,6 +131,7 @@ export const buildExperiments = ({
     experimentsModel: (experiments as any).experiments as ExperimentsModel,
     gitReader,
     internalCommands,
+    mockAddPipeline,
     mockCheckOrAddPipeline,
     mockCheckSignalFile,
     mockExpShow,

--- a/extension/src/test/suite/pipeline/index.test.ts
+++ b/extension/src/test/suite/pipeline/index.test.ts
@@ -30,16 +30,50 @@ suite('Pipeline Test Suite', () => {
   })
 
   describe('Pipeline', () => {
+    it('should not show a modal when addPipeline is called', async () => {
+      const mockInputBox = stub(window, 'showInputBox').resolves(undefined)
+      const { mockShowInformation, pipeline } = buildPipeline({
+        disposer: disposable,
+        dvcYamls: []
+      })
+      await pipeline.isReady()
+      await pipeline.addPipeline()
+      expect(mockShowInformation).not.to.have.been.calledOnce
+      expect(mockInputBox).to.have.been.calledOnce
+    })
+
     it('should ask to create a stage and not return a cwd if there is no pipeline', async () => {
       const mockInputBox = stub(window, 'showInputBox').resolves(undefined)
-      const { pipeline } = buildPipeline({
+      const { mockShowInformation, pipeline } = buildPipeline({
         disposer: disposable,
         dvcYamls: []
       })
       await pipeline.isReady()
       const cwd = await pipeline.getCwd()
-      expect(mockInputBox, 'the user should be prompted to add a pipeline').to
+      expect(
+        mockShowInformation,
+        'the user should be asked whether or not they want to add a stage'
+      ).to.have.been.calledOnce
+      expect(mockInputBox, 'the user should be prompted for a stage name').to
         .have.been.calledOnce
+      expect(cwd, 'no cwd is returned').to.be.undefined
+    })
+
+    it('should not create a stage if the user does not want to add one', async () => {
+      const mockInputBox = stub(window, 'showInputBox').resolves(undefined)
+      const { mockShowInformation, pipeline } = buildPipeline({
+        disposer: disposable,
+        dvcYamls: []
+      })
+      mockShowInformation.resetBehavior()
+      mockShowInformation.resolves(undefined)
+      await pipeline.isReady()
+      const cwd = await pipeline.getCwd()
+      expect(
+        mockShowInformation,
+        'the user should be asked whether or not they want to add a stage'
+      ).to
+      expect(mockInputBox).not.to.have.been.called
       expect(cwd, 'no cwd is returned').to.be.undefined
     })
 

--- a/extension/src/test/suite/pipeline/util.ts
+++ b/extension/src/test/suite/pipeline/util.ts
@@ -6,6 +6,8 @@ import { Pipeline } from '../../../pipeline'
 import { PipelineData } from '../../../pipeline/data'
 import { dvcDemoPath } from '../../util'
 import { buildDependencies } from '../util'
+import { Response } from '../../../vscode/response'
+import { Modal } from '../../../vscode/modal'
 
 export const buildExperimentsPipeline = ({
   disposer,
@@ -56,9 +58,15 @@ export const buildPipeline = ({
     dvcYamls,
     internalCommands
   })
+
+  const mockShowInformation = stub(Modal, 'showInformation').resolves(
+    Response.YES
+  )
+
   return {
     dvcReader,
     internalCommands,
+    mockShowInformation,
     pipeline,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     pipelineData: (pipeline as any).data as PipelineData


### PR DESCRIPTION
Address [this feedback](https://iterativeai.slack.com/archives/C01APS0FHDM/p1697789220288419?thread_ts=1697667391.944309&cid=C01APS0FHDM):

"
When you click Add Plot -> Data Series  it opens the Finder where you can select files. In my case doesn’t work  :disappointed:  I see the next prompt like below. Do you know why is it difference?
"

### Demo


https://github.com/iterative/vscode-dvc/assets/37993418/9c06c820-2af9-4fbd-a1c2-000d9f18dc3d

Note: As demonstrated above this modal will be shown any time that a user tries to perform an action without a stage except adding the stage from the experiments webview.
