### PR TITLE
Move e2e tests to stable

### DIFF
--- a/extension/src/test/e2e/wdio.conf.ts
+++ b/extension/src/test/e2e/wdio.conf.ts
@@ -47,7 +47,7 @@ export const config: Options.Testrunner = {
   capabilities: [
     {
       browserName: 'vscode',
-      browserVersion: 'insiders',
+      browserVersion: 'stable',
       'wdio:vscodeOptions': {
         extensionPath,
         userSettings: {


### PR DESCRIPTION
Fixes the failing e2e tests:

```
  Stopping runner...
      at file:///home/runner/work/vscode-dvc/vscode-dvc/node_modules/@wdio/cli/build/utils.js:59:35
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
      at async Launcher.run (file:///home/runner/work/vscode-dvc/vscode-dvc/node_modules/@wdio/cli/build/launcher.js:94:13)
  HookError [SevereServiceError]: 
  A service failed in the 'onPrepare' hook
  SevereServiceError: Couldn't set up Chromedriver Response code 404 (Not Found)
      at VSCodeServiceLauncher._setupChromedriver (file:///home/runner/work/vscode-dvc/vscode-dvc/node_modules/wdio-vscode-service/src/launcher.ts:235:19)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
      at async VSCodeServiceLauncher._setupVSCodeDesktop (file:///home/runner/work/vscode-dvc/vscode-dvc/node_modules/wdio-vscode-service/src/launcher.ts:191:72)
      at async VSCodeServiceLauncher.onPrepare (file:///home/runner/work/vscode-dvc/vscode-dvc/node_modules/wdio-vscode-service/src/launcher.ts:107:17)
      at async file:///home/runner/work/vscode-dvc/vscode-dvc/node_modules/@wdio/cli/build/utils.js:43:17
      at async Promise.all (index 0)
      at async Launcher.run (file:///home/runner/work/vscode-dvc/vscode-dvc/node_modules/@wdio/cli/build/launcher.js:94:13)
```