### PR TITLE
Use resize observer to simplify use get plot

### DIFF
--- a/webview/setup-tests.js
+++ b/webview/setup-tests.js
@@ -4,11 +4,12 @@ window = {
   dispatchEvent: jest.fn()
 }
 
-const intersectionObserverMock = jest.fn().mockImplementation(() => {
-  return {
-    disconnect: jest.fn(),
-    observe: jest.fn(),
-    unobserve: jest.fn()
-  }
-})
-global.IntersectionObserver = intersectionObserverMock
+for (const observer of ['IntersectionObserver', 'ResizeObserver']) {
+  global[observer] = jest.fn().mockImplementation(() => {
+    return {
+      disconnect: jest.fn(),
+      observe: jest.fn(),
+      unobserve: jest.fn()
+    }
+  })
+}

--- a/webview/src/plots/components/ZoomedInPlot.tsx
+++ b/webview/src/plots/components/ZoomedInPlot.tsx
@@ -105,6 +105,7 @@ export const ZoomedInPlot: React.FC<ZoomedInPlotProps> = ({
         onNewView={onNewView}
         parentRef={zoomedInPlotRef}
         section={section}
+        focused={true}
       />
     </div>
   )

--- a/webview/src/plots/components/vegaLite/ExtendedVegaLite.tsx
+++ b/webview/src/plots/components/vegaLite/ExtendedVegaLite.tsx
@@ -13,7 +13,8 @@ export const ExtendedVegaLite = ({
   id,
   parentRef,
   onNewView,
-  section
+  section,
+  focused = false
 }: {
   actions:
     | false
@@ -23,12 +24,13 @@ export const ExtendedVegaLite = ({
         export: false
         source: false
       }
+  focused?: boolean
   id: string
   parentRef: React.RefObject<HTMLDivElement | HTMLButtonElement>
   onNewView: (view: View) => void
   section: PlotsSection
 }) => {
-  const spec = useGetPlot(section, id, parentRef)
+  const spec = useGetPlot(section, id, parentRef, focused)
 
   const vegaLiteProps: VegaLiteProps = {
     actions,


### PR DESCRIPTION
Matches part of the change that I made in https://github.com/iterative/studio/pull/8490.

@sroy3 when you're back I'd like to get your opinion on performance implications of the change 🙏🏻. 

The thread at https://github.com/iterative/studio/pull/8490#discussion_r1419809476 is relevant.