### PR TITLE
fix source control e2e test - all items no longer fit on single screen due to source control graph

### DIFF
--- a/extension/src/test/e2e/extension.test.ts
+++ b/extension/src/test/e2e/extension.test.ts
@@ -213,13 +213,12 @@ describe('Source Control View', function () {
     }
 
     const expectedScmSet = new Set(expectedScmItemLabels)
-    let dvcTreeItemLabels: string[] = []
+    const dvcTreeItemLabels = new Set<string>()
 
     let openView = true
 
     await browser.waitUntil(
       async () => {
-        dvcTreeItemLabels = []
         const treeItems = await findScmTreeItems(openView)
         openView = false
         for (const treeItem of treeItems) {
@@ -227,12 +226,12 @@ describe('Source Control View', function () {
           if (!expectedScmSet.has(treeItemLabel)) {
             continue
           }
-          dvcTreeItemLabels.push(treeItemLabel)
+          dvcTreeItemLabels.add(treeItemLabel)
 
           const tooltip = await findDecorationTooltip(treeItem)
           expect(tooltip).toBeTruthy()
         }
-        return expectedScmItemLabels.length === dvcTreeItemLabels.length
+        return expectedScmItemLabels.length === dvcTreeItemLabels.size
       },
       {
         interval: 5000,
@@ -241,7 +240,8 @@ describe('Source Control View', function () {
     )
 
     expectedScmItemLabels.sort()
-    dvcTreeItemLabels.sort()
-    expect(expectedScmItemLabels).toStrictEqual(dvcTreeItemLabels)
+    const a = [...dvcTreeItemLabels]
+    a.sort()
+    expect(expectedScmItemLabels).toStrictEqual(a)
   })
 })

--- a/extension/src/test/e2e/util.ts
+++ b/extension/src/test/e2e/util.ts
@@ -235,9 +235,10 @@ export const findScmTreeItems = async (openView: boolean) => {
       .up(Key.Tab)
       .pause(100)
       .perform()
+    return findCurrentTreeItems()
   }
 
-  for (let i = 0; i < 30; i++) {
+  for (let i = 0; i < 15; i++) {
     await browser.keys(Key.ArrowDown)
   }
 


### PR DESCRIPTION
Introduction of [this](https://code.visualstudio.com/updates/v1_93#_source-control-graph-view). Changes the default size of the SCM view and broke the e2e tests.

