### PR TITLE
Update webview test timeout

### DIFF
--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -2075,7 +2075,7 @@ suite('Experiments Test Suite', () => {
       ])
       expect(sorts).to.deep.equal([{ descending: true, path: paramPath }])
     })
-  })
+  }).timeout(WEBVIEW_TEST_TIMEOUT)
 
   describe('persisted state', () => {
     const firstSortDefinition = {


### PR DESCRIPTION
Spotted one of our tests ('should not show duplicate rows when sorted') failing on the CI tests and realized it didn't have a webview timeout. 