### PR TITLE
Move e2e tests to stable version

### DIFF
--- a/extension/src/test/e2e/extension.test.ts
+++ b/extension/src/test/e2e/extension.test.ts
@@ -236,7 +236,7 @@ describe('Source Control View', function () {
       },
       {
         interval: 5000,
-        timeout: 60000
+        timeout: 80000
       }
     )
 

--- a/extension/src/test/e2e/extension.test.ts
+++ b/extension/src/test/e2e/extension.test.ts
@@ -191,6 +191,7 @@ describe('Plots Webview', function () {
 describe('Source Control View', function () {
   // eslint-disable-next-line sonarjs/cognitive-complexity
   it('should show the expected changes after running an experiment', async function () {
+    this.timeout(80000)
     const expectedScmItemLabels = [
       'hist.csv',
       'model.pt',
@@ -236,7 +237,7 @@ describe('Source Control View', function () {
       },
       {
         interval: 5000,
-        timeout: 80000
+        timeout: 60000
       }
     )
 

--- a/extension/src/test/e2e/extension.test.ts
+++ b/extension/src/test/e2e/extension.test.ts
@@ -237,7 +237,7 @@ describe('Source Control View', function () {
       },
       {
         interval: 5000,
-        timeout: 60000
+        timeout: 80000
       }
     )
 

--- a/extension/src/test/e2e/wdio.conf.ts
+++ b/extension/src/test/e2e/wdio.conf.ts
@@ -47,7 +47,7 @@ export const config: Options.Testrunner = {
   capabilities: [
     {
       browserName: 'vscode',
-      browserVersion: 'insiders',
+      browserVersion: 'stable',
       'wdio:vscodeOptions': {
         extensionPath,
         userSettings: {


### PR DESCRIPTION
E2e tests are failing locally and [possibly remotely](https://github.com/iterative/vscode-dvc/actions/runs/7035621841/job/19146421216). Moving to stable seems to fix the issue. 

See https://iterativeai.slack.com/archives/C01RB7BTG4C/p1701266045783539