### PR TITLE
patch process exists for windows machines

### DIFF
--- a/extension/src/process/execution.ts
+++ b/extension/src/process/execution.ts
@@ -85,8 +85,13 @@ export const executeProcess = async (
   return stdout
 }
 
-export const processExists = (pid: number): Promise<boolean> =>
-  doesProcessExist(pid)
+export const processExists = async (pid: number): Promise<boolean> => {
+  try {
+    return await doesProcessExist(pid)
+  } catch {
+    return false
+  }
+}
 
 export const stopProcesses = async (pids: number[]): Promise<boolean> => {
   let allKilled = true


### PR DESCRIPTION
Trying to solve the issues detailed here: https://discord.com/channels/485586884165107732/1250736030806446192

From https://github.com/MarkTiedemann/fastlist -> fastlist was originally built for use in [sindresorhus/ps-list](https://github.com/sindresorhus/ps-list) (see https://github.com/sindresorhus/ps-list/issues/20). We use `process-exists` that uses `ps-list`. It looks like the required binary is no longer packaged when we run `vsce`. Rather than try and dig through the dependencies I've just added a patch.

