### PR TITLE
Increase plot webview test timeout

### DIFF
--- a/extension/src/test/suite/plots/index.test.ts
+++ b/extension/src/test/suite/plots/index.test.ts
@@ -1195,7 +1195,7 @@ suite('Plots Test Suite', () => {
         templatePlot.id,
         0.5
       )
-    })
+    }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should handle an update comparison multi plot value message from the webview', async () => {
       const { mockMessageReceived, plotsModel } = await buildPlotsWebview({


### PR DESCRIPTION
Noticed that `should handle an update smooth plot values message from the webview` has been timing out repeatedly on windows. 