### PR TITLE
Increase VSCode test timeout

### DIFF
--- a/extension/src/test/suite/experiments/data/index.test.ts
+++ b/extension/src/test/suite/experiments/data/index.test.ts
@@ -223,7 +223,7 @@ suite('Experiments Data Test Suite', () => {
       await dataUpdatedEvent
 
       expect(managedUpdateSpy).to.be.called
-    }).timeout(10000)
+    }).timeout(20000)
 
     it('should prune any old branches to show before calling exp show on them', async () => {
       stub(ExperimentsData.prototype, 'managedUpdate').resolves()


### PR DESCRIPTION
The test `should watch the .git directory for updates when the directory is inside workspace` will timeout in CI sometimes. I've increased the timeout. 