### PR TITLE
Remove the rename command from the DVC tracked tree

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -336,11 +336,6 @@
         "icon": "$(discard)"
       },
       {
-        "title": "Rename",
-        "command": "dvc.renameTarget",
-        "category": "DVC"
-      },
-      {
         "title": "Run Experiment",
         "command": "dvc.runExperiment",
         "category": "DVC",
@@ -832,10 +827,6 @@
           "when": "false"
         },
         {
-          "command": "dvc.renameTarget",
-          "when": "false"
-        },
-        {
           "command": "dvc.discardWorkspaceChanges",
           "when": "dvc.commands.available && dvc.project.available && !dvc.scm.command.running"
         },
@@ -1169,11 +1160,6 @@
           "command": "dvc.copyRelativeFilePath",
           "group": "6_copypath@2",
           "when": "view == dvc.views.trackedExplorerTree"
-        },
-        {
-          "command": "dvc.renameTarget",
-          "group": "7_modification@1",
-          "when": "view == dvc.views.trackedExplorerTree && viewItem =~ /^.*Data$/"
         },
         {
           "command": "dvc.deleteTarget",

--- a/extension/src/cli/dvc/executor.test.ts
+++ b/extension/src/cli/dvc/executor.test.ts
@@ -402,30 +402,6 @@ describe('CliExecutor', () => {
     })
   })
 
