### PR TITLE
Remove @types/react-measure

### DIFF
--- a/webview/package.json
+++ b/webview/package.json
@@ -60,7 +60,6 @@
     "@types/node": "16.x",
     "@types/react": "18.2.28",
     "@types/react-dom": "18.2.13",
-    "@types/react-measure": "2.0.9",
     "@types/react-virtualized": "9.21.23",
     "@types/webpack": "5.28.3",
     "@welldone-software/why-did-you-render": "7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6236,13 +6236,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-measure@2.0.9":
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/@types/react-measure/-/react-measure-2.0.9.tgz#aeedc50ecb012f474f7d3b7e9b2c9954359f8906"
-  integrity sha512-8h9n24GK9Ckg1IxDjZLIjUu7/LDNVx2NbQd6KoD9R0JRy8B4ipA5OGCpsYhB6VULc4KlhsINKYUjd8+Urecq1A==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-syntax-highlighter@11.0.5":
   version "11.0.5"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz#0d546261b4021e1f9d85b50401c0a42acb106087"


### PR DESCRIPTION
Noticed this [here](https://github.com/iterative/vscode-dvc/pull/4897#pullrequestreview-1697368820) we are not using this type anywhere and we do not even install the main package.