### PR TITLE
Bump min version of VS Code to 1.75.0

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -39,7 +39,7 @@
     "theme": "dark"
   },
   "engines": {
-    "vscode": "^1.64.0",
+    "vscode": "^1.75.0",
     "node": ">=16.13.0"
   },
   "activationEvents": [
@@ -1778,7 +1778,7 @@
     "@types/sinon-chai": "3.2.12",
     "@types/uuid": "9.0.7",
     "@types/vega": "3.2.0",
-    "@types/vscode": "1.64.0",
+    "@types/vscode": "1.75.0",
     "@vscode/test-electron": "2.3.8",
     "@vscode/vsce": "2.22.0",
     "@wdio/cli": "8.16.7",

--- a/extension/src/test/suite/vscode/outputChannel.test.ts
+++ b/extension/src/test/suite/vscode/outputChannel.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, it, suite } from 'mocha'
 import { expect } from 'chai'
-import { EventEmitter, window, OutputChannel as VSOutputChannel } from 'vscode'
+import {
+  EventEmitter,
+  window,
+  LogOutputChannel as VSOutputChannel
+} from 'vscode'
 import { restore, stub, fake } from 'sinon'
 import { OutputChannel } from '../../../vscode/outputChannel'
 import { Disposable } from '../../../extension'

--- a/yarn.lock
+++ b/yarn.lock
@@ -6347,10 +6347,10 @@
   dependencies:
     vega "*"
 
-"@types/vscode@1.64.0":
-  version "1.64.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.64.0.tgz#bfd82c8d92dc7824c1be084be1ab46ce20d7fb55"
-  integrity sha512-bSlAWz5WtcSL3cO9tAT/KpEH9rv5OBnm93OIIFwdCshaAiqr2bp1AUyEwW9MWeCvZBHEXc3V0fTYVdVyzDNwHA==
+"@types/vscode@1.75.0":
+  version "1.75.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.75.0.tgz#f1892a727db9a0eb4997058a804170b8c0ba218e"
+  integrity sha512-SAr0PoOhJS6FUq5LjNr8C/StBKALZwDVm3+U4pjF/3iYkt3GioJOPV/oB1Sf1l7lROe4TgrMyL5N1yaEgTWycw==
 
 "@types/webpack-env@^1.16.0":
   version "1.16.3"


### PR DESCRIPTION
Follow up from [this conversation](https://discord.com/channels/485586884165107732/842220310585147452/1182458752704725072) on Discord.

tl;dr

Since https://github.com/iterative/vscode-dvc/pull/3274 we haven't supported any further back than `1.75.0`. This makes users aware of the real requirements.