-  describe('move', () => {
-    it('should call createProcess with the correct parameters to move a DVC tracked target', async () => {
-      const cwd = __dirname
-      const target = 'data/data.xml.dvc'
-      const destination = 'data/data1.xml.dvc'
-      const stdout = `                                                                      
-			To track the changes with git, run:
-			
-							git add ${destination} data/.gitignore`
-
-      mockedCreateProcess.mockReturnValueOnce(getMockedProcess(stdout))
-
-      const output = await dvcExecutor.move(cwd, target, destination)
-      expect(output).toStrictEqual(stdout)
-
-      expect(mockedCreateProcess).toHaveBeenCalledWith({
-        args: ['move', target, destination],
-        cwd,
-        env: mockedEnv,
-        executable: 'dvc'
-      })
-    })
-  })
-
   describe('pull', () => {
     it('should call createProcess with the correct parameters to pull the entire repository', async () => {
       const cwd = __dirname

--- a/extension/src/cli/dvc/executor.ts
+++ b/extension/src/cli/dvc/executor.ts
@@ -24,7 +24,6 @@ export const autoRegisteredCommands = {
   EXP_RENAME: 'expRename',
   INIT: 'init',
   IS_SCM_COMMAND_RUNNING: 'isScmCommandRunning',
-  MOVE: 'move',
   PULL: 'pull',
   PUSH: 'push',
   QUEUE_KILL: 'queueKill',
@@ -119,10 +118,6 @@ export class DvcExecutor extends DvcCli {
       Command.INITIALIZE,
       Flag.SUBDIRECTORY
     )
-  }
-
-  public move(cwd: string, target: string, destination: string) {
-    return this.blockAndExecuteProcess(cwd, Command.MOVE, target, destination)
   }
 
   public pull(cwd: string, ...args: Args) {

--- a/extension/src/commands/external.ts
+++ b/extension/src/commands/external.ts
@@ -34,7 +34,6 @@ export enum RegisteredCliCommands {
   PUSH = 'dvc.push',
   PUSH_TARGET = 'dvc.pushTarget',
   REMOVE_TARGET = 'dvc.removeTarget',
-  RENAME_TARGET = 'dvc.renameTarget',
 
   REMOTE_ADD = 'dvc.addRemote',
   REMOTE_MODIFY = 'dvc.modifyRemote',

--- a/extension/src/repository/model/tree.ts
+++ b/extension/src/repository/model/tree.ts
@@ -11,7 +11,7 @@ import {
 import { collectSelected, collectTrackedPaths, PathItem } from './collect'
 import { Resource } from '../commands'
 import { WorkspaceRepositories } from '../workspace'
-import { exists, relativeWithUri } from '../../fileSystem'
+import { exists } from '../../fileSystem'
 import { standardizePath } from '../../fileSystem/path'
 import { fireWatcher } from '../../fileSystem/watcher'
 import { deleteTarget, moveTargets } from '../../fileSystem/workspace'
@@ -32,7 +32,6 @@ import {
 } from '../../commands/external'
 import { sendViewOpenedTelemetryEvent } from '../../telemetry'
 import { EventName } from '../../telemetry/constants'
-import { getInput } from '../../vscode/inputBox'
 import { pickResources } from '../../vscode/resourcePicker'
 import { Modal } from '../../vscode/modal'
 import { Response } from '../../vscode/response'
@@ -240,27 +239,6 @@ export class RepositoriesTree
           AvailableCommands.REMOVE,
           dvcRoot,
           relPath
-        )
-      }
-    )
-
-    this.internalCommands.registerExternalCliCommand<Resource>(
-      RegisteredCliCommands.RENAME_TARGET,
-      async ({ dvcRoot, resourceUri }) => {
-        const relPath = relativeWithUri(dvcRoot, resourceUri)
-        const relDestination = await getInput(
-          Title.ENTER_RELATIVE_DESTINATION,
-          relPath
-        )
-        if (!relDestination || relDestination === relPath) {
-          return
-        }
-
-        return this.internalCommands.executeCommand(
-          AvailableCommands.MOVE,
-          dvcRoot,
-          relPath,
-          relDestination
         )
       }
     )

--- a/extension/src/telemetry/constants.ts
+++ b/extension/src/telemetry/constants.ts
@@ -215,7 +215,6 @@ export interface IEventNamePropertyMapping {
   [EventName.PUSH_TARGET]: undefined
   [EventName.PUSH]: undefined
   [EventName.REMOVE_TARGET]: undefined
-  [EventName.RENAME_TARGET]: undefined
 
   [EventName.REMOTE_ADD]: undefined
   [EventName.REMOTE_MODIFY]: undefined

--- a/extension/src/test/suite/repository/model/tree.test.ts
+++ b/extension/src/test/suite/repository/model/tree.test.ts
@@ -29,7 +29,6 @@ import {
   RegisteredCommands
 } from '../../../../commands/external'
 import { WEBVIEW_TEST_TIMEOUT } from '../../timeouts'
-import { Title } from '../../../../vscode/title'
 import { Repository } from '../../../../repository'
 import { WorkspaceRepositories } from '../../../../repository/workspace'
 import { RepositoriesTree } from '../../../../repository/model/tree'
@@ -257,31 +256,6 @@ suite('Repositories Tree Test Suite', () => {
         getPathItem(relPath)
       )
       expect(mockRemove).to.be.calledOnce
-    })
-
-    it('should be able to run dvc.renameTarget without error', async () => {
-      const relPath = join('mock', 'data', 'MNIST', 'raw')
-      stub(path, 'relative').returns(relPath)
-
-      const mockMove = stub(DvcExecutor.prototype, 'move').resolves(
-        'target moved to new destination'
-      )
-
-      const mockInputBox = stub(window, 'showInputBox').resolves(
-        relPath + 'est'
-      )
-
-      await commands.executeCommand(
-        RegisteredCliCommands.RENAME_TARGET,
-        getPathItem(relPath)
-      )
-      expect(mockMove).to.be.calledOnce
-      expect(mockInputBox).to.be.calledOnce
-      expect(mockInputBox).to.be.calledWith({
-        prompt: undefined,
-        title: Title.ENTER_RELATIVE_DESTINATION,
-        value: relPath
-      })
     })
 
     it('should pull the correct target(s) when asked to dvc.pullTarget a non-tracked directory', async () => {

--- a/extension/src/vscode/title.ts
+++ b/extension/src/vscode/title.ts
@@ -6,7 +6,6 @@ export enum Title {
   ENTER_COMMIT_MESSAGE = 'Enter a Commit Message',
   ENTER_EXPERIMENT_WORKER_COUNT = 'Enter the Number of Queue Workers',
   ENTER_FILTER_VALUE = 'Enter a Filter Value',
-  ENTER_RELATIVE_DESTINATION = 'Enter a Destination Relative to the Root',
   ENTER_REMOTE_NAME = 'Enter a Name for the Remote',
   ENTER_REMOTE_URL = 'Enter the URL for the Remote',
   ENTER_PATH_OR_CHOOSE_FILE = 'Enter the path to your training script or select it',


### PR DESCRIPTION
Closes https://github.com/iterative/vscode-dvc/issues/808 by removing the rename command from the DVC tracked tree (and the extension). 

I don't think any user has ever used this command.