### PR TITLE
Pin version of VS Code tested against to 1.85.2 for e2e tests

### DIFF
--- a/extension/src/test/e2e/wdio.conf.ts
+++ b/extension/src/test/e2e/wdio.conf.ts
@@ -47,7 +47,7 @@ export const config: Options.Testrunner = {
   capabilities: [
     {
       browserName: 'vscode',
-      browserVersion: 'stable',
+      browserVersion: '1.85.2',
       'wdio:vscodeOptions': {
         extensionPath,
         userSettings: {


### PR DESCRIPTION
I (really) don't want to do this but 

- the stack of `renovate` PRs
- https://github.com/iterative/vscode-dvc/issues/4804
- lack of movement on https://github.com/webdriverio-community/wdio-vscode-service/pull/94
- being stuck on Node 16

is forcing us at least temporarily down this path.

