### PR TITLE
Attempt to fix e2e tests

### DIFF
--- a/extension/src/test/e2e/wdio.conf.ts
+++ b/extension/src/test/e2e/wdio.conf.ts
@@ -47,7 +47,7 @@ export const config: Options.Testrunner = {
   capabilities: [
     {
       browserName: 'vscode',
-      browserVersion: 'stable',
+      browserVersion: 'insiders',
       'wdio:vscodeOptions': {
         extensionPath,
         userSettings: {

--- a/extension/src/test/e2e/wdio.conf.ts
+++ b/extension/src/test/e2e/wdio.conf.ts
@@ -54,6 +54,7 @@ export const config: Options.Testrunner = {
           'dvc.pythonPath': getVenvBinPath(dvcDemoPath, '.env', 'python'),
           'window.commandCenter': false
         },
+        verboseLogging: false,
         workspacePath: dvcDemoPath
       }
     }

--- a/extension/src/test/e2e/wdio.conf.ts
+++ b/extension/src/test/e2e/wdio.conf.ts
@@ -47,14 +47,13 @@ export const config: Options.Testrunner = {
   capabilities: [
     {
       browserName: 'vscode',
-      browserVersion: 'insiders',
+      browserVersion: '1.85.0',
       'wdio:vscodeOptions': {
         extensionPath,
         userSettings: {
           'dvc.pythonPath': getVenvBinPath(dvcDemoPath, '.env', 'python'),
           'window.commandCenter': false
         },
-        verboseLogging: false,
         workspacePath: dvcDemoPath
       }
     }


### PR DESCRIPTION
e2e tests are failing with 

```
  SevereServiceError in "onPrepare"
  SevereServiceError: 
  A service failed in the 'onPrepare' hook
  SevereServiceError: Couldn't set up Chromedriver Response code 404 (Not Found)
      at VSCodeServiceLauncher._setupChromedriver (file:///home/runner/work/vscode-dvc/vscode-dvc/node_modules/wdio-vscode-service/src/launcher.ts:236:19)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
      at async VSCodeServiceLauncher._setupVSCodeDesktop (file:///home/runner/work/vscode-dvc/vscode-dvc/node_modules/wdio-vscode-service/src/launcher.ts:192:72)
      at async VSCodeServiceLauncher.onPrepare (file:///home/runner/work/vscode-dvc/vscode-dvc/node_modules/wdio-vscode-service/src/launcher.ts:108:17)
      at async file:///home/runner/work/vscode-dvc/vscode-dvc/node_modules/@wdio/cli/build/utils.js:43:17
      at async Promise.all (index 0)
      at async Launcher.run (file:///home/runner/work/vscode-dvc/vscode-dvc/node_modules/@wdio/cli/build/launcher.js:94:13)
```

Starting off with switching to `insiders`. **Update** no luck there
Tests are running on `1.85.0` of vscode but breaks on `1.86.0`. 