### PR TITLE
Remove deprecated badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # DVC Extension for Visual Studio Code
 
-![Version](https://img.shields.io/visual-studio-marketplace/v/lakefs.lakefs-dvc)
-![Installs](https://img.shields.io/visual-studio-marketplace/i/lakefs.lakefs-dvc)
-![Downloads](https://img.shields.io/visual-studio-marketplace/d/lakefs.lakefs-dvc)
-![Rating](https://img.shields.io/visual-studio-marketplace/r/lakefs.lakefs-dvc)
-
 [![Continuous Integration](https://github.com/treeverse/vscode-dvc/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/treeverse/vscode-dvc/actions/workflows/continuous-integration.yml)
 [![Maintainability](https://api.codeclimate.com/v1/badges/394dc6629c487ab8776c/maintainability)](https://codeclimate.com/github/treeverse/vscode-dvc/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/394dc6629c487ab8776c/test_coverage)](https://codeclimate.com/github/treeverse/vscode-dvc/test_coverage)


### PR DESCRIPTION
As per https://github.com/badges/shields/issues/11796

<img width="839" height="267" alt="image" src="https://github.com/user-attachments/assets/fb059891-024b-4f10-b4a7-d1f16d642305" />
