### PR TITLE
Add tags filters to experiments table

### DIFF
--- a/extension/src/experiments/columns/like.ts
+++ b/extension/src/experiments/columns/like.ts
@@ -2,25 +2,35 @@ import { Column } from '../webview/contract'
 
 export type ColumnLike = {
   firstValueType?: string
+  description?: string
   label: string
   path: string
 }
 
-const starredColumnLike: ColumnLike = {
+export const starredColumnLike: ColumnLike = {
+  description: '$(star-full)',
   firstValueType: 'boolean',
-  label: '$(star-full)',
+  label: 'Starred',
   path: 'starred'
 }
 
-export const addStarredToColumns = (
-  columns: Column[] | undefined
+export const tagsColumnLike: ColumnLike = {
+  description: '$(git-commit)',
+  firstValueType: 'tags',
+  label: 'Git Tag',
+  path: 'Git Tag'
+}
+
+export const addToColumns = (
+  columns: Column[] | undefined,
+  ...columnLikes: ColumnLike[]
 ): ColumnLike[] | undefined => {
   if (!columns?.length) {
     return
   }
 
   return [
-    starredColumnLike,
+    ...columnLikes,
     ...columns.map(({ label, path, firstValueType }) => ({
       firstValueType,
       label,

--- a/extension/src/experiments/columns/quickPick.ts
+++ b/extension/src/experiments/columns/quickPick.ts
@@ -1,4 +1,4 @@
-import { ColumnLike } from './like'
+import { ColumnLike, starredColumnLike, tagsColumnLike } from './like'
 import { definedAndNonEmpty } from '../../util/array'
 import {
   QuickPickOptionsWithTitle,
@@ -16,9 +16,11 @@ export const pickFromColumnLikes = (
 
   const items = []
   for (const columnLike of columnLikes) {
-    if (columnLike.path === 'starred') {
+    if (
+      [starredColumnLike.path, tagsColumnLike.path].includes(columnLike.path)
+    ) {
       items.push({
-        description: columnLike.path,
+        description: columnLike.description,
         label: columnLike.label,
         value: columnLike
       })

--- a/extension/src/experiments/index.ts
+++ b/extension/src/experiments/index.ts
@@ -7,7 +7,12 @@ import {
   workspace
 } from 'vscode'
 import omit from 'lodash.omit'
-import { ColumnLike, addStarredToColumns } from './columns/like'
+import {
+  ColumnLike,
+  addToColumns,
+  starredColumnLike,
+  tagsColumnLike
+} from './columns/like'
 import { setContextForEditorTitleIcons } from './context'
 import { ExperimentsModel } from './model'
 import { collectRemoteExpShas } from './model/collect'
@@ -291,7 +296,7 @@ export class Experiments extends BaseRepository<TableData> {
 
   public async addSort() {
     const columns = this.columns.getTerminalNodes()
-    const columnLikes = addStarredToColumns(columns)
+    const columnLikes = addToColumns(columns, starredColumnLike)
 
     const sortToAdd = await pickSortToAdd(columnLikes)
     if (!sortToAdd) {
@@ -773,7 +778,7 @@ export class Experiments extends BaseRepository<TableData> {
       return overrideColumn
     }
     const columns = this.columns.getTerminalNodes()
-    const columnLikes = addStarredToColumns(columns)
+    const columnLikes = addToColumns(columns, starredColumnLike, tagsColumnLike)
     return pickColumnToFilter(columnLikes)
   }
 

--- a/extension/src/experiments/model/filterBy/quickPick.ts
+++ b/extension/src/experiments/model/filterBy/quickPick.ts
@@ -92,6 +92,18 @@ export const OPERATORS = [
     label: Operator.ON_DATE,
     types: [ColumnType.TIMESTAMP],
     value: Operator.ON_DATE
+  },
+  {
+    description: 'Git Tag Equal',
+    label: '=',
+    types: ['tags'],
+    value: Operator.EQUAL
+  },
+  {
+    description: 'Git Tag Contains',
+    label: Operator.CONTAINS,
+    types: ['tags'],
+    value: Operator.CONTAINS
   }
 ]
 

--- a/extension/src/test/fixtures/expShow/base/gitLog.ts
+++ b/extension/src/test/fixtures/expShow/base/gitLog.ts
@@ -4,7 +4,7 @@ import { COMMITS_SEPARATOR } from '../../../../cli/git/constants'
 const data = `${expShowFixture[1].rev}
 github-actions[bot]
 6 hours ago
-refNames:tag: 0.9.3, origin/main, origin/HEAD, main
+refNames:HEAD, tag: 0.9.3, origin/main, origin/HEAD, main
 message:Update version and CHANGELOG for release (#4022)
 
 Co-authored-by: Olivaw[bot] <olivaw@iterative.ai>${COMMITS_SEPARATOR}${expShowFixture[2].rev}

--- a/extension/src/test/suite/experiments/model/filterBy/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/filterBy/tree.test.ts
@@ -45,6 +45,7 @@ import {
   ValueTree,
   FileDataOrError
 } from '../../../../../cli/dvc/contract'
+import { tagsColumnLike } from '../../../../../experiments/columns/like'
 
 suite('Experiments Filter By Tree Test Suite', () => {
   const disposable = Disposable.fn()
@@ -361,6 +362,36 @@ suite('Experiments Filter By Tree Test Suite', () => {
         columnOrder: columnsOrderFixture,
         columns: columnsFixture,
         filters: ['starred'],
+        rows: filteredRows
+      }
+
+      await messageSent
+      expect(messageSpy).to.be.calledWithMatch(filteredTableData)
+    }).timeout(WEBVIEW_TEST_TIMEOUT)
+
+    it('should be able to filter to tagged commits', async () => {
+      const { experiments, messageSpy } =
+        await stubWorkspaceGettersWebview(disposable)
+
+      const messageSent = waitForSpyCall(messageSpy, messageSpy.callCount)
+      await addFilterViaQuickInput(experiments, {
+        operator: Operator.CONTAINS,
+        path: tagsColumnLike.path,
+        value: '9.3'
+      })
+
+      const [workspace, main] = rowsFixture
+
+      const mainNoSubRows = { ...main }
+      delete mainNoSubRows.subRows
+
+      const filteredRows = [workspace, mainNoSubRows]
+
+      const filteredTableData: Partial<TableData> = {
+        changes: workspaceChangesFixture,
+        columnOrder: columnsOrderFixture,
+        columns: columnsFixture,
+        filters: ['Git Tag'],
         rows: filteredRows
       }
 

--- a/extension/src/test/suite/experiments/model/filterBy/util.ts
+++ b/extension/src/test/suite/experiments/model/filterBy/util.ts
@@ -5,16 +5,22 @@ import { FilterDefinition } from '../../../../../experiments/model/filterBy'
 import { experimentsUpdatedEvent } from '../../../util'
 import { Experiments } from '../../../../../experiments'
 import { RegisteredCommands } from '../../../../../commands/external'
-import { addStarredToColumns } from '../../../../../experiments/columns/like'
+import {
+  addToColumns,
+  starredColumnLike,
+  tagsColumnLike
+} from '../../../../../experiments/columns/like'
 
 export const mockQuickInputFilter = (
   fixtureFilter: FilterDefinition,
   mockShowQuickPick = stub(window, 'showQuickPick'),
   mockShowInputBox = stub(window, 'showInputBox')
 ) => {
-  const column = addStarredToColumns(columnsFixture)?.find(
-    column => column.path === fixtureFilter.path
-  )
+  const column = addToColumns(
+    columnsFixture,
+    starredColumnLike,
+    tagsColumnLike
+  )?.find(column => column.path === fixtureFilter.path)
   mockShowQuickPick
     .onFirstCall()
     .resolves({ value: column } as unknown as QuickPickItem)


### PR DESCRIPTION
Closes https://github.com/iterative/vscode-dvc/issues/4878

This PR adds equals and contains filters to the experiments table for tags.

When the equals filter is applied each of the commits tags will be checked for equality when the contains filter is applied each of the commits tags will be checked for a substring.

### Demo

https://github.com/iterative/vscode-dvc/assets/37993418/1ab9a3e7-dd26-40f3-b8d9-7f170cf58b61