### PR TITLE
Remove redundant version check from exp rename code

### DIFF
--- a/extension/src/cli/dvc/version.ts
+++ b/extension/src/cli/dvc/version.ts
@@ -18,25 +18,21 @@ export const extractSemver = (stdout: string): ParsedSemver | undefined => {
   return { major: Number(major), minor: Number(minor), patch: Number(patch) }
 }
 
-const checkCLIVersion = (
-  currentSemVer: {
-    major: number
-    minor: number
-    patch: number
-  },
-  minSemVer = MIN_CLI_VERSION
-): CliCompatible => {
+const checkCLIVersion = (currentSemVer: {
+  major: number
+  minor: number
+  patch: number
+}): CliCompatible => {
   const {
     major: currentMajor,
     minor: currentMinor,
     patch: currentPatch
   } = currentSemVer
-  minSemVer = minSemVer || MIN_CLI_VERSION
   const {
     major: minMajor,
     minor: minMinor,
     patch: minPatch
-  } = extractSemver(minSemVer) as ParsedSemver
+  } = extractSemver(MIN_CLI_VERSION) as ParsedSemver
 
   const isBehindMinVersion =
     currentMajor < minMajor ||
@@ -51,8 +47,7 @@ const checkCLIVersion = (
 }
 
 export const isVersionCompatible = (
-  version: string | undefined,
-  requiredVersion = MIN_CLI_VERSION
+  version: string | undefined
 ): CliCompatible => {
   if (!version) {
     return CliCompatible.NO_NOT_FOUND
@@ -67,10 +62,6 @@ export const isVersionCompatible = (
     Number.isNaN(currentSemVer.patch)
   ) {
     return CliCompatible.NO_CANNOT_VERIFY
-  }
-
-  if (requiredVersion) {
-    return checkCLIVersion(currentSemVer, requiredVersion)
   }
 
   return checkCLIVersion(currentSemVer)

--- a/extension/src/experiments/commands/register.ts
+++ b/extension/src/experiments/commands/register.ts
@@ -13,10 +13,6 @@ import { Title } from '../../vscode/title'
 import { Context, getDvcRootFromContext } from '../../vscode/context'
 import { Setup } from '../../setup'
 import { showSetupOrExecuteCommand } from '../../commands/util'
-import { CliCompatible, isVersionCompatible } from '../../cli/dvc/version'
-import { Toast } from '../../vscode/toast'
-import { Response } from '../../vscode/response'
-import { SetupSection } from '../../setup/webview/contract'
 
 type ExperimentDetails = { dvcRoot: string; id: string }
 
@@ -129,8 +125,7 @@ const registerExperimentNameCommands = (
 
 const registerExperimentInputCommands = (
   experiments: WorkspaceExperiments,
-  internalCommands: InternalCommands,
-  setup: Setup
+  internalCommands: InternalCommands
 ): void => {
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.EXPERIMENT_BRANCH,
@@ -139,34 +134,14 @@ const registerExperimentInputCommands = (
 
   internalCommands.registerExternalCliCommand(
     RegisteredCliCommands.EXPERIMENT_VIEW_RENAME,
-    async ({ dvcRoot, id }: ExperimentDetails) => {
-      const cliVersion = await setup.getCliVersion(dvcRoot)
-      const REQUIRED_CLI_VERSION = '3.22.0'
-
-      if (
-        !(
-          isVersionCompatible(cliVersion, REQUIRED_CLI_VERSION) ===
-          CliCompatible.YES
-        )
-      ) {
-        const response = await Toast.warnWithOptions(
-          'To rename experiments, you need DVC version 3.22.0 or greater. Please update your DVC installation.',
-          Response.SHOW_SETUP
-        )
-        if (response === Response.SHOW_SETUP) {
-          return setup.showSetup(SetupSection.DVC)
-        }
-        return
-      }
-
-      return experiments.getInputAndRun(
+    ({ dvcRoot, id }: ExperimentDetails) =>
+      experiments.getInputAndRun(
         getRenameExperimentCommand(experiments),
         Title.ENTER_NEW_EXPERIMENT_NAME,
         id,
         dvcRoot,
         id
       )
-    }
   )
 
   internalCommands.registerExternalCliCommand(
@@ -306,7 +281,7 @@ export const registerExperimentCommands = (
 ) => {
   registerExperimentCwdCommands(experiments, internalCommands)
   registerExperimentNameCommands(experiments, internalCommands)
-  registerExperimentInputCommands(experiments, internalCommands, setup)
+  registerExperimentInputCommands(experiments, internalCommands)
   registerExperimentQuickPickCommands(experiments, internalCommands, setup)
   registerExperimentRunCommands(experiments, internalCommands, setup)
 

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -540,8 +540,6 @@ suite('Experiments Test Suite', () => {
         mockUpdateExperimentsData
       } = await stubWorkspaceGettersWebview(disposable)
 
-      stub(Setup.prototype, 'getCliVersion').resolves('3.22.0')
-
       const mockExperimentId = 'exp-e7a67'
       const mockBranch = 'mock-branch-input'
       const mockExperimentBranch = stub(DvcExecutor.prototype, 'expBranch')
@@ -618,8 +616,6 @@ suite('Experiments Test Suite', () => {
 
       const mockNewExperimentName = 'new-experiment-name'
       const inputEvent = getInputBoxEvent(mockNewExperimentName)
-
-      stub(Setup.prototype, 'getCliVersion').resolves('3.22.0')
 
       const mockRenameExperiment = stub(DvcExecutor.prototype, 'expRename')
 


### PR DESCRIPTION
The min required version of DVC is now above `3.22.0` so we do not need the legacy version check for `dvc exp rename`.