### PR TITLE
Remove Studio data request failed Toast

### DIFF
--- a/extension/src/experiments/data/index.ts
+++ b/extension/src/experiments/data/index.ts
@@ -26,7 +26,6 @@ import { COMMITS_SEPARATOR, gitPath } from '../../cli/git/constants'
 import { getGitPath } from '../../fileSystem'
 import { ExperimentsModel } from '../model'
 import { Studio } from '../studio'
-import { Toast } from '../../vscode/toast'
 
 export class ExperimentsData extends BaseData<ExperimentsOutput> {
   private readonly experiments: ExperimentsModel
@@ -157,9 +156,6 @@ export class ExperimentsData extends BaseData<ExperimentsOutput> {
       })
     } catch {
       this.notifyChanged(defaultData)
-      void Toast.showError(
-        `Unable to fetch data from [Studio](${this.studio.getInstanceUrl()}).`
-      )
     }
   }
 

--- a/extension/src/test/suite/experiments/data/index.test.ts
+++ b/extension/src/test/suite/experiments/data/index.test.ts
@@ -35,7 +35,6 @@ import {
 } from '../../../../data'
 import { Studio } from '../../../../experiments/studio'
 import { DEFAULT_STUDIO_URL } from '../../../../setup/webview/contract'
-import { Toast } from '../../../../vscode/toast'
 
 const MOCK_WORKSPACE_GIT_FOLDER = join(dvcDemoPath, '.mock-git')
 
@@ -408,44 +407,6 @@ suite('Experiments Data Test Suite', () => {
           },
           method: 'GET'
         }
-      )
-    })
-
-    it('should show a toast if the request to Studio fails', async () => {
-      const mockStudioToken = 'isat_BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
-      const mockSelfHostedStudioUrl = 'https://studio.example.com'
-      const { data, mockFetch } = buildExperimentsData(
-        disposable,
-        '* main',
-        gitLogFixture,
-        mockStudioToken,
-        mockSelfHostedStudioUrl
-      )
-      const mockToast = stub(Toast, 'showError')
-
-      mockFetch.onFirstCall().callsFake(() => {
-        throw new Error('request failed')
-      })
-
-      const requestSent = new Promise(resolve =>
-        data.onDidUpdate(data => {
-          if (isStudioExperimentsOutput(data)) {
-            resolve(undefined)
-            expect(data).to.deep.equal({
-              live: [],
-              pushed: [],
-              view_url: mockBaseStudioUrl
-            })
-          }
-        })
-      )
-
-      await data.isReady()
-
-      await requestSent
-
-      expect(mockToast).to.be.calledWithExactly(
-        `Unable to fetch data from [Studio](${mockSelfHostedStudioUrl}).`
       )
     })
   })


### PR DESCRIPTION
Removes the "Unable to fetch data from Studio" Toast since we try to fetch data periodically (meaning user could get this multiple times in a session)

Fixes #5120