### PR TITLE
Fix image by step plots with bounding boxes

### DIFF
--- a/extension/src/plots/model/collect.ts
+++ b/extension/src/plots/model/collect.ts
@@ -468,7 +468,41 @@ const getSelectedImgComparisonPlotClasses = ({
   return imgClasses
 }
 
-const collectedSelectedPathComparisonPlotClasses = ({
+const collectSelectedImgComparisonPlotClasses = ({
+  acc,
+  id,
+  img,
+  path,
+  selectedClassLabels
+}: {
+  acc: ComparisonPlotClasses
+  selectedClassLabels: string[]
+  img: ImagePlot
+  path: string
+  id: string
+}) => {
+  const imgClasses = getSelectedImgComparisonPlotClasses({
+    img,
+    path,
+    selectedClassLabels
+  })
+
+  if (imgClasses.length === 0) {
+    return
+  }
+
+  if (!acc[id]) {
+    acc[id] = {}
+  }
+
+  if (!acc[id][path]) {
+    acc[id][path] = {}
+  }
+
+  acc[id][path][img.ind || 0] = imgClasses
+}
+
+const collectSelectedPathComparisonPlotClasses = ({
   acc,
   id,
   comparisonData,
@@ -482,21 +516,13 @@ const collectedSelectedPathComparisonPlotClasses = ({
   id: string
 }) => {
   for (const img of comparisonData[id][path]) {
-    const imgClasses = getSelectedImgComparisonPlotClasses({
+    collectSelectedImgComparisonPlotClasses({
+      acc,
+      id,
       img,
       path,
       selectedClassLabels
     })
-
-    if (imgClasses.length === 0) {
-      return
-    }
-
-    if (!acc[id]) {
-      acc[id] = {}
-    }
-
-    acc[id][path] = imgClasses
   }
 }
 
@@ -520,7 +546,7 @@ export const collectSelectedComparisonPlotClasses = ({
     }
 
     for (const id of selectedRevisionIds) {
-      collectedSelectedPathComparisonPlotClasses({
+      collectSelectedPathComparisonPlotClasses({
         acc,
         comparisonData,
         id,

--- a/extension/src/plots/webview/contract.ts
+++ b/extension/src/plots/webview/contract.ts
@@ -94,7 +94,9 @@ export type ComparisonPlotClass = {
 }
 
 export type ComparisonPlotClasses = {
-  [revision: string]: { [path: string]: ComparisonPlotClass[] }
+  [revision: string]: {
+    [path: string]: { [imgInd: number]: ComparisonPlotClass[] }
+  }
 }
 
 export interface PlotsComparisonData {

--- a/extension/src/test/fixtures/plotsDiff/index.ts
+++ b/extension/src/test/fixtures/plotsDiff/index.ts
@@ -1009,11 +1009,13 @@ export const collectPlotClasses = ({
   imgLabels,
   imgBoxes,
   id,
-  path
+  path,
+  imgInd
 }: {
   plotClasses: ComparisonPlotClasses
   imgLabels: string[]
   imgBoxes: { [label: string]: BoundingBox[] }
+  imgInd: number
   id: string
   path: string
 }) => {
@@ -1027,7 +1029,11 @@ export const collectPlotClasses = ({
     plotClasses[id] = {}
   }
 
-  plotClasses[id][path] = Object.values(classAcc)
+  if (!plotClasses[id][path]) {
+    plotClasses[id][path] = {}
+  }
+
+  plotClasses[id][path][imgInd] = Object.values(classAcc)
 }
 
 export const collectClassLabels = (
@@ -1095,6 +1101,7 @@ export const getComparisonWebviewMessage = (
           plotClasses,
           imgBoxes: boxes,
           imgLabels,
+          imgInd: img.ind || 0,
           id,
           path
         })

--- a/extension/src/test/suite/plots/index.test.ts
+++ b/extension/src/test/suite/plots/index.test.ts
@@ -259,7 +259,7 @@ suite('Plots Test Suite', () => {
       })
     })
 
-    it('should handle a plots diff output with a comparison multi plot containing bounding boxes', async () => {
+    it('should handle a plots diff output with a comparison multi plot containing classes', async () => {
       const multiImgPath = join('plots', 'image', '5.jpg')
       const mockBoxes = {
         car: [{ box: { bottom: 0, left: 0, right: 0, top: 0 }, score: 0.5 }]
@@ -1341,10 +1341,10 @@ suite('Plots Test Suite', () => {
         comparisonPlotsFixture.plotClasses
       )) {
         const classes = classesByPath[boundingBoxPlot.path]
-        filteredPlotsClasses[id][0] = {
-          [boundingBoxPlot.path]: classes[0].filter(
-            ({ label }) => label !== toggledLabel
-          )
+        filteredPlotsClasses[id] = {
+          [boundingBoxPlot.path]: {
+            0: classes[0].filter(({ label }) => label !== toggledLabel)
+          }
         }
       }
 
@@ -1367,6 +1367,9 @@ suite('Plots Test Suite', () => {
       const toggleComparisonClassSpy = spy(plotsModel, 'toggleComparisonClass')
 
       messageSpy.resetHistory()
+
+      const messageSent = waitForSpyCall(messageSpy, messageSpy.callCount)
+
       mockMessageReceived.fire({
         payload: {
           label: toggledLabel,
@@ -1375,6 +1378,8 @@ suite('Plots Test Suite', () => {
         },
         type: MessageFromWebviewType.TOGGLE_COMPARISON_CLASS
       })
+
+      await messageSent
 
       expect(toggleComparisonClassSpy).to.be.called
       expect(toggleComparisonClassSpy).to.be.calledWithExactly(

--- a/extension/src/test/suite/plots/index.test.ts
+++ b/extension/src/test/suite/plots/index.test.ts
@@ -264,7 +264,7 @@ suite('Plots Test Suite', () => {
       it('should handle image by step plots with bounding boxes', async () => {
         const multiImgDirPath = join('plots', 'image')
         const multiImgPath = join('plots', 'image', '5.jpg')
-        const mockBoxes = {
+        const mockAnnotations = {
           car: [{ box: { bottom: 0, left: 0, right: 0, top: 0 }, score: 0.5 }]
         }
         const imgDataWithBoundingBoxes = plotsDiffFixture.data[
@@ -274,7 +274,7 @@ suite('Plots Test Suite', () => {
           if (rev === 'main' || rev === 'exp-e7a67') {
             return {
               ...img,
-              boxes: mockBoxes
+              annotations: mockAnnotations
             }
           }
 
@@ -310,13 +310,13 @@ suite('Plots Test Suite', () => {
           'exp-e7a67': {
             ...comparisonPlotsFixture.plotClasses['exp-e7a67'],
             [multiImgDirPath]: {
-              '5': [{ boxes: mockBoxes.car, label: 'car' }]
+              '5': [{ boxes: mockAnnotations.car, label: 'car' }]
             }
           },
           main: {
             ...comparisonPlotsFixture.plotClasses.main,
             [multiImgDirPath]: {
-              '5': [{ boxes: mockBoxes.car, label: 'car' }]
+              '5': [{ boxes: mockAnnotations.car, label: 'car' }]
             }
           }
         }

--- a/webview/src/plots/components/comparisonTable/cell/ComparisonTableBoundingBoxImg.tsx
+++ b/webview/src/plots/components/comparisonTable/cell/ComparisonTableBoundingBoxImg.tsx
@@ -11,9 +11,14 @@ import { PlotsState } from '../../../store'
 
 const plotClassesSelector = (state: PlotsState) => state.comparison.plotClasses
 const classesSelector = createSelector(
-  [plotClassesSelector, (_, id: string) => id, (_, id, path: string) => path],
-  (plotClasses: ComparisonPlotClasses, id: string, path: string) =>
-    plotClasses[id]?.[path] || []
+  [
+    plotClassesSelector,
+    (_, id: string) => id,
+    (_, id, path: string) => path,
+    (_, id, path, ind: number) => ind
+  ],
+  (plotClasses: ComparisonPlotClasses, id: string, path: string, ind: number) =>
+    plotClasses[id]?.[path]?.[ind] || []
 )
 
 export const ComparisonTableBoundingBoxImg: React.FC<{
@@ -22,9 +27,10 @@ export const ComparisonTableBoundingBoxImg: React.FC<{
   path: string
   classDetails: ComparisonClassDetails
   alt: string
-}> = ({ alt, classDetails, id, src, path }) => {
+  ind?: number
+}> = ({ alt, classDetails, id, src, path, ind = 0 }) => {
   const classes = useSelector((state: PlotsState) =>
-    classesSelector(state, id, path)
+    classesSelector(state, id, path, ind)
   )
   const [naturalWidth, setNaturalWidth] = useState(0)
   const [naturalHeight, setNaturalHeight] = useState(0)

--- a/webview/src/plots/components/comparisonTable/cell/ComparisonTableCell.tsx
+++ b/webview/src/plots/components/comparisonTable/cell/ComparisonTableCell.tsx
@@ -14,7 +14,8 @@ export const ComparisonTableCell: React.FC<{
   plot: ComparisonPlot
   classDetails: ComparisonClassDetails
   imgAlt?: string
-}> = ({ path, plot, imgAlt, classDetails }) => {
+  imgInd?: number
+}> = ({ path, plot, imgAlt, classDetails, imgInd }) => {
   const plotImg = plot.imgs[0]
 
   const loading = plotImg.loading
@@ -42,6 +43,7 @@ export const ComparisonTableCell: React.FC<{
           path={path}
           classDetails={classDetails}
           alt={alt}
+          ind={imgInd}
         />
       ) : (
         <img

--- a/webview/src/plots/components/comparisonTable/cell/ComparisonTableMultiCell.tsx
+++ b/webview/src/plots/components/comparisonTable/cell/ComparisonTableMultiCell.tsx
@@ -60,6 +60,7 @@ export const ComparisonTableMultiCell: React.FC<{
           imgs: [selectedImg]
         }}
         imgAlt={`${selectedImg.ind} of ${path} (${plot.id})`}
+        imgInd={selectedImg.ind}
         classDetails={classDetails}
       />
       <div


### PR DESCRIPTION
# `main` <- #5227 <- https://github.com/iterative/vscode-dvc/pull/5241 <- #5250 <- #5305 <- this

Fixes a bug with bounding boxes not being shown in every image in multi img plots. 

