### PR TITLE
Fix editor decorations for folders/files tracked by DVC

### DIFF
--- a/extension/src/repository/sourceControlManagement/decorationProvider.ts
+++ b/extension/src/repository/sourceControlManagement/decorationProvider.ts
@@ -108,6 +108,7 @@ export class DecorationProvider
   }
 
   private static DecorationTracked: FileDecoration = {
+    color: new ThemeColor('list.inactiveSelectionIconForeground'),
     tooltip: 'DVC Tracked'
   }
 
@@ -163,6 +164,7 @@ export class DecorationProvider
   public setState(state: ScmDecorationState) {
     const urisToUpdate = this.getUnion(this.state, state)
     this.state = state
+
     this.decorationsChanged.fire(urisToUpdate)
   }
 


### PR DESCRIPTION
Decorations for files/folders tracked by DVC have been reverted the color for gitignored files. This PR fixes the issue

### Before

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/1a6b4897-d8a5-44d9-8067-99abc23a809c">


### After

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/8b7f9843-5b4e-41af-a266-f75427329dc4">
