### PR TITLE
Fix repeatedly failing windows test timeouts

### DIFF
--- a/extension/src/test/suite/cli/index.test.ts
+++ b/extension/src/test/suite/cli/index.test.ts
@@ -69,7 +69,7 @@ suite('CLI Suite', () => {
         })
       )
       expect(killed).to.be.true
-    })
+    }).timeout(10000)
 
     it('should cleanup all non-background processes on dispose', async () => {
       const processStarted = disposable.track(new EventEmitter<CliEvent>())

--- a/extension/src/test/suite/experiments/index.test.ts
+++ b/extension/src/test/suite/experiments/index.test.ts
@@ -2036,8 +2036,8 @@ suite('Experiments Test Suite', () => {
         ['main', 'other-branch']
       ])
       expect(sorts).to.deep.equal([{ descending: true, path: paramPath }])
-    })
-  }).timeout(WEBVIEW_TEST_TIMEOUT)
+    }).timeout(WEBVIEW_TEST_TIMEOUT)
+  })
 
   describe('persisted state', () => {
     const firstSortDefinition = {

--- a/extension/src/test/suite/experiments/model/tree.test.ts
+++ b/extension/src/test/suite/experiments/model/tree.test.ts
@@ -370,7 +370,7 @@ suite('Experiments Tree Test Suite', () => {
 
       expect(mockExpPush).to.be.calledWithExactly(dvcDemoPath, mockExperimentId)
       expect(mockUpdate).to.be.calledOnce
-    })
+    }).timeout(WEBVIEW_TEST_TIMEOUT)
 
     it('should be able to push the provided experiment with dvc.views.experimentsTree.pushExperiment (if no experiments are selected)', async () => {
       bypassProgressCloseDelay()

--- a/extension/src/test/suite/experiments/workspace.test.ts
+++ b/extension/src/test/suite/experiments/workspace.test.ts
@@ -152,8 +152,8 @@ suite('Workspace Experiments Test Suite', () => {
 
       await testFile('params.yaml')
       await testFile('dvc.yaml')
-    })
-  }).timeout(WEBVIEW_TEST_TIMEOUT)
+    }).timeout(WEBVIEW_TEST_TIMEOUT)
+  })
 
   describe('dvc.modifyWorkspaceParamsAndQueue', () => {
     it('should be able to queue an experiment using an existing one as a base', async () => {

--- a/extension/src/test/suite/plots/index.test.ts
+++ b/extension/src/test/suite/plots/index.test.ts
@@ -180,81 +180,79 @@ suite('Plots Test Suite', () => {
       )
     })
 
-    describe('Custom Plots Creation', () => {
-      it('should only use unfiltered experiments and commits in custom plots', async () => {
-        const { plots, plotsModel, experimentsModel } = await buildPlots({
-          disposer: disposable,
-          plotsDiff: plotsDiffFixture
-        })
+    it('should only use unfiltered experiments and commits in custom plots', async () => {
+      const { plots, plotsModel, experimentsModel } = await buildPlots({
+        disposer: disposable,
+        plotsDiff: plotsDiffFixture
+      })
 
-        const plotsCustomPlotsSpy = spy(PlotsCollectUtils, 'collectCustomPlots')
+      const plotsCustomPlotsSpy = spy(PlotsCollectUtils, 'collectCustomPlots')
 
-        await plots.isReady()
+      await plots.isReady()
 
-        stub(experimentsModel, 'getFilters')
-          .onFirstCall()
-          .returns([
-            {
-              operator: Operator.EQUAL,
-              path: 'params:params.yaml:epochs',
-              value: 2
-            }
-          ])
+      stub(experimentsModel, 'getFilters')
+        .onFirstCall()
+        .returns([
+          {
+            operator: Operator.EQUAL,
+            path: 'params:params.yaml:epochs',
+            value: 2
+          }
+        ])
 
-        plotsModel.getCustomPlots()
+      plotsModel.getCustomPlots()
 
-        const allExperiments: Experiment[] =
-          experimentsModel.getWorkspaceCommitsAndExperiments()
+      const allExperiments: Experiment[] =
+        experimentsModel.getWorkspaceCommitsAndExperiments()
 
-        const { experiments } = plotsCustomPlotsSpy.firstCall.args[0]
+      const { experiments } = plotsCustomPlotsSpy.firstCall.args[0]
 
-        expect(experiments).to.deep.equal(
-          allExperiments.filter(
-            ({ id, params }) =>
-              id !== EXPERIMENT_WORKSPACE_ID &&
-              params?.['params.yaml']?.epochs === 2
-          )
+      expect(experiments).to.deep.equal(
+        allExperiments.filter(
+          ({ id, params }) =>
+            id !== EXPERIMENT_WORKSPACE_ID &&
+            params?.['params.yaml']?.epochs === 2
         )
+      )
+    })
+
+    it('should handle sending custom plots when all experiments/commits being filtered', async () => {
+      const { plots, plotsModel, experimentsModel } = await buildPlots({
+        disposer: disposable,
+        plotsDiff: plotsDiffFixture
       })
 
-      it('should handle all experiments/commits being filtered', async () => {
-        const { plots, plotsModel, experimentsModel } = await buildPlots({
-          disposer: disposable,
-          plotsDiff: plotsDiffFixture
-        })
+      await plots.isReady()
 
-        await plots.isReady()
+      stub(experimentsModel, 'getUnfilteredCommitsAndExperiments')
+        .onFirstCall()
+        .returns([])
 
-        stub(experimentsModel, 'getUnfilteredCommitsAndExperiments')
-          .onFirstCall()
-          .returns([])
+      const customPlots = plotsModel.getCustomPlots()
 
-        const customPlots = plotsModel.getCustomPlots()
+      expect(customPlots).to.deep.equal({
+        ...customPlotsFixture,
+        hasUnfilteredExperiments: false,
+        plots: []
+      })
+    })
 
-        expect(customPlots).to.deep.equal({
-          ...customPlotsFixture,
-          hasUnfilteredExperiments: false,
-          plots: []
-        })
+    it('should handle sending custom plots when no plots have been added yet', async () => {
+      const { plots, plotsModel } = await buildPlots({
+        disposer: disposable,
+        plotsDiff: plotsDiffFixture
       })
 
-      it('should handle no plots being added yet', async () => {
-        const { plots, plotsModel } = await buildPlots({
-          disposer: disposable,
-          plotsDiff: plotsDiffFixture
-        })
+      await plots.isReady()
 
-        await plots.isReady()
+      stub(plotsModel, 'getCustomPlotsOrder').onFirstCall().returns([])
 
-        stub(plotsModel, 'getCustomPlotsOrder').onFirstCall().returns([])
+      const customPlots = plotsModel.getCustomPlots()
 
-        const customPlots = plotsModel.getCustomPlots()
-
-        expect(customPlots).to.deep.equal({
-          ...customPlotsFixture,
-          hasAddedPlots: false,
-          plots: []
-        })
+      expect(customPlots).to.deep.equal({
+        ...customPlotsFixture,
+        hasAddedPlots: false,
+        plots: []
       })
     })
 


### PR DESCRIPTION
~A couple tests are repeatedly failing in windows. Attempting to fix by adjusting the timeouts.~ Tests are now running correctly, but there are still some issues that can be corrected: 

* `timeout` being set on `describe` blocks
* `describe` blocks being nested inside of `describe` blocks 
* `should be able to create a background process that does not exit when the parent process exits` needing a larger timeout